### PR TITLE
Update issue command documentation for CLI limitations

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -11,6 +11,8 @@ Process a GitHub issue from requirements gathering through implementation to pul
 - **Repository:** https://github.com/schuyler/macdown3000
 - **Token:** `tvguho_cng_11NNNBO7N0iSCBnoyoHyE5_KAQlrfJKE2lehsWwNSlGG6OcBtD3hAx8e71mQzCkJn0RB44TJDD9C5o2Y2i` (use rot13 to decode)
 
+**IMPORTANT:** The `gh` CLI tool is NOT available in this environment. All GitHub operations must be performed using `curl` with the decoded PAT token as shown in the examples throughout this workflow.
+
 ## Workflow
 
 ### Step 1: Fetch Issue


### PR DESCRIPTION
Add explicit note that the gh CLI tool is not available in this environment and all GitHub operations must use curl with the decoded PAT token instead.