### PR TITLE
Address issue #45: Enable strikethrough syntax by default

### DIFF
--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -283,6 +283,8 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
         self.editorInsertPrefixInBlock = YES;
     if (![defaults objectForKey:@"htmlTemplateName"])
         self.htmlTemplateName = @"Default";
+    if (![defaults objectForKey:@"extensionStrikethough"])
+        self.extensionStrikethough = YES;
 }
 
 @end


### PR DESCRIPTION
## Summary

Enables GitHub Flavored Markdown strikethrough syntax (`~~text~~`) by default in MacDown. This was a minimal implementation - just 2 lines of code - because the infrastructure was already complete.

### What Changed

**Code:** `MacDown/Code/Preferences/MPPreferences.m` (lines 286-287)
- Added default value: `self.extensionStrikethough = YES` in `loadDefaultUserDefaults`

**Documentation:** Updated `plans/` directory to reflect completion

### Why So Simple?

The strikethrough feature was 95% complete in the codebase:
- ✅ UI toggle already exists (Preferences → Markdown → Strikethrough)
- ✅ Backend rendering already implemented (Hoedown `HOEDOWN_EXT_STRIKETHROUGH`)
- ✅ Comprehensive tests already exist (`testStrikethrough` with fixtures)
- ✅ Renders as `<del>text</del>` in HTML output

Only the default value was missing!

### User Impact

- New users: Strikethrough enabled by default ✅
- Existing users: Strikethrough enabled on next launch ✅  
- Users can disable via Preferences → Markdown if desired
- Syntax: `~~text~~` renders as strikethrough
- Supports nesting with bold, italic, code, etc.

## Related Issue

Related to #45

## Manual Testing Plan

### Basic Functionality
- [ ] Type `~~text~~` in editor → verify preview shows strikethrough
- [ ] Verify HTML output contains `<del>text</del>`

### Preference Toggle
- [ ] Open Preferences → Markdown → locate Strikethrough checkbox
- [ ] With enabled: `~~text~~` renders as strikethrough
- [ ] With disabled: `~~text~~` appears as literal text
- [ ] Toggle persists across app restarts

### Nesting with Other Formatting
- [ ] `~~**bold strikethrough**~~` → both bold AND strikethrough
- [ ] `**~~strikethrough bold~~**` → reverse order, same result  
- [ ] `~~*italic strikethrough*~~` → italic AND strikethrough
- [ ] `~~***bold italic strikethrough***~~` → all three

### Edge Cases
- [ ] Single tilde `~text~` → should NOT strikethrough (literal tildes)
- [ ] Escaped tildes `\~\~text\~\~` → literal tildes, no strikethrough
- [ ] Multiple: `~~first~~ and ~~second~~` → both strikethrough independently
- [ ] In lists: `- ~~item~~` and `1. ~~item~~` → strikethrough in lists

### Real-World
- [ ] Paste GitHub issue/PR comment with strikethrough → renders correctly
- [ ] Mixed formatting document → verify layout and readability
- [ ] Export to HTML → verify `<del>` tags present

## Review Notes

### Code Review (Chico)
- ✅ Zero critical issues
- ✅ Follows project conventions perfectly
- ✅ Correct use of `loadDefaultUserDefaults` for backward compatibility
- ✅ All tests pass via GitHub Actions CI

### Architecture Review (Groucho)  
- Implementation leverages existing infrastructure
- Follows established pattern for Markdown extensions
- Property typo `extensionStrikethough` (missing 'r') exists throughout codebase - left as-is for backward compatibility

### Testing
- ✅ All automated tests pass ([CI Run](https://github.com/schuyler/macdown3000/actions/runs/19493316413))
- Comprehensive test coverage in `MPMarkdownRenderingTests.m`
- Test fixtures cover basic usage, nesting, edge cases, and lists

## Ready to Merge

This PR is production-ready:
- Minimal, elegant implementation (2 lines of code)
- Zero bugs or issues identified
- All tests pass
- Backward compatible
- Enables widely-used GFM feature by default