### PR TITLE
Update README to match website content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,109 @@
-# MacDown
+# MacDown 3000
 
-[![](https://img.shields.io/github/release/MacDownApp/macdown.svg)](http://macdown.uranusjr.com/download/latest/)
-![Total downloads](https://img.shields.io/github/downloads/MacDownApp/macdown/latest/total.svg)
-[![Tests](https://github.com/MacDownApp/macdown/workflows/Tests/badge.svg)](https://github.com/MacDownApp/macdown/actions)
+[![Tests](https://github.com/schuyler/macdown3000/workflows/Tests/badge.svg)](https://github.com/schuyler/macdown3000/actions)
 
+MacDown 3000 is a free Markdown editor for macOS, available under the MIT License. It continues the legacy started by Chen Luo's [Mou](http://25.io/mou/) and carried forward by Tzu-ping Chung's [MacDown](https://macdown.uranusjr.com).
 
-MacDown is an open source Markdown editor for OS X, released under the MIT License. The author stole the idea from [Chen Luo](https://twitter.com/chenluois)’s [Mou](http://mouapp.com) so that people can make crappy clones.
+Visit the [project website](https://schuyler.github.io/macdown3000/) for more information, or download from the [releases](https://github.com/schuyler/macdown3000/releases) page.
 
-Visit the [project site](http://macdown.uranusjr.com/) for more information, or download [MacDown.app.zip](http://macdown.uranusjr.com/download/latest/) directly from the [latest releases](https://github.com/MacDownApp/macdown/releases/latest) page.
+## About MacDown 3000
 
-## Install
+In 2025, there's still a need for a modern, lightweight Markdown editor for macOS with live preview capabilities. MacDown 3000 is essentially *MacDown Continued*. The focus is on keeping MacDown up to date with modern Markdown best practices and maintaining compatibility with current library dependencies.
 
-[Download](http://macdown.uranusjr.com/download/latest/), unzip, and drag the app to Applications folder. MacDown is also available through [Homebrew Cask](https://caskroom.github.io/):
+MacDown 3000 supports macOS 11.0 (Big Sur) and later, exclusively on Apple Silicon.
 
-    brew install --cask macdown
+This project honors the original intentions and contributions of both Mou and MacDown while ensuring that this valuable tool remains available and actively maintained for today's Mac users.
+
+## Download & Install
+
+**Version 3000.0.0** - Coming Soon
+
+Download the latest release from the [GitHub Releases](https://github.com/schuyler/macdown3000/releases) page, unzip, and drag the app to your Applications folder.
+
+### System Requirements
+
+- macOS 11.0 (Big Sur) or later
+- Apple Silicon (M-series processor)
+- Intel Macs are not supported
+
+### Important Note
+
+MacDown 3000 is not signed with a paid Apple developer certificate. macOS will display an "unidentified developer" warning. To open the app:
+
+1. Go to System Settings → Privacy & Security
+2. Find the blocked app message and click "Open Anyway"
+3. Alternatively, right-click the app and choose "Open" the first time you launch it
 
 ## Screenshot
 
 ![screenshot](assets/screenshot.png)
 
+## Features
+
+### Live Preview & Markdown Rendering
+
+MacDown 3000 uses Hoedown to convert Markdown to HTML with live preview as you type. It supports:
+
+- **Fenced code blocks** with language identifiers
+- **GitHub Flavored Markdown** including tables, strikethrough, and autolinks
+- **Task lists** for GFM-style checkboxes
+- **Customizable rendering options** in Preferences
+
+### Syntax Highlighting
+
+Code blocks get syntax highlighting via Prism, supporting numerous programming and markup languages.
+
+### Additional Rendering Tools
+
+- **Math notation** using TeX-like syntax ($$...$$, \[...\], \(...\), and optional $...$ blocks)
+- **Jekyll front-matter** for static site generators
+- **Export to HTML or PDF** with customizable styling
+
+### Editor Features
+
+- **Auto-completion**: Automatic bracket and quote pairing, list continuation, and formatting shortcuts (customizable or disable)
+- **Apple Silicon optimized**: Built natively for M-series Macs
+- **Modern Markdown**: Supports CommonMark and GitHub Flavored Markdown
+
+## Development
+
+### Requirements
+
+If you wish to build MacDown 3000 yourself, you will need the following components/tools:
+
+* macOS SDK (11.0 or later)
+* Git
+* [Bundler](http://bundler.io)
+
+> Note: Old versions of CocoaPods are not supported. Please use Bundler to execute CocoaPods, or make sure your CocoaPods is later than shown in `Gemfile.lock`.
+
+> Note: The Command Line Tools (CLT) should be unnecessary. If you failed to compile without it, please install CLT with
+>
+>     xcode-select --install
+>
+> and report back.
+
+An appropriate SDK should be bundled with recent versions of Xcode.
+
+### Environment Setup
+
+After cloning the repository, run the following commands inside the repository root (directory containing this `README.md` file):
+
+    git submodule update --init
+    bundle install
+    bundle exec pod install
+    make -C Dependency/peg-markdown-highlight
+
+and open `MacDown.xcworkspace` in Xcode. The first command initialises the dependency submodule(s) used in MacDown; the second one installs dependencies managed by CocoaPods.
+
+Refer to the official guides of Git and CocoaPods if you need more instructions. If you run into build issues later on, try running the following commands to update dependencies:
+
+    git submodule update
+    bundle exec pod install
+
 ## License
 
-MacDown is released under the terms of MIT License. You may find the content of the license [here](http://opensource.org/licenses/MIT), or inside the `LICENSE` directory.
+MacDown 3000 is released under the terms of MIT License. You may find the content of the license [here](http://opensource.org/licenses/MIT), or inside the `LICENSE` directory.
 
 You may find full text of licenses about third-party components in the `LICENSE` directory, or the **About MacDown** panel in the application.
 
@@ -43,59 +125,16 @@ The following editor themes and CSS files are extracted from [Mou](http://mouapp
 * GitHub
 * GitHub2
 
-## Development
+## Contributing & Support
 
-### Requirements
+MacDown 3000 is Free Software under the MIT License. Contributions are welcome!
 
-If you wish to build MacDown yourself, you will need the following components/tools:
+Please [file an issue](https://github.com/schuyler/macdown3000/issues/new) on GitHub for bug reports, feature requests, or questions. **Please search first to make sure no-one has reported the same issue already** before opening one yourself.
 
-* OS X SDK (10.14 or later)
-* Git
-* [Bundler](http://bundler.io)
+MacDown 3000 depends on other open source projects, such as [Hoedown](https://github.com/hoedown/hoedown) for Markdown-to-HTML rendering, [Prism](http://prismjs.com) for syntax highlighting (in code blocks), and [PEG Markdown Highlight](https://github.com/ali-rantakari/peg-markdown-highlight) for editor highlighting. If you find problems when using those particular features, you can also consider reporting them directly to upstream projects as well as to MacDown 3000's issue tracker.
 
-> Note: Old versions of CocoaPods are not supported. Please use Bundler to execute CocoaPods, or make sure your CocoaPods is later than shown in `Gemfile.lock`.
+## Support MacDown 3000
 
-> Note: The Command Line Tools (CLT) should be unnecessary. If you failed to compile without it, please install CLT with
->
->     xcode-select --install
->
-> and report back.
+Donations help cover the cost of the Apple developer license ($99/year). Any proceeds beyond our maintenance costs will be donated to the [Signal Foundation](https://signal.org/donate/).
 
-An appropriate SDK should be bundled with Xcode 5 or later versions.
-
-### Environment Setup
-
-After cloning the repository, run the following commands inside the repository root (directory containing this `README.md` file):
-
-    git submodule update --init
-    bundle install
-    bundle exec pod install
-    make -C Dependency/peg-markdown-highlight
-
-and open `MacDown.xcworkspace` in Xcode. The first command initialises the dependency submodule(s) used in MacDown; the second one installs dependencies managed by CocoaPods.
-
-Refer to the official guides of Git and CocoaPods if you need more instructions. If you run into build issues later on, try running the following commands to update dependencies:
-
-    git submodule update
-    bundle exec pod install
-
-### Translation
-
-Please help translation on [Transifex](https://www.transifex.com/macdown/macdown/).
-
-![Transifex translation percentage](https://www.transifex.com/projects/p/macdown/resource/macdownxliff/chart/image_png/)
-
-## Discussion
-
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/MacDownApp/macdown)
-
-Join our [Gitter channel](https://gitter.im/MacDownApp/macdown) if you have any problems with MacDown. Any suggestions are welcomed, too!
-
-You can also [file an issue directly](https://github.com/MacDownApp/macdown/issues/new) on GitHub if you prefer so. But please, **search first to make sure no-one has reported the same issue already** before opening one yourself. MacDown does not update in your computer immediately when we make changes, so something you experienced might be known, or even fixed in the development version.
-
-MacDown depends a lot on other open source projects, such as [Hoedown](https://github.com/hoedown/hoedown) for Markdown-to-HTML rendering, [Prism](http://prismjs.com) for syntax highlighting (in code blocks), and [PEG Markdown Highlight](https://github.com/ali-rantakari/peg-markdown-highlight) for editor highlighting. If you find problems when using those particular features, you can also consider reporting them directly to upstream projects as well as to MacDown’s issue tracker. I will do what I can if you report it here, but sometimes it can be more beneficial to interact with them directly.
-
-## Tipping
-
-If you find MacDown suitable for your needs, please consider [giving me a tip through PayPal](http://macdown.uranusjr.com/faq/#donation). Or, if you prefer to buy me a drink *personally* instead, just [send me a tweet](https://twitter.com/uranusjr) when you visit [Taipei, Taiwan](http://en.wikipedia.org/wiki/Taipei), where I live. I look forward to meeting you!
-
+[Donate via PayPal](https://www.paypal.com/donate/?business=22WG7CGNSSF8C&no_recurring=0&amount=5&item_name=Thank+you+for+supporting+MacDown+3000.+Once+our+maintenance+costs+are+covered%2C+further+donations+will+go+the+Signal+Foundation.&currency_code=USD)


### PR DESCRIPTION
This updates the README to reflect MacDown 3000 branding and content:

- Replace MacDownApp/macdown references with schuyler/macdown3000
- Add "About MacDown 3000" section explaining project lineage
- Update system requirements (macOS 11.0+, Apple Silicon only)
- Add detailed features section from website content
- Update download/install instructions with unsigned app warning
- Replace old support channels with GitHub Issues
- Update donation section with new PayPal link and Signal Foundation info
- Remove outdated references (Gitter, Transifex, Homebrew Cask)
- Add link to project website (schuyler.github.io/macdown3000)

Related to website content in docs/index.html