### PR TITLE
Add tags to recently created issues

### DIFF
--- a/plans/labels_guide.md
+++ b/plans/labels_guide.md
@@ -1,6 +1,7 @@
 # MacDown 3000 Label System Guide
 
 **Created:** 2025-11-18
+**Last Updated:** 2025-11-19
 **Purpose:** Standardized issue categorization and tracking
 
 ---
@@ -8,67 +9,64 @@
 ## 🏷️ Label Categories
 
 ### 1. Type (What kind of issue?)
-- `type: bug` - Something isn't working correctly
-- `type: enhancement` - New feature or improvement
-- `type: documentation` - Documentation needs work
-- `type: infrastructure` - Build, CI/CD, tooling, dependencies
-- `type: security` - Security vulnerability or concern
-- `type: performance` - Performance improvement needed
-- `type: refactor` - Code cleanup without behavior change
-- `type: question` - Further information is requested
+
+- `bug` - Something isn't working correctly (38 issues)
+- `enhancement` - New feature or improvement (30 issues)
+- `documentation` - Improvements or additions to documentation (6 issues)
+- `question` - Further information is requested (1 issue)
 
 ### 2. Priority (How urgent?)
-- `priority: critical` 🔴 - Blocking release, security issue, data loss
-- `priority: high` 🟠 - Important for release, significant impact
-- `priority: medium` 🟡 - Should do, moderate impact
-- `priority: low` 🟢 - Nice to have, minor impact
 
-### 3. Component/Area (Which part?)
-- `component: rendering` - Markdown/HTML/LaTeX rendering
-- `component: editor` - Text editor pane
-- `component: preview` - Preview pane
-- `component: export` - PDF/HTML export
-- `component: ui` - User interface, windows, menus
-- `component: preferences` - Settings and preferences
-- `component: file-io` - File operations, autosave
-- `component: diagrams` - Mermaid diagrams
-- `component: syntax` - Syntax highlighting
-- `component: themes` - Editor/preview themes
-- `component: cli` - Command-line tool
+- `critical` - Blocking release, security issue, data loss (7 issues)
+- `high` - Important for release, significant impact (22 issues)
+- `medium` - Should do, moderate impact (25 issues)
+- `low` - Nice to have, minor impact (7 issues)
 
-### 4. Platform/Technology
-- `platform: macos` - macOS-specific issues
-- `platform: apple-silicon` - M1/M2/M3 related
-- `tech: dependencies` - CocoaPods, npm, gems
-- `tech: ci-cd` - GitHub Actions, workflows
-- `tech: testing` - Unit tests, integration tests
-- `tech: build` - Build system, Xcode configuration
-- `tech: localization` - i18n, translations
+### 3. Component/Area (Which part of the application?)
 
-### 5. Status/Workflow
-- `status: ready` - Ready to be worked on
-- `status: in-progress` - Someone is actively working on this
-- `status: blocked` - Blocked by another issue or external factor
-- `status: needs-discussion` - Needs community/maintainer discussion
+- `rendering` - Markdown/HTML/LaTeX rendering (14 issues)
+- `editor` - Text editor pane (5 issues)
+- `preview` - Preview pane functionality (5 issues)
+- `export` - PDF/HTML export (6 issues)
+- `ui` - User interface, windows, menus (2 issues)
+- `preferences` - Settings and preferences (3 issues)
+- `file-io` - File operations, autosave (4 issues)
+- `diagrams` - Mermaid/Graphviz diagram rendering (4 issues)
+- `syntax` - Syntax highlighting (1 issue)
 
-### 6. Effort/Size
-- `size: small` - < 4 hours, simple change
-- `size: medium` - 1-3 days, moderate complexity
-- `size: large` - 1+ weeks, significant work
+### 4. Technology/Infrastructure
 
-### 7. Special Categories
-- `good-first-issue` 🌱 - Good for newcomers
-- `help-wanted` 🙋 - Extra attention needed
-- `breaking-change` ⚠️ - Will break backward compatibility
-- `upstream` - Issue in a dependency, not our code
+- `build` - Build system, Xcode configuration (12 issues)
+- `dependencies` - Pull requests that update dependencies (7 issues)
+- `ci-cd` or `ci/cd` - GitHub Actions, CI/CD workflows (6 + 1 issues)
+- `testing` - Testing infrastructure and test cases (25 issues)
+- `infrastructure` - Build, CI/CD, project infrastructure (21 issues)
+- `code-signing` - Code signing and notarization (1 issue)
+- `localization` - Internationalization and translations (2 issues)
+- `security` - Security issues and improvements (2 issues)
 
-### 8. Milestone/Release
-- `milestone: v0.1` - Must have for v0.1 release
-- `milestone: backlog` - Not scheduled yet
+### 5. Special Technical
 
-### 9. Source
-- `source: cloned-issue` - Cloned from original MacDown
-- `source: cloned-pr` - Based on original MacDown PR
+- `hoedown` - Related to Hoedown Markdown parser (8 issues)
+- `markdown-parsing` - Markdown parsing issues (1 issue)
+- `javascript` - JavaScript-related updates (1 issue)
+- `cli` - Command-line tool (1 issue)
+
+### 6. Status/Workflow
+
+- `backlog` - Not scheduled yet (3 issues)
+- `good-first-issue` - Good for newcomers (2 issues)
+- `help-wanted` - Extra attention needed (1 issue)
+- `upstream` - Issue in a dependency, not our code (1 issue)
+
+### 7. Milestone/Release
+
+- `v0.1` - Must have for v0.1 release (27 issues)
+
+### 8. Source/Origin
+
+- `cloned-issue` - Cloned from original MacDown repository (34 issues)
+- `cloned-pr` - Based on original MacDown PR (4 issues)
 
 ---
 
@@ -77,62 +75,104 @@
 ### For Contributors
 
 **Finding Work:**
+
 ```
 Good first issues:
   - Filter: label:"good-first-issue"
-  - Small, well-defined tasks
+  - Small, well-defined tasks perfect for getting started
 
 Help wanted:
   - Filter: label:"help-wanted"
   - Issues needing extra attention
 
 By component:
-  - Filter: label:"component: editor"
-  - Focus on specific area
+  - Filter: label:"rendering"
+  - Focus on specific area of the codebase
+
+By priority and size:
+  - Filter: label:"medium" label:"good-first-issue"
+  - Medium priority tasks good for newcomers
 ```
 
-**Issue Triage:**
-1. Apply `type:` label (what)
-2. Apply `priority:` label (urgency)
-3. Apply `component:` labels (where)
-4. Apply `size:` if clear (effort)
-5. Apply `milestone:` if release-critical
-6. Apply special labels as needed
+**Issue Triage Process:**
+
+1. Apply type label: `bug`, `enhancement`, `documentation`, etc.
+2. Apply priority label: `critical`, `high`, `medium`, or `low`
+3. Apply component labels as appropriate: `rendering`, `editor`, `preview`, etc.
+4. Apply milestone label if release-critical: `v0.1` or `backlog`
+5. Apply special labels if needed: `good-first-issue`, `help-wanted`, etc.
+6. Apply source label if from upstream: `cloned-issue` or `cloned-pr`
 
 ### For Maintainers
 
 **Planning v0.1 Release:**
+
 ```
 Critical path:
-  - Filter: label:"milestone: v0.1" label:"priority: critical"
-  - 5 issues that MUST be done
+  - Filter: label:"v0.1" label:"critical"
+  - Must be done before v0.1 release
 
 High priority v0.1:
-  - Filter: label:"milestone: v0.1" label:"priority: high"
-  - 15 issues important for quality
+  - Filter: label:"v0.1" label:"high"
+  - Important for v0.1 quality
 
 All v0.1 issues:
-  - Filter: label:"milestone: v0.1"
-  - 27 total issues
+  - Filter: label:"v0.1"
+  - 27 total issues targeted for first release
 ```
 
-**By Technology:**
+**By Technology Area:**
+
 ```
+Testing infrastructure:
+  - Filter: label:"testing"
+  - 25 issues improving test coverage
+
+Build and infrastructure:
+  - Filter: label:"infrastructure"
+  - 21 issues for build system, CI/CD
+
 Dependencies to update:
-  - Filter: label:"tech: dependencies"
-  - 3 critical dependency issues
+  - Filter: label:"dependencies"
+  - 7 dependency-related issues
 
 CI/CD improvements:
-  - Filter: label:"tech: ci-cd"
-  - 2 infrastructure issues
+  - Filter: label:"ci-cd" OR label:"ci/cd"
+  - Workflow and automation improvements
+```
+
+**By Component:**
+
+```
+Rendering issues:
+  - Filter: label:"rendering"
+  - 14 issues with Markdown/HTML/LaTeX rendering
+
+Editor improvements:
+  - Filter: label:"editor"
+  - 5 issues with text editor pane
+
+Preview pane:
+  - Filter: label:"preview"
+  - 5 issues with preview functionality
 ```
 
 ---
 
 ## 📈 Current Project State
 
-Use GitHub's issue filters to view current state:
-- **Release Blockers:** `label:"priority: critical" is:open`
+**Total Issues:** 114 (open and closed)
+
+**Label Statistics:**
+- Most common type: `bug` (38 issues)
+- Most common priority: `medium` (25 issues)
+- Most common component: `rendering` (14 issues)
+- Release targeted: `v0.1` (27 issues)
+- From upstream: `cloned-issue` (34 issues)
+
+**Use GitHub's issue filters to view current state:**
+- **Release Blockers:** `label:"critical" is:open`
+- **v0.1 Milestone:** `label:"v0.1" is:open`
 - **Quick Wins:** `label:"good-first-issue" is:open`
 - **Help Wanted:** `label:"help-wanted" is:open`
 
@@ -141,44 +181,99 @@ Use GitHub's issue filters to view current state:
 ## 🔍 Useful Filters
 
 ### For Contributors
-- **Easy wins:** `label:"good-first-issue" label:"size: small"`
-- **Documentation:** `label:"type: documentation"`
-- **Your area:** `label:"component: editor"` (pick your component)
+
+- **Easy wins:** `label:"good-first-issue" is:open`
+- **Documentation:** `label:"documentation" is:open`
+- **Bugs to fix:** `label:"bug" is:open`
+- **New features:** `label:"enhancement" is:open`
+- **Rendering work:** `label:"rendering" is:open`
+- **Editor work:** `label:"editor" is:open`
 
 ### For Project Management
-- **This week:** `label:"milestone: v0.1" label:"priority: critical"`
-- **Next sprint:** `label:"milestone: v0.1" label:"priority: high"`
-- **Backlog:** `label:"milestone: backlog"`
-- **Blocked:** `label:"status: blocked"`
+
+- **This week:** `label:"v0.1" label:"critical" is:open`
+- **Next sprint:** `label:"v0.1" label:"high" is:open`
+- **Backlog:** `label:"backlog" is:open`
+- **All v0.1 work:** `label:"v0.1" is:open`
 
 ### For Quality Assurance
-- **Security issues:** `label:"type: security"`
-- **Critical bugs:** `label:"type: bug" label:"priority: critical"`
-- **macOS compatibility:** `label:"platform: macos"`
+
+- **Security issues:** `label:"security" is:open`
+- **Critical bugs:** `label:"bug" label:"critical" is:open`
+- **Testing gaps:** `label:"testing" is:open`
+- **High priority bugs:** `label:"bug" label:"high" is:open`
+
+### For Infrastructure Work
+
+- **Build system:** `label:"build" is:open`
+- **CI/CD:** `label:"ci-cd" is:open OR label:"ci/cd" is:open`
+- **Dependencies:** `label:"dependencies" is:open`
+- **Infrastructure:** `label:"infrastructure" is:open`
 
 ---
 
 ## 📝 Label Maintenance
 
+### Cleanup History
+
+**2025-11-19:** Major label cleanup
+- Replaced `priority: {x}` prefix labels with `{x}` (removed redundant prefix)
+- Restored 11 orphaned labels that were in use but missing from repository
+- Deleted 25 unused labels
+- Result: 37 labels, all actively in use
+
 ### Adding New Labels
+
 If you need a new label:
-1. Check if existing label fits
-2. Discuss in issue or PR
-3. Follow naming convention: `category: name`
-4. Choose appropriate color for category
-5. Add to this guide
+
+1. Check if an existing label fits the purpose
+2. Discuss in an issue or PR first
+3. Choose a clear, concise name (avoid prefixes unless necessary)
+4. Add an appropriate description
+5. Choose a color that fits with similar labels
+6. Update this guide after creating the label
+
+### Label Naming Conventions
+
+- Use lowercase with hyphens: `good-first-issue`, not `GoodFirstIssue`
+- Be descriptive but concise: `rendering`, not `rendering-related-issues`
+- Avoid redundant prefixes unless they add clarity
+- Use existing labels when possible before creating new ones
 
 ### Modifying Labels
+
 Labels can be edited at:
 https://github.com/schuyler/macdown3000/labels
 
-Keep colors consistent within categories.
+Keep colors consistent within categories:
+- **Type labels:** Red/orange/blue tones
+- **Priority labels:** Red (critical) → Yellow (low)
+- **Component labels:** Light blues and purples
+- **Infrastructure labels:** Dark blues
+- **Status labels:** Greens and yellows
+
+---
+
+## 🎨 Label Color Scheme
+
+Current color associations:
+
+- **Critical/Security:** Red tones (#D93F0B)
+- **High Priority:** Orange tones (#D93F0B)
+- **Medium Priority:** Orange (#FFA500)
+- **Low Priority:** Yellow (#FBCA04)
+- **Bug:** Red (#d73a4a)
+- **Enhancement:** Blue (#a2eeef)
+- **Documentation:** Blue (#0075ca)
+- **Infrastructure:** Dark blue (#0052CC)
+- **Testing:** Green (#0E8A16)
+- **UI/Preview:** Purple (#D4C5F9)
 
 ---
 
 ## 🚀 Next Steps
 
-With labels applied, you can now:
+With labels applied and cleaned up, you can now:
 
 1. **Create GitHub Projects** - Organize issues into boards
 2. **Create Milestones** - Track v0.1, v0.2, etc. progress
@@ -187,7 +282,57 @@ With labels applied, you can now:
 5. **Onboard contributors** - Help them find good first issues
 
 **Recommended:** Create a GitHub Project board for v0.1 with columns:
-- To Do (ready)
-- In Progress (status: in-progress)
-- Blocked (status: blocked)
-- Done (closed)
+- To Do (`label:"v0.1" is:open no:assignee`)
+- In Progress (`label:"v0.1" is:open assignee:*`)
+- In Review (`label:"v0.1" is:pr`)
+- Done (`label:"v0.1" is:closed`)
+
+---
+
+## 📊 All Active Labels
+
+Complete list of all 37 labels currently in use:
+
+| Label | Usage | Description |
+|-------|-------|-------------|
+| `bug` | 38 | Something isn't working |
+| `cloned-issue` | 34 | Cloned from original MacDown |
+| `enhancement` | 30 | New feature or request |
+| `v0.1` | 27 | Must have for v0.1 release |
+| `medium` | 25 | Should do, moderate impact |
+| `testing` | 25 | Testing infrastructure and test cases |
+| `high` | 22 | Important for release, significant impact |
+| `infrastructure` | 21 | Build system, CI/CD, project infrastructure |
+| `rendering` | 14 | Rendering and display issues |
+| `build` | 12 | Build system, Xcode configuration |
+| `hoedown` | 8 | Related to Hoedown parser |
+| `critical` | 7 | Blocking release, critical issues |
+| `dependencies` | 7 | Pull requests that update dependencies |
+| `low` | 7 | Nice to have, minor impact |
+| `ci-cd` | 6 | CI/CD workflows |
+| `documentation` | 6 | Improvements or additions to documentation |
+| `export` | 6 | PDF/HTML export |
+| `editor` | 5 | Text editor pane |
+| `preview` | 5 | Preview pane |
+| `cloned-pr` | 4 | Based on original MacDown PR |
+| `diagrams` | 4 | Mermaid/Graphviz diagrams |
+| `file-io` | 4 | File operations, autosave |
+| `backlog` | 3 | Not scheduled yet |
+| `preferences` | 3 | Settings and preferences |
+| `good-first-issue` | 2 | Good for newcomers |
+| `localization` | 2 | i18n, translations |
+| `security` | 2 | Security issues |
+| `ui` | 2 | User interface, windows, menus |
+| `ci/cd` | 1 | CI/CD workflows (duplicate) |
+| `cli` | 1 | Command-line tool |
+| `code-signing` | 1 | Code signing |
+| `help-wanted` | 1 | Extra attention needed |
+| `javascript` | 1 | JavaScript code |
+| `markdown-parsing` | 1 | Markdown parsing |
+| `question` | 1 | Further information requested |
+| `syntax` | 1 | Syntax highlighting |
+| `upstream` | 1 | Issue in a dependency |
+
+---
+
+**Note:** This guide is a living document. Update it when labels are added, modified, or removed.


### PR DESCRIPTION
- Updated all label categories with actual labels in use
- Added usage counts for each label (based on 114 total issues)
- Documented cleanup history (replaced priority: prefix, removed unused labels)
- Updated statistics: 37 labels, all actively in use
- Improved filtering examples with current labels
- Added complete label reference table with all 37 active labels
- Removed outdated prefix-based naming convention
- Added label naming conventions and color scheme documentation

Related to label cleanup and organization work.