### PR TITLE
Address issue #32: Fix Open Recent menu on macOS Sonoma

### DIFF
--- a/MacDown/MacDown-Info.plist
+++ b/MacDown/MacDown-Info.plist
@@ -124,6 +124,12 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014–2020 Tzu-ping Chung.</string>
+	<key>NSDesktopFolderUsageDescription</key>
+	<string>MacDown needs access to your Desktop to track recently opened files.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>MacDown needs access to your Documents folder to track recently opened files.</string>
+	<key>NSDownloadsFolderUsageDescription</key>
+	<string>MacDown needs access to your Downloads folder to track recently opened files.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
## Summary

Fixes the "Open Recent" menu on macOS Sonoma (14.x+) by adding required folder permission description keys to Info.plist.

### Problem
The "Open Recent" menu was completely broken on macOS Sonoma:
- Menu appeared blank with "Clear Menu" greyed out
- OR showed blank entries that generated "document (null) could not be opened" errors

### Root Cause
macOS Sonoma requires specific permission keys in Info.plist to access protected folders (Desktop, Documents, Downloads). Without these keys, the consent dialogue never appears and the app cannot track recently opened files.

### Solution
Added three permission description keys to `MacDown/MacDown-Info.plist`:

```xml
<key>NSDesktopFolderUsageDescription</key>
<string>MacDown needs access to your Desktop to track recently opened files.</string>
<key>NSDocumentsFolderUsageDescription</key>
<string>MacDown needs access to your Documents folder to track recently opened files.</string>
<key>NSDownloadsFolderUsageDescription</key>
<string>MacDown needs access to your Downloads folder to track recently opened files.</string>
```

### Changes
- **Modified:** `MacDown/MacDown-Info.plist` (added 6 lines)
- **No code changes required** - uses existing NSDocument recent file tracking

### User Impact
When users first open a file from Desktop/Documents/Downloads after this update:
1. macOS will display a permission dialog with the description above
2. User grants permission (one-time per folder)
3. "Open Recent" menu will then work correctly

### Backward Compatibility
✅ These keys are ignored on older macOS versions - no compatibility issues

## Related Issue

Related to #32

## Testing

### CI Results
✅ Build succeeded on macOS 14 (Sonoma)
✅ All tests passed

### Code Review
✅ Reviewed by Chico - Approved with no critical issues
- Implementation is complete and correct
- Permission descriptions are clear and user-friendly
- XML formatting follows project conventions
- No security concerns

### Manual Testing Plan

**⚠️ Manual testing on macOS Sonoma (14.x+) is REQUIRED** to verify:

#### Critical Test Cases
1. **Permission Dialog Appearance**
   - Open file from Desktop → permission dialog should appear
   - Dialog should show: "MacDown needs access to your Desktop to track recently opened files."
   - Repeat for Documents and Downloads folders

2. **Permission Granted**
   - After granting permission, file should open normally
   - File should appear in File → Open Recent menu
   - "Clear Menu" option should be enabled

3. **Subsequent Files (No Dialog)**
   - Open another file from same folder
   - Should NOT show permission dialog again
   - File should appear in Recent menu

4. **Multiple Folders**
   - Open files from all three folders (Desktop, Documents, Downloads)
   - Each should trigger separate permission dialog
   - Recent menu should show files from all folders

5. **Clear Menu**
   - File → Open Recent → Clear Menu
   - All recent files should be removed
   - "Clear Menu" should become greyed out

#### Edge Cases to Test
- User denies permission → file may open but won't appear in Recent menu
- Permission revoked via System Settings → new files won't be tracked until permission re-granted
- Files in nested folders (e.g., ~/Desktop/Subfolder/) → should work with parent folder permission
- App restart → Recent menu and permissions should persist

**Full manual testing plan available in the Zeppo consultation** (comprehensive test suite covering 18+ test cases including setup, core functionality, edge cases, and regression tests).

#### Minimum Testing (15-20 minutes)
- Test cases 1-5 above on macOS Sonoma 14.x
- Verify permission dialogs appear with correct text
- Verify Recent menu populates after granting permissions

## Review Notes

### Architectural Guidance (Groucho)
- Confirmed Info.plist location and structure
- Recommended permission description text (clear, user-centric, consistent)
- Advised limiting to Desktop/Documents/Downloads (covers 95%+ use cases)
- Confirmed no code changes needed

### Code Review (Chico)
- ✅ **Approved for merge**
- Implementation is complete and correct
- No critical issues found
- Minor note: Alphabetical ordering within NS* keys is optional (current functional grouping is acceptable)

### Documentation (Harpo)
- No updates needed to plans/ directory
- This is a self-contained bug fix that doesn't impact planning documents

### Testing (Zeppo)
- Created comprehensive 18-test-case manual testing plan
- Emphasizes importance of testing on actual macOS Sonoma system
- Covers permission dialogs, Recent menu functionality, edge cases, and regressions

## Deployment Considerations

### Release Notes
Suggest including in release notes:
- "Fixed: Open Recent menu now works on macOS Sonoma (14.x+)"
- "Note: First time opening files from Desktop/Documents/Downloads will trigger macOS permission dialogs (one-time per folder)"

### Support Considerations
- Users may contact support about permission dialogs → this is expected macOS behavior
- If users deny permission, "Open Recent" won't work for that folder → they can grant permission later via System Settings → Privacy & Security → Files and Folders

---

**Ready for review and manual testing on macOS Sonoma.**