### PR TITLE
Fix mobile hamburger menu styling to overlay hero section

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -515,9 +515,26 @@ footer a:hover {
 
 /* Responsive Design */
 @media (max-width: 768px) {
+    /* Make header transparent and overlay content on mobile */
+    header {
+        background-color: transparent;
+        border-bottom: none;
+        position: absolute;
+        width: 100%;
+    }
+
     /* Hamburger menu for mobile */
     .hamburger {
         display: flex;
+        border: 2px solid white;
+        border-radius: 8px;
+        padding: 8px;
+        background-color: rgba(255, 255, 255, 0.1);
+    }
+
+    /* Make hamburger lines white */
+    .hamburger-line {
+        background-color: white;
     }
 
     nav .container {


### PR DESCRIPTION
The hamburger menu had several visual issues on mobile:
- Black hamburger lines (now white for contrast on teal background)
- White header pushed down content (now transparent and overlays)
- Missing white rounded border on button (now added)

Changes:
- Header: transparent background, absolute positioning on mobile
- Hamburger button: white border with 8px border-radius
- Hamburger lines: white color
- Added subtle white background (10% opacity) for button visibility

Related to hamburger menu visual improvements.