### PR TITLE
Add manual trigger to update-website workflow

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["Staple and Publish Release"]
     types:
       - completed
+  workflow_dispatch:  # Allow manual triggering
 
 permissions:
   contents: write  # Required to commit and push website updates
@@ -13,7 +14,7 @@ jobs:
   update-website:
     name: Update Website Download Links
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` trigger to the update-website workflow, allowing manual runs for testing.

## Changes

- Added `workflow_dispatch` trigger to enable manual workflow execution from GitHub Actions UI
- Updated workflow condition to handle both automatic triggers (from staple workflow completion) and manual triggers

## Use Case

This allows testing the workflow fix from PR #160 without waiting for a new release. After merging, you can manually trigger the workflow from:
- GitHub Actions → Update Website with Latest Release → Run workflow

Related to website update workflow improvements.