### PR TITLE
Auto-publish releases after successful stapling

### DIFF
--- a/.github/workflows/staple-release.yml
+++ b/.github/workflows/staple-release.yml
@@ -298,6 +298,18 @@ jobs:
           gh release edit "$TAG" --notes-file release-notes.md
 
           echo "✅ Release notes updated"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🚀 Publishing release..."
+
+          # Publish the release (make it public)
+          gh release edit "$TAG" --draft=false
+
           echo ""
-          echo "🎉 Release is now ready for publication!"
-          echo "   View at: https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG"
+          echo "✅ Release published successfully!"
+          echo "🎉 View at: https://github.com/${{ github.repository }}/releases/tag/$TAG"
+          echo ""
+          echo "The update-website workflow will now run automatically."


### PR DESCRIPTION
Adds automatic release publication to the staple-release workflow.

## Changes

Adds a new final step to automatically publish the release after stapling is complete.

Previously:
- Workflow stapled DMG and updated release notes
- Left release as draft
- Required manual publication

Now:
- All of the above, plus
- Automatically publishes the release with --draft=false
- Triggers update-website workflow automatically

## Benefits

- Streamlined release process (one less manual step)
- Website updates immediately after stapling
- Reduces time between stapling completion and public availability
- Ensures consistency (no forgotten unpublished releases)

## Workflow

After this merges, the complete automated flow will be:
1. Create release (draft) with build-release workflow
2. Staple and verify with staple-release workflow
3. **Auto-publish release** (new step)
4. Update website automatically via update-website workflow

All automated end-to-end.