### PR TITLE
Support pre-releases and dual-release website display

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -26,81 +26,182 @@ jobs:
         run: |
           echo "📥 Fetching latest release information..."
 
-          # Get the latest published release (including pre-releases, excluding drafts)
-          # gh release view without a tag excludes pre-releases, so we list first then view
-          LATEST_TAG=$(gh release list --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName')
+          # Function to extract release details
+          extract_release_info() {
+            local TAG=$1
+            local OUTPUT_VAR_PREFIX=$2
 
-          if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
+            if ! gh release view "$TAG" --json tagName,publishedAt,assets,url,isPrerelease > "release_${OUTPUT_VAR_PREFIX}.json" 2>/dev/null; then
+              return 1
+            fi
+
+            local tag_name=$(jq -r '.tagName' "release_${OUTPUT_VAR_PREFIX}.json")
+            local published_at=$(jq -r '.publishedAt' "release_${OUTPUT_VAR_PREFIX}.json")
+            local release_url=$(jq -r '.url' "release_${OUTPUT_VAR_PREFIX}.json")
+            local version="${tag_name#v}"
+
+            # Find DMG asset
+            local dmg_name=$(jq -r '.assets[] | select(.name | endswith(".dmg")) | .name' "release_${OUTPUT_VAR_PREFIX}.json")
+            local dmg_size=$(jq -r '.assets[] | select(.name | endswith(".dmg")) | .size' "release_${OUTPUT_VAR_PREFIX}.json")
+
+            if [ -z "$dmg_name" ] || [ "$dmg_name" = "null" ]; then
+              echo "⚠️  No DMG found for $TAG"
+              return 1
+            fi
+
+            local dmg_size_mb=$(echo "scale=1; $dmg_size / 1024 / 1024" | bc)
+            local download_url="https://github.com/${{ github.repository }}/releases/download/${tag_name}/${dmg_name}"
+            local checksum_url="https://github.com/${{ github.repository }}/releases/download/${tag_name}/${dmg_name}.sha256"
+
+            # Export variables with prefix
+            eval "${OUTPUT_VAR_PREFIX}_VERSION='$version'"
+            eval "${OUTPUT_VAR_PREFIX}_TAG_NAME='$tag_name'"
+            eval "${OUTPUT_VAR_PREFIX}_PUBLISHED_AT='$published_at'"
+            eval "${OUTPUT_VAR_PREFIX}_RELEASE_URL='$release_url'"
+            eval "${OUTPUT_VAR_PREFIX}_DMG_NAME='$dmg_name'"
+            eval "${OUTPUT_VAR_PREFIX}_DMG_SIZE_MB='$dmg_size_mb'"
+            eval "${OUTPUT_VAR_PREFIX}_DOWNLOAD_URL='$download_url'"
+            eval "${OUTPUT_VAR_PREFIX}_CHECKSUM_URL='$checksum_url'"
+
+            return 0
+          }
+
+          # Get latest stable release (non-pre-release)
+          STABLE_TAG=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')
+
+          # Get latest pre-release
+          PRERELEASE_TAG=$(gh release list --exclude-drafts --limit 1 --json tagName,isPrerelease --jq '.[] | select(.isPrerelease == true) | .tagName' | head -1)
+
+          # Process stable release if it exists
+          HAS_STABLE=false
+          if [ -n "$STABLE_TAG" ] && [ "$STABLE_TAG" != "null" ]; then
+            echo "Found stable release: $STABLE_TAG"
+            if extract_release_info "$STABLE_TAG" "STABLE"; then
+              HAS_STABLE=true
+              echo "✅ Stable release: $STABLE_VERSION"
+            fi
+          fi
+
+          # Process pre-release if it exists
+          HAS_PRERELEASE=false
+          if [ -n "$PRERELEASE_TAG" ] && [ "$PRERELEASE_TAG" != "null" ]; then
+            echo "Found pre-release: $PRERELEASE_TAG"
+            if extract_release_info "$PRERELEASE_TAG" "PRERELEASE"; then
+              HAS_PRERELEASE=true
+              echo "✅ Pre-release: $PRERELEASE_VERSION"
+            fi
+          fi
+
+          # Ensure we have at least one release
+          if [ "$HAS_STABLE" = "false" ] && [ "$HAS_PRERELEASE" = "false" ]; then
             echo "❌ Error: No published releases found in repository"
             exit 1
           fi
 
-          echo "Found latest release: $LATEST_TAG"
-
-          # Now get full details for this specific release
-          if ! gh release view "$LATEST_TAG" --json tagName,publishedAt,assets,url > release.json 2>/dev/null; then
-            echo "❌ Error: Failed to get release details for $LATEST_TAG"
-            exit 1
+          # Export VERSION for commit message (use stable if available, otherwise prerelease)
+          if [ "$HAS_STABLE" = "true" ]; then
+            echo "VERSION=$STABLE_VERSION" >> $GITHUB_ENV
+          else
+            echo "VERSION=$PRERELEASE_VERSION" >> $GITHUB_ENV
           fi
 
-          # Extract release info
-          TAG_NAME=$(jq -r '.tagName' release.json)
-          PUBLISHED_AT=$(jq -r '.publishedAt' release.json)
-          RELEASE_URL=$(jq -r '.url' release.json)
-          VERSION="${TAG_NAME#v}"
+          # Build JSON data file
+          UPDATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          # Validate we got valid data
-          if [ -z "$TAG_NAME" ] || [ "$TAG_NAME" = "null" ]; then
-            echo "❌ Error: Failed to extract tag name from release"
-            exit 1
+          if [ "$HAS_STABLE" = "true" ] && [ "$HAS_PRERELEASE" = "true" ]; then
+            # Both stable and pre-release exist
+            jq -n \
+              --arg stableVersion "$STABLE_VERSION" \
+              --arg stableTagName "$STABLE_TAG_NAME" \
+              --arg stableReleaseUrl "$STABLE_RELEASE_URL" \
+              --arg stablePublishedAt "$STABLE_PUBLISHED_AT" \
+              --arg stableDownloadUrl "$STABLE_DOWNLOAD_URL" \
+              --arg stableDmgName "$STABLE_DMG_NAME" \
+              --arg stableDmgSizeMB "$STABLE_DMG_SIZE_MB" \
+              --arg stableChecksumUrl "$STABLE_CHECKSUM_URL" \
+              --arg prereleaseVersion "$PRERELEASE_VERSION" \
+              --arg prereleaseTagName "$PRERELEASE_TAG_NAME" \
+              --arg prereleaseReleaseUrl "$PRERELEASE_RELEASE_URL" \
+              --arg prereleasePublishedAt "$PRERELEASE_PUBLISHED_AT" \
+              --arg prereleaseDownloadUrl "$PRERELEASE_DOWNLOAD_URL" \
+              --arg prereleaseDmgName "$PRERELEASE_DMG_NAME" \
+              --arg prereleaseDmgSizeMB "$PRERELEASE_DMG_SIZE_MB" \
+              --arg prereleaseChecksumUrl "$PRERELEASE_CHECKSUM_URL" \
+              --arg updatedAt "$UPDATED_AT" \
+              '{
+                stable: {
+                  version: $stableVersion,
+                  tagName: $stableTagName,
+                  releaseUrl: $stableReleaseUrl,
+                  publishedAt: $stablePublishedAt,
+                  downloadUrl: $stableDownloadUrl,
+                  dmgName: $stableDmgName,
+                  dmgSizeMB: $stableDmgSizeMB,
+                  checksumUrl: $stableChecksumUrl
+                },
+                prerelease: {
+                  version: $prereleaseVersion,
+                  tagName: $prereleaseTagName,
+                  releaseUrl: $prereleaseReleaseUrl,
+                  publishedAt: $prereleasePublishedAt,
+                  downloadUrl: $prereleaseDownloadUrl,
+                  dmgName: $prereleaseDmgName,
+                  dmgSizeMB: $prereleaseDmgSizeMB,
+                  checksumUrl: $prereleaseChecksumUrl
+                },
+                updatedAt: $updatedAt
+              }' > docs/_data/latest.json
+          elif [ "$HAS_STABLE" = "true" ]; then
+            # Only stable release exists
+            jq -n \
+              --arg version "$STABLE_VERSION" \
+              --arg tagName "$STABLE_TAG_NAME" \
+              --arg releaseUrl "$STABLE_RELEASE_URL" \
+              --arg publishedAt "$STABLE_PUBLISHED_AT" \
+              --arg downloadUrl "$STABLE_DOWNLOAD_URL" \
+              --arg dmgName "$STABLE_DMG_NAME" \
+              --arg dmgSizeMB "$STABLE_DMG_SIZE_MB" \
+              --arg checksumUrl "$STABLE_CHECKSUM_URL" \
+              --arg updatedAt "$UPDATED_AT" \
+              '{
+                stable: {
+                  version: $version,
+                  tagName: $tagName,
+                  releaseUrl: $releaseUrl,
+                  publishedAt: $publishedAt,
+                  downloadUrl: $downloadUrl,
+                  dmgName: $dmgName,
+                  dmgSizeMB: $dmgSizeMB,
+                  checksumUrl: $checksumUrl
+                },
+                updatedAt: $updatedAt
+              }' > docs/_data/latest.json
+          else
+            # Only pre-release exists
+            jq -n \
+              --arg version "$PRERELEASE_VERSION" \
+              --arg tagName "$PRERELEASE_TAG_NAME" \
+              --arg releaseUrl "$PRERELEASE_RELEASE_URL" \
+              --arg publishedAt "$PRERELEASE_PUBLISHED_AT" \
+              --arg downloadUrl "$PRERELEASE_DOWNLOAD_URL" \
+              --arg dmgName "$PRERELEASE_DMG_NAME" \
+              --arg dmgSizeMB "$PRERELEASE_DMG_SIZE_MB" \
+              --arg checksumUrl "$PRERELEASE_CHECKSUM_URL" \
+              --arg updatedAt "$UPDATED_AT" \
+              '{
+                prerelease: {
+                  version: $version,
+                  tagName: $tagName,
+                  releaseUrl: $releaseUrl,
+                  publishedAt: $publishedAt,
+                  downloadUrl: $downloadUrl,
+                  dmgName: $dmgName,
+                  dmgSizeMB: $dmgSizeMB,
+                  checksumUrl: $checksumUrl
+                },
+                updatedAt: $updatedAt
+              }' > docs/_data/latest.json
           fi
-
-          # Find DMG asset
-          DMG_NAME=$(jq -r '.assets[] | select(.name | endswith(".dmg")) | .name' release.json)
-          DMG_SIZE=$(jq -r '.assets[] | select(.name | endswith(".dmg")) | .size' release.json)
-
-          # Validate DMG exists
-          if [ -z "$DMG_NAME" ] || [ "$DMG_NAME" = "null" ]; then
-            echo "❌ Error: No DMG file found in release $TAG_NAME"
-            echo "Available assets:"
-            jq -r '.assets[].name' release.json
-            exit 1
-          fi
-
-          # Calculate size (now safe because we validated DMG_SIZE exists)
-          DMG_SIZE_MB=$(echo "scale=1; $DMG_SIZE / 1024 / 1024" | bc)
-
-          # Build download URLs
-          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${TAG_NAME}/${DMG_NAME}"
-          CHECKSUM_URL="https://github.com/${{ github.repository }}/releases/download/${TAG_NAME}/${DMG_NAME}.sha256"
-
-          echo "✅ Found release: $VERSION"
-
-          # Export VERSION for use in next step
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-          # Update the data file (Jekyll will use this via Liquid templating)
-          jq -n \
-            --arg version "$VERSION" \
-            --arg tagName "$TAG_NAME" \
-            --arg releaseUrl "$RELEASE_URL" \
-            --arg publishedAt "$PUBLISHED_AT" \
-            --arg downloadUrl "$DOWNLOAD_URL" \
-            --arg dmgName "$DMG_NAME" \
-            --arg dmgSizeMB "$DMG_SIZE_MB" \
-            --arg checksumUrl "$CHECKSUM_URL" \
-            --arg updatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '{
-              version: $version,
-              tagName: $tagName,
-              releaseUrl: $releaseUrl,
-              publishedAt: $publishedAt,
-              downloadUrl: $downloadUrl,
-              dmgName: $dmgName,
-              dmgSizeMB: $dmgSizeMB,
-              checksumUrl: $checksumUrl,
-              updatedAt: $updatedAt
-            }' > docs/_data/latest.json
 
           echo "✅ Updated docs/_data/latest.json"
           cat docs/_data/latest.json

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,29 +27,57 @@ description: MacDown 3000 - A free, open source Markdown editor for macOS with l
         </div>
         <div class="download-content" id="download">
             <h2>Download</h2>
-            <p class="version"><strong>Version {{ site.data.latest.version }}</strong></p>
 
-            {% if site.data.latest.downloadUrl %}
-            <p style="margin-top: 1.5rem;">
-                <a href="{{ site.data.latest.downloadUrl }}" class="btn">Download MacDown {{ site.data.latest.version }}</a>
-            </p>
+            {% if site.data.latest.stable %}
+            <!-- Stable Release -->
+            <div style="margin-bottom: 2rem;">
+                <p class="version"><strong>Stable Release: {{ site.data.latest.stable.version }}</strong></p>
 
-            <p style="margin-top: 1rem;">
-                <small><strong>Size:</strong> {{ site.data.latest.dmgSizeMB }} MB | <strong>Platform:</strong> macOS 11.0+ (Universal Binary)</small>
-            </p>
+                <p style="margin-top: 1.5rem;">
+                    <a href="{{ site.data.latest.stable.downloadUrl }}" class="btn">Download MacDown {{ site.data.latest.stable.version }}</a>
+                </p>
 
-            <p style="margin-top: 1rem;">
-                <small>
-                    <a href="{{ site.data.latest.checksumUrl }}">SHA256 Checksum</a> |
-                    <a href="{{ site.data.latest.releaseUrl }}">Release Notes</a> |
-                    <a href="https://github.com/schuyler/macdown3000/releases">All Releases</a>
-                </small>
-            </p>
+                <p style="margin-top: 1rem;">
+                    <small><strong>Size:</strong> {{ site.data.latest.stable.dmgSizeMB }} MB | <strong>Platform:</strong> macOS 11.0+ (Universal Binary)</small>
+                </p>
 
-            <p style="margin-top: 1.5rem; padding: 1rem; background: #f5f5f5; border-radius: 4px;">
-                <small><strong>Note:</strong> MacDown 3000 is signed and notarized by Apple. Your Mac will verify the download automatically.</small>
-            </p>
-            {% else %}
+                <p style="margin-top: 1rem;">
+                    <small>
+                        <a href="{{ site.data.latest.stable.checksumUrl }}">SHA256 Checksum</a> |
+                        <a href="{{ site.data.latest.stable.releaseUrl }}">Release Notes</a> |
+                        <a href="https://github.com/schuyler/macdown3000/releases">All Releases</a>
+                    </small>
+                </p>
+            </div>
+            {% endif %}
+
+            {% if site.data.latest.prerelease %}
+            <!-- Pre-release -->
+            <div style="margin-bottom: 2rem; padding: 1rem; background: #fff3cd; border-radius: 4px; border: 1px solid #ffc107;">
+                <p class="version"><strong>🧪 Pre-release: {{ site.data.latest.prerelease.version }}</strong></p>
+                <p style="margin-top: 0.5rem;">
+                    <small><em>Beta version - may contain experimental features or bugs</em></small>
+                </p>
+
+                <p style="margin-top: 1rem;">
+                    <a href="{{ site.data.latest.prerelease.downloadUrl }}" class="btn btn-secondary">Download Beta {{ site.data.latest.prerelease.version }}</a>
+                </p>
+
+                <p style="margin-top: 1rem;">
+                    <small><strong>Size:</strong> {{ site.data.latest.prerelease.dmgSizeMB }} MB | <strong>Platform:</strong> macOS 11.0+ (Universal Binary)</small>
+                </p>
+
+                <p style="margin-top: 1rem;">
+                    <small>
+                        <a href="{{ site.data.latest.prerelease.checksumUrl }}">SHA256 Checksum</a> |
+                        <a href="{{ site.data.latest.prerelease.releaseUrl }}">Release Notes</a>
+                    </small>
+                </p>
+            </div>
+            {% endif %}
+
+            {% if site.data.latest.stable == null and site.data.latest.prerelease == null %}
+            <!-- No releases available -->
             <p>Coming Soon</p>
 
             <p style="margin-top: 2rem;">
@@ -57,6 +85,10 @@ description: MacDown 3000 - A free, open source Markdown editor for macOS with l
             </p>
             <p style="margin-top: 1rem;">
                 <small>Releases will be available on the <a href="https://github.com/schuyler/macdown3000/releases">GitHub Releases</a> page.</small>
+            </p>
+            {% else %}
+            <p style="margin-top: 1.5rem; padding: 1rem; background: #f5f5f5; border-radius: 4px;">
+                <small><strong>Note:</strong> MacDown 3000 is signed and notarized by Apple. Your Mac will verify the download automatically.</small>
             </p>
             {% endif %}
         </div>


### PR DESCRIPTION
Adds comprehensive support for pre-releases in the update-website workflow and displays both stable and pre-release versions on the website.

## Changes

### 1. Fix Pre-release Detection

Previously, gh release view without a tag excluded pre-releases, causing the workflow to fail when only a pre-release existed.

**Solution:**
- Use gh release list to get latest tag (includes pre-releases)
- Then view that specific release for full details

### 2. Dual-Release Support

The workflow now fetches and displays BOTH stable releases and pre-releases when available.

**Workflow enhancements:**
- Helper function to extract release info for any tag
- Fetches latest stable release (--exclude-pre-releases)
- Fetches latest pre-release separately
- Generates JSON with separate stable/prerelease sections
- Handles all combinations: both, stable only, or prerelease only

**Website enhancements:**
- Stable release shown prominently when available
- Pre-release shown in highlighted yellow box with beta warning
- Each has its own download button, size, checksum, release notes
- Gracefully handles when only one type exists

## Data Structure

**Before (single release):**
```json
{
  "version": "1.0.0",
  "downloadUrl": "...",
  ...
}
```

**After (supports both):**
```json
{
  "stable": {
    "version": "1.0.0",
    "downloadUrl": "...",
    ...
  },
  "prerelease": {
    "version": "1.1.0-beta.1",
    "downloadUrl": "...",
    ...
  },
  "updatedAt": "2025-11-22T..."
}
```

## Benefits

- Users can choose between stable and bleeding-edge versions
- Pre-releases are clearly marked as beta with warnings
- Workflow works with any combination of release types
- Future-proof as project matures from beta to stable releases

## Testing

Currently only a pre-release exists (v3000.0.0-beta.0). Once merged and workflow runs:
- Website will show beta download with warning
- When first stable release is published, both will appear
- Each type maintains its own download section