### PR TITLE
Fix pre-release text contrast for better readability

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,9 +53,9 @@ description: MacDown 3000 - A free, open source Markdown editor for macOS with l
 
             {% if site.data.latest.prerelease %}
             <!-- Pre-release -->
-            <div style="margin-bottom: 2rem; padding: 1rem; background: #fff3cd; border-radius: 4px; border: 1px solid #ffc107;">
-                <p class="version"><strong>🧪 Pre-release: {{ site.data.latest.prerelease.version }}</strong></p>
-                <p style="margin-top: 0.5rem;">
+            <div style="margin-bottom: 2rem; padding: 1rem; background: #fff3cd; border-radius: 4px; border: 1px solid #ffc107; color: #856404;">
+                <p class="version" style="color: #856404;"><strong>🧪 Pre-release: {{ site.data.latest.prerelease.version }}</strong></p>
+                <p style="margin-top: 0.5rem; color: #856404;">
                     <small><em>Beta version - may contain experimental features or bugs</em></small>
                 </p>
 
@@ -63,14 +63,14 @@ description: MacDown 3000 - A free, open source Markdown editor for macOS with l
                     <a href="{{ site.data.latest.prerelease.downloadUrl }}" class="btn btn-secondary">Download Beta {{ site.data.latest.prerelease.version }}</a>
                 </p>
 
-                <p style="margin-top: 1rem;">
+                <p style="margin-top: 1rem; color: #856404;">
                     <small><strong>Size:</strong> {{ site.data.latest.prerelease.dmgSizeMB }} MB | <strong>Platform:</strong> macOS 11.0+ (Universal Binary)</small>
                 </p>
 
-                <p style="margin-top: 1rem;">
+                <p style="margin-top: 1rem; color: #856404;">
                     <small>
-                        <a href="{{ site.data.latest.prerelease.checksumUrl }}">SHA256 Checksum</a> |
-                        <a href="{{ site.data.latest.prerelease.releaseUrl }}">Release Notes</a>
+                        <a href="{{ site.data.latest.prerelease.checksumUrl }}" style="color: #0056b3;">SHA256 Checksum</a> |
+                        <a href="{{ site.data.latest.prerelease.releaseUrl }}" style="color: #0056b3;">Release Notes</a>
                     </small>
                 </p>
             </div>


### PR DESCRIPTION
Improves text readability in the pre-release download section.

## Changes

Updated pre-release section styling with better color contrast:
- **Text color**: Dark brown (#856404) instead of default (likely white/light)
- **Background**: Light yellow (#fff3cd) - unchanged
- **Links**: Dark blue (#0056b3) for clear visibility

## Before
White/light text on yellow background (illegible)

## After
Dark brown text on yellow background (high contrast, easy to read)

This follows Bootstrap's warning alert color scheme which uses similar colors for accessibility.