### PR TITLE
Fix French localization errors

### DIFF
--- a/MacDown/Localization/fr.lproj/Localizable.strings
+++ b/MacDown/Localization/fr.lproj/Localizable.strings
@@ -8,10 +8,10 @@
 "Blockquote" = "Bloc de citation";
 
 /* (No Comment) */
-"CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ charactère (sans espaces);%@ charactères (sans espaces)";
+"CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ caractère (sans espaces);%@ caractères (sans espaces)";
 
 /* (No Comment) */
-"CHARACTERS_PLURAL_STRING" = "%@ charactère;%@ charactères";
+"CHARACTERS_PLURAL_STRING" = "%@ caractère;%@ caractères";
 
 /* Comment toolbar button */
 "Comment" = "Commentaire";

--- a/MacDown/Localization/fr.lproj/MainMenu.strings
+++ b/MacDown/Localization/fr.lproj/MainMenu.strings
@@ -143,7 +143,7 @@
 "HFQ-gK-NFA.title" = "Remplacement de texte";
 
 /* Class = "NSMenuItem"; title = "Left 1:1 Right"; ObjectID = "hOV-YQ-vzy"; */
-"hOV-YQ-vzy.title" = "Gauche 1:1 Right";
+"hOV-YQ-vzy.title" = "Gauche 1:1 Droite";
 
 /* Class = "NSMenuItem"; title = "Smart Quotes"; ObjectID = "hQb-2v-fYv"; */
 "hQb-2v-fYv.title" = "Citations intelligentes";
@@ -179,7 +179,7 @@
 "Jzs-tR-jkL.title" = "Diminuer le retrait";
 
 /* Class = "NSMenuItem"; title = "Contributing to MacDown"; ObjectID = "K3J-v5-s91"; */
-"K3J-v5-s91.title" = "Contribue à MacDown 3000";
+"K3J-v5-s91.title" = "Contribuer à MacDown 3000";
 
 /* Class = "NSMenuItem"; title = "Revert to Saved"; ObjectID = "KaW-ft-85H"; */
 "KaW-ft-85H.title" = "Revenir à la version sauvegardée";
@@ -221,7 +221,7 @@
 "OY7-WF-poV.title" = "Réduire";
 
 /* Class = "NSMenuItem"; title = "Stop Speaking"; ObjectID = "Oyz-dy-DGm"; */
-"Oyz-dy-DGm.title" = "Arrêter Dictée";
+"Oyz-dy-DGm.title" = "Arrêter la dictée";
 
 /* Class = "NSMenuItem"; title = "Delete"; ObjectID = "pa3-QI-u2k"; */
 "pa3-QI-u2k.title" = "Supprimer";
@@ -344,7 +344,7 @@
 "YEy-JH-Tfz.title" = "Rechercher et remplacer…";
 
 /* Class = "NSMenuItem"; title = "Start Speaking"; ObjectID = "Ynk-f8-cLZ"; */
-"Ynk-f8-cLZ.title" = "Démarrer Dictée";
+"Ynk-f8-cLZ.title" = "Démarrer la dictée";
 
 /* Class = "NSMenuItem"; title = "Show Substitutions"; ObjectID = "z6F-FW-3nz"; */
 "z6F-FW-3nz.title" = "Afficher les remplacements";


### PR DESCRIPTION
## Summary

Fixes multiple French localization errors discovered during comprehensive review of French language files. Includes the original typo fix from MacDownApp/macdown PR #1274 plus additional grammar and consistency improvements.

### Changes Made

**1. MacDown/Localization/fr.lproj/Localizable.strings** (2 fixes)
- Line 11: Fixed spelling "charactère" → "caractère" in `CHARACTERS_NO_SPACES_PLURAL_STRING`
- Line 14: Fixed spelling "charactère" → "caractère" in `CHARACTERS_PLURAL_STRING`

**2. MacDown/Localization/fr.lproj/MainMenu.strings** (4 fixes)
- Line 146: Fixed mixed language "Gauche 1:1 Right" → "Gauche 1:1 Droite"
- Line 182: Fixed verb form "Contribue à MacDown 3000" → "Contribuer à MacDown 3000" (imperative → infinitive)
- Line 224: Added missing article "Arrêter Dictée" → "Arrêter la dictée"
- Line 347: Added missing article "Démarrer Dictée" → "Démarrer la dictée"

## Related Issue

Related to #107

## Manual Testing Plan

### Setup
Configure macOS to use French locale:
1. Open System Preferences → Language & Region
2. Add "Français" and move to top of preferred languages
3. Restart MacDown 3000

Or launch MacDown in French without changing system language:
```bash
open -a "MacDown 3000" --args -AppleLanguages "(fr)"
```

### Test Cases

#### 1. Character Count Display (Status Bar)
- Type text in editor and verify status bar shows:
  - Single character: "1 caractère" (not "charactère")
  - Multiple: "X caractères" (not "charactères")
  - With spaces: "X caractère (sans espaces)" variant

#### 2. Layout Menu (Présentation → View)
- Verify menu item shows "Gauche 1:1 Droite" (fully French)
- NOT "Gauche 1:1 Right" (mixed language)

#### 3. Help Menu (Aide)
- Verify "Contributing to MacDown" shows as "Contribuer à MacDown 3000"
- Infinitive form, not imperative "Contribue"

#### 4. Speech Menu (Édition → Dicter)
- Verify "Start Speaking" shows as "Démarrer la dictée" (with article "la")
- Verify "Stop Speaking" shows as "Arrêter la dictée" (with article "la")

### Edge Cases
- Test character counts with accented characters (café, école)
- Test with emojis and mixed content
- Verify large numbers format correctly (1,000+ characters)
- Ensure menu items fit without truncation
- Verify English locale still works: `open -a "MacDown 3000" --args -AppleLanguages "(en)"`

## Review Notes

### Code Review (Chico)
✅ **APPROVED** - All changes correct and ready to merge

- UTF-8 encoding properly preserved
- .strings file syntax valid
- French grammar and spelling correct
- Follows project conventions
- No critical issues found

**Note:** Chico identified a pre-existing semantic issue (unrelated to this PR): "Speech" is translated as "Dictée" (dictation) but typically means text-to-speech in macOS. Standard French term would be "Parole" or "Élocution". This is NOT a blocker and could be addressed in a separate issue if desired.

### Documentation Review (Harpo)
✅ **No documentation updates needed** - Changes are localization-only and don't affect documented processes, testing procedures, or architecture.

### Testing Plan (Zeppo)
✅ **Comprehensive manual testing plan provided** (see Manual Testing Plan section above)

## Why These Fixes Matter

- **"charactère"** - Spelling error that appears unprofessional
- **"Gauche 1:1 Right"** - Mixed language is jarring for French users  
- **"Contribue" vs "Contribuer"** - Grammatically incorrect verb form in menu context
- **Missing "la"** - Makes French sound unnatural/robotic without the article

These corrections improve the user experience and professionalism of MacDown 3000 for French-speaking users.

## Files Modified

- `MacDown/Localization/fr.lproj/Localizable.strings`
- `MacDown/Localization/fr.lproj/MainMenu.strings`

**Commit:** efa082c