### PR TITLE
Fix website styling and prerelease link colors

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -168,14 +168,9 @@ nav .container {
 }
 
 .btn-secondary {
-    background-color: transparent;
-    color: white;
-    border: 2px solid white;
-}
-
-.btn-secondary:hover {
     background-color: white;
     color: #20a0a0;
+    border: 2px solid white;
 }
 
 /* Demo and Download Section */

--- a/docs/index.html
+++ b/docs/index.html
@@ -86,10 +86,6 @@ description: MacDown 3000 - A free, open source Markdown editor for macOS with l
             <p style="margin-top: 1rem;">
                 <small>Releases will be available on the <a href="https://github.com/schuyler/macdown3000/releases">GitHub Releases</a> page.</small>
             </p>
-            {% else %}
-            <p style="margin-top: 1.5rem; padding: 1rem; background: #f5f5f5; border-radius: 4px;">
-                <small><strong>Note:</strong> MacDown 3000 is signed and notarized by Apple. Your Mac will verify the download automatically.</small>
-            </p>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
- Remove the grey box note about Apple signing and notarization
- Change prerelease link button to use white background with teal text as default state and remove the hover effect