### PR TITLE
Fix buffer overflow in toolbar initialization (Intel Mac crash)

### DIFF
--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -135,10 +135,17 @@ static CGFloat itemWidth = 37;
     // Add space after the specified toolbar item indices
     int spaceAfterIndices[] = {}; // No space in the default set
     int flexibleSpaceAfterIndices[] = {2, 3, 5, 7, 11};
+
+    // Bounds checking to prevent buffer overflow when accessing C arrays
+    // Empty spaceAfterIndices array must not be accessed (count = 0)
+    // flexibleSpaceAfterIndices has 5 elements, so k must be < 5
+    size_t spaceAfterIndicesCount = sizeof(spaceAfterIndices) / sizeof(int);
+    size_t flexibleSpaceAfterIndicesCount = sizeof(flexibleSpaceAfterIndices) / sizeof(int);
+
     int i = 0;
     int j = 0;
     int k = 0;
-    
+
     for (NSString *itemIdentifier in orderedToolbarItemIdentifiers)
     {
         // exclude some toolbar items from the default toolbar
@@ -149,19 +156,19 @@ static CGFloat itemWidth = 37;
         }else {
             [defaultItemIdentifiers addObject:itemIdentifier];
         }
-        
-        if (i == spaceAfterIndices[j])
+
+        if (j < spaceAfterIndicesCount && i == spaceAfterIndices[j])
         {
             [defaultItemIdentifiers addObject:NSToolbarSpaceItemIdentifier];
             j++;
         }
-        
-        if (i == flexibleSpaceAfterIndices[k])
+
+        if (k < flexibleSpaceAfterIndicesCount && i == flexibleSpaceAfterIndices[k])
         {
             [defaultItemIdentifiers addObject:NSToolbarFlexibleSpaceItemIdentifier];
             k++;
         }
-        
+
         i++;
     }
     


### PR DESCRIPTION
## Summary

Fixes the Intel Mac crash reported in #169 by adding bounds checking to prevent buffer overflow in toolbar initialization.

## Root Cause

Buffer overflow in `MPToolbarController.m` when accessing C arrays without bounds checking:
- Empty `spaceAfterIndices[]` array was accessed on every iteration
- `flexibleSpaceAfterIndices[]` could overflow when `k >= 5`

This undefined behavior existed since 2017 but only crashed on Intel Macs after `ENABLE_HARDENED_RUNTIME=YES` was added in November 2025.

## Changes

- Added bounds checking using `sizeof()` before array access
- Added explanatory comments documenting the fix
- Preserves existing toolbar layout behavior

## Testing

- [x] Code reviewed by Groucho (architect agent)
- [ ] CI tests pass on macOS 14 and 15
- [ ] Launch smoke test passes (validates #169 fix)
- [ ] Manual testing by @benel on Intel Mac

## Related Issue

Related to #169
