### PR TITLE
Make Release workflow version input optional with auto-detection

### DIFF
--- a/.github/workflows/staple-release.yml
+++ b/.github/workflows/staple-release.yml
@@ -33,7 +33,7 @@ jobs:
           else
             # Auto-detect latest draft release
             echo "🔍 Auto-detecting latest draft release..."
-            LATEST_DRAFT=$(gh release list --limit 10 --json tagName,isDraft --jq '.[] | select(.isDraft == true) | .tagName' | head -n 1)
+            LATEST_DRAFT=$(gh release list --draft --limit 1 --json tagName --jq '.[0].tagName')
 
             if [[ -z "$LATEST_DRAFT" ]]; then
               echo "::error::No draft releases found. Please provide a release tag manually."


### PR DESCRIPTION
## Improvement

When Release workflow is triggered manually (workflow_dispatch), it now:
- Auto-detects the latest release tag if no version is provided  
- Extracts the version from that tag
- Still allows manual override by providing a version input

## UX Enhancement

This follows the same pattern as the Staple workflow. Now you can:
1. Manually trigger Release workflow with **no parameters**
2. It auto-detects the latest release version
3. Builds and submits for notarization automatically

This eliminates the need to manually look up and type the version number.