### PR TITLE
Fix documentation typos and add missing Oxford commas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ All code should obey the 80-column rule.
 
 Exception: If a URL in a comment is too long, it can go over the limit. This happens a lot for Apple’s official documentation. Remember, however, that many websites offer alternative, shorter URL forms that are permanent. For example:
 
-* The title slug in StackOverflow (and other StackExchange sites) URLs can be ommitted. The following two are equivalent:
+* The title slug in StackOverflow (and other StackExchange sites) URLs can be omitted. The following two are equivalent:
 
     `http://stackoverflow.com/questions/13155612/how-does-one-eliminate-objective-c-try-catch-blocks-like-this`
     `http://stackoverflow.com/questions/13155612`
@@ -29,7 +29,7 @@ Exception: If a URL in a comment is too long, it can go over the limit. This hap
 * If only one statement is contained inside the block, omit braces unless...
     * This is part of an if-(else if-)else structure. All brace styles in the same structure should match (i.e. either non or all of them omit braces).
 
-#### Stetements Inside `if`, `while`, etc.
+#### Statements Inside `if`, `while`, etc.
 
 * Prefer implicit boolean conversion when it makes sense.
     * `if (str.length)` is better than `if (str.length != 0)` if you want to know whether a string is empty. 
@@ -56,7 +56,7 @@ Exception: If a URL in a comment is too long, it can go over the limit. This hap
     }
     ```
 
-* If code alignment is ambiguious, add extra indentation.
+* If code alignment is ambiguous, add extra indentation.
 
     Yes:
     ```c
@@ -88,7 +88,7 @@ Exception: If a URL in a comment is too long, it can go over the limit. This hap
 
 Always use *four spaces* instead of tabs for indentation. Trailing whitespaces should be removed. You can turn on the **Automatically trim trailing whitespace** option in Xcode to let it do the job for you.
 
-Try to ensure that there’s a trailing newline in the end of a file. This is not strictly enforced since there are no easy ways to do that (except checking manually), but I’d appriciate the effort.
+Try to ensure that there’s a trailing newline in the end of a file. This is not strictly enforced since there are no easy ways to do that (except checking manually), but I’d appreciate the effort.
 
 ## Version Control
 

--- a/MacDown/Resources/contribute.md
+++ b/MacDown/Resources/contribute.md
@@ -10,11 +10,11 @@ MacDown 3000 is hosted on GitHub:
 
 https://github.com/schuyler/macdown3000
 
-Here you can get the source code, read through the issues and start contributing.
+Here you can get the source code, read through the issues, and start contributing.
 
 ## But, I am not a Coder
 
-Contribution is not limited to software developers, since there are other ways you can help. For example, contributing towards documentation, translation and support.
+Contribution is not limited to software developers, since there are other ways you can help. For example, contributing towards documentation, translation, and support.
 
 If you want to help translate, please open an issue on GitHub to discuss adding or updating translations for your language.
 

--- a/MacDown/Resources/help.md
+++ b/MacDown/Resources/help.md
@@ -21,7 +21,7 @@ You can also find me in the **"Open With"** menu whenever you right-click a `.md
 
 ## Markdown and I
 
-**Markdown** is a plain text formatting syntax created by John Gruber, aiming to provide a easy-to-read and feasible markup. The original Markdown syntax specification can be found [here](https://daringfireball.net/projects/markdown/syntax).
+**Markdown** is a plain text formatting syntax created by John Gruber, aiming to provide an easy-to-read and feasible markup. The original Markdown syntax specification can be found [here](https://daringfireball.net/projects/markdown/syntax).
 
 **MacDown 3000** is created as a simple-to-use editor for Markdown documents. I render your Markdown contents real-time into HTML, and display them in a preview panel.
 
@@ -36,7 +36,7 @@ You can customize the editor window to your liking in the [**Editor** preference
 You can configure various application (that's me!) behaviors in the [**General** preference pane](#general-pane).
 
 ## The Basics
-Before I tell you about all the extra syntaxes and capabilities I have, I'll introduce you to the basics of standard markdown. If you already know markdown, and want to jump straight to learning about the fancier things I can do, I suggest you skip to the [**Markdown** preference pane](#markdown-pane). Lets jump right in.  
+Before I tell you about all the extra syntaxes and capabilities I have, I'll introduce you to the basics of standard markdown. If you already know markdown, and want to jump straight to learning about the fancier things I can do, I suggest you skip to the [**Markdown** preference pane](#markdown-pane). Let's jump right in.  
 
 ### Line Breaks
 To force a line break, put two spaces and a newline (return) at the end of the line.
@@ -96,10 +96,10 @@ Perhaps you want to link some text like this: [MacDown 3000 Website](https://mac
 #### Reference style
 Sometimes it looks too messy to include big long urls inline, or you want to keep all your urls together.
 
-Make [a link][arbitrary_id] `[a link][arbitrary_id]` then on it's own line anywhere else in the file:
+Make [a link][arbitrary_id] `[a link][arbitrary_id]` then on its own line anywhere else in the file:
 `[arbitrary_id]: https://macdown.app "Title"`
 
-If the link text itself would make a good id, you can link [like this][] `[like this][]`, then on it's own line anywhere else in the file:
+If the link text itself would make a good id, you can link [like this][] `[like this][]`, then on its own line anywhere else in the file:
 `[like this]: https://macdown.app`
 
 [arbitrary_id]: https://macdown.app "Title"

--- a/assets/demo.md
+++ b/assets/demo.md
@@ -1,7 +1,7 @@
 
 # Graph Visualization
 
-Two graph visualization grammer are supported, mermaid and graphviz.
+Two graph visualization grammars are supported, mermaid and graphviz.
 To enable these features, options `Mermaid` and/or `Graphviz` in `MacDown 3000` -> `Preferences...` -> `Rendering` should be checked.
 
 # Mermaid


### PR DESCRIPTION
## Summary

Applies minor documentation fixes based on [PR #1272](https://github.com/MacDownApp/macdown/pull/1272) from upstream MacDown, plus additional typo fixes found during review.

### Changes

**MacDown/Resources/contribute.md** (from PR #1272)
- Added Oxford comma: "read through the issues, and start contributing"
- Added Oxford comma: "documentation, translation, and support"

**MacDown/Resources/help.md**
- Fixed grammar: "a easy-to-read" → "an easy-to-read"
- Fixed contraction: "Lets" → "Let's"
- Fixed possessive: "it's own line" → "its own line" (3 occurrences)

**assets/demo.md**
- Fixed typo: "grammer" → "grammars"

**CONTRIBUTING.md**
- Fixed typo: "ommitted" → "omitted"
- Fixed typo: "Stetements" → "Statements"
- Fixed typo: "ambiguious" → "ambiguous"
- Fixed typo: "appriciate" → "appreciate"

## Related Issue

Related to #108

## Manual Testing Plan

N/A - documentation-only changes

## Review Notes

No code changes, only documentation fixes.