### PR TITLE
Address issue #196: Add markdown UTType when copying from editor

### DIFF
--- a/MacDown/Code/View/MPEditorView.m
+++ b/MacDown/Code/View/MPEditorView.m
@@ -181,22 +181,37 @@ NS_INLINE BOOL MPAreRectsEqual(NSRect r1, NSRect r2)
         [self updateContentGeometry];
 }
 
-/** Overriden to include markdown UTType when copying to pasteboard.
+/** Overridden to advertise markdown UTType support for pasteboard operations.
+ */
+- (NSArray<NSPasteboardType> *)writablePasteboardTypes
+{
+    NSMutableArray *types = [[super writablePasteboardTypes] mutableCopy];
+    if (![types containsObject:kMPMarkdownPasteboardType])
+        [types addObject:kMPMarkdownPasteboardType];
+    return types;
+}
+
+/** Overridden to include markdown UTType when copying to pasteboard.
  *
- * Writes both plain text and net.daringfireball.markdown types to the
- * pasteboard, improving interoperability with Markdown-aware applications.
+ * Writes plain text and net.daringfireball.markdown types to the pasteboard
+ * when requested, improving interoperability with Markdown-aware applications.
  * This method is called by both copy: and cut: operations.
  */
 - (BOOL)writeSelectionToPasteboard:(NSPasteboard *)pboard
                              types:(NSArray<NSPasteboardType> *)types
 {
     NSString *selectedText = [[self string] substringWithRange:[self selectedRange]];
-    NSData *markdownData = [selectedText dataUsingEncoding:NSUTF8StringEncoding];
 
-    [pboard declareTypes:@[NSPasteboardTypeString, kMPMarkdownPasteboardType]
-                   owner:nil];
-    [pboard setString:selectedText forType:NSPasteboardTypeString];
-    [pboard setData:markdownData forType:kMPMarkdownPasteboardType];
+    [pboard declareTypes:types owner:nil];
+
+    if ([types containsObject:NSPasteboardTypeString])
+        [pboard setString:selectedText forType:NSPasteboardTypeString];
+
+    if ([types containsObject:kMPMarkdownPasteboardType])
+    {
+        NSData *markdownData = [selectedText dataUsingEncoding:NSUTF8StringEncoding];
+        [pboard setData:markdownData forType:kMPMarkdownPasteboardType];
+    }
 
     return YES;
 }


### PR DESCRIPTION
## Summary

When copying content from the editor, MacDown now places `net.daringfireball.markdown` on the pasteboard alongside `public.utf8-plain-text`. This improves interoperability with Markdown-aware applications that can identify and handle markdown content specially.

**Changes:**
- Override `writablePasteboardTypes` to advertise markdown UTType support
- Override `writeSelectionToPasteboard:types:` to write both plain text and markdown types when requested
- Both copy (⌘C) and cut (⌘X) operations benefit from this change

## Related Issue

Related to #196

## Manual Testing Plan

### Key Test Scenarios

1. **Plain Text Fallback** - Copy text, paste in TextEdit → plain text works normally
2. **Markdown-Aware Apps** - Copy text, paste in Ulysses/iA Writer → markdown recognized
3. **Cut Operation** - Cut text, verify removal and correct paste
4. **Special Characters** - Copy emoji, unicode, symbols → no corruption
5. **Code Blocks** - Copy fenced code blocks → syntax preserved
6. **Large Selections** - Select all in large document → no lag or crashes
7. **Cross-Document** - Copy between MacDown documents → works correctly

### Success Criteria
- Plain text copying/pasting works with all existing applications (backward compatible)
- `net.daringfireball.markdown` UTType is available for Markdown-aware applications
- Copy and cut operations both write both pasteboard types
- No errors or crashes occur

## Review Notes

- **Architecture (Groucho):** Recommended overriding `writablePasteboardTypes` and `writeSelectionToPasteboard:types:` in MPEditorView
- **Code Review (Chico):** Fixed initial implementation to respect the `types:` parameter per NSTextView API contract
- **Documentation (Harpo):** No documentation updates needed
- **Testing (Zeppo):** Provided comprehensive 15-scenario manual testing plan