### PR TITLE
Style release links with teal accent color

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -492,6 +492,16 @@ nav .container {
     text-decoration: underline;
 }
 
+/* Download section links - teal accent to match site theme */
+.download-content a:not(.btn) {
+    color: #20a0a0;
+    text-decoration: none;
+}
+
+.download-content a:not(.btn):hover {
+    text-decoration: underline;
+}
+
 /* Footer */
 footer {
     background-color: #333;

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,8 +75,8 @@ description: MacDown 3000 - A free, open source Markdown editor for macOS with l
 
                 <p style="margin-top: 1rem; color: #856404;">
                     <small>
-                        <a href="{{ site.data.latest.prerelease.checksumUrl }}" style="color: #0056b3;">SHA256 Checksum</a> |
-                        <a href="{{ site.data.latest.prerelease.releaseUrl }}" style="color: #0056b3;">Release Notes</a>
+                        <a href="{{ site.data.latest.prerelease.checksumUrl }}">SHA256 Checksum</a> |
+                        <a href="{{ site.data.latest.prerelease.releaseUrl }}">Release Notes</a>
                     </small>
                 </p>
             </div>


### PR DESCRIPTION
Replace default blue link color with the site's teal accent (#20a0a0)
for the SHA256 Checksum, Release Notes, and All Releases links in
the download section. Also removes inline blue styles from pre-release
links to use the new CSS rule instead.