### PR TITLE
Skip unit tests when no application code changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,30 @@ on:
     branches: [ main, develop ]
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      app_code: ${{ steps.filter.outputs.app_code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app_code:
+              - 'MacDown/**'
+              - 'MacDownTests/**'
+              - 'Dependency/**'
+              - 'MacDown 3000.xcodeproj/**'
+              - 'MacDown 3000.xcworkspace/**'
+              - 'Podfile'
+              - 'Podfile.lock'
+
   test:
     name: Run Unit Tests
+    needs: changes
+    if: needs.changes.outputs.app_code == 'true'
     strategy:
       matrix:
         os: [macos-14, macos-15, macos-15-intel]


### PR DESCRIPTION
Use dorny/paths-filter to detect if any application code
changed. Tests are only run when changes are detected in:
- MacDown/ (main app source)
- MacDownTests/ (tests)
- Dependency/ (dependencies)
- Xcode project/workspace files
- Podfile/Podfile.lock

This saves CI minutes for documentation-only PRs while still
running the workflow (so branch protection checks pass).