### PR TITLE
Address issue #214: Fix copy-paste regression in editor

### DIFF
--- a/MacDown/Code/View/MPEditorView.m
+++ b/MacDown/Code/View/MPEditorView.m
@@ -193,27 +193,26 @@ NS_INLINE BOOL MPAreRectsEqual(NSRect r1, NSRect r2)
 
 /** Overridden to include markdown UTType when copying to pasteboard.
  *
- * Writes plain text and net.daringfireball.markdown types to the pasteboard
- * when requested, improving interoperability with Markdown-aware applications.
+ * Adds net.daringfireball.markdown type to the pasteboard alongside standard
+ * types, improving interoperability with Markdown-aware applications.
  * This method is called by both copy: and cut: operations.
  */
 - (BOOL)writeSelectionToPasteboard:(NSPasteboard *)pboard
                              types:(NSArray<NSPasteboardType> *)types
 {
-    NSString *selectedText = [[self string] substringWithRange:[self selectedRange]];
+    // Let superclass handle standard types (plain text, RTF, etc.)
+    BOOL success = [super writeSelectionToPasteboard:pboard types:types];
 
-    [pboard declareTypes:types owner:nil];
-
-    if ([types containsObject:NSPasteboardTypeString])
-        [pboard setString:selectedText forType:NSPasteboardTypeString];
-
-    if ([types containsObject:kMPMarkdownPasteboardType])
+    // Add markdown type if requested (without clearing existing pasteboard data)
+    if (success && [types containsObject:kMPMarkdownPasteboardType])
     {
+        NSString *selectedText = [[self string] substringWithRange:[self selectedRange]];
         NSData *markdownData = [selectedText dataUsingEncoding:NSUTF8StringEncoding];
+        [pboard addTypes:@[kMPMarkdownPasteboardType] owner:nil];
         [pboard setData:markdownData forType:kMPMarkdownPasteboardType];
     }
 
-    return YES;
+    return success;
 }
 
 


### PR DESCRIPTION
## Summary

- Fixed a regression in `MPEditorView.m` where the `writeSelectionToPasteboard:types:` method completely replaced NSTextView's implementation instead of extending it
- The bug was introduced in commit `bd2e293` (issue #196: Add markdown UTType support)
- Copy-paste broke because the override only handled `NSPasteboardTypeString` and `kMPMarkdownPasteboardType`, ignoring other types NSTextView normally handles (RTF, attributed strings, etc.)

**The fix:** Call `super` first to let NSTextView handle standard pasteboard operations, then add the markdown type on top using `addTypes:owner:` which preserves existing pasteboard data.

## Related Issue

Related to #214

## Manual Testing Plan

### Smoke Test (minimum)
1. **Basic copy-paste** - Copy text, paste within same document → works
2. **Cut operation** - Cut text, paste elsewhere → text removed and pasted
3. **Cross-app paste** - Copy from MacDown, paste to TextEdit → works
4. **Markdown syntax** - Copy `**bold** *italic*`, paste → syntax preserved

### Regression Comparison
- Build broken version (`bd2e293`): Copy-paste fails
- Build fixed version: Copy-paste works

### Markdown UTType Verification (issue #196)
- Copy from MacDown to a Markdown-aware app (Bear, Ulysses)
- Should recognize content as Markdown

## Review Notes

- **Code Review:** Approved - fix follows standard Cocoa pattern of calling super first then extending behavior
- **Documentation:** No updates needed
- **Architecture:** The fix properly delegates to NSTextView for standard types while preserving markdown interoperability