### PR TITLE
Fix CI to run tests on every push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  push:
   pull_request:
     branches: [ main, develop ]
 


### PR DESCRIPTION
Run tests on every push to any branch, not just on pull requests. This restores the CI behavior to what it had been previously.