### PR TITLE
Address issue #238: Code-Sign the macdown CLI Binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## [3000.0.3-test] - 2025-12-31
-
-### Infrastructure
-- Code-sign the macdown CLI binary for Homebrew Cask compatibility (#238)
-
 ## [3000.0.2] - 2025-12-30
 
 This release removes remote image loading from the built-in help file, fixes broken localization for German and Slovak, and expands unit test coverage.


### PR DESCRIPTION
## Summary

Add explicit code signing for the `macdown` CLI binary in the release workflow to ensure it passes Homebrew Cask's signature verification.

### Changes

1. **New "Sign CLI binary explicitly" step** (after build, before verification):
   - Signs CLI binary at `Contents/SharedSupport/bin/macdown`
   - Uses `--force --options runtime --timestamp` flags
   - Re-signs app bundle to update code signature seal

2. **Enhanced "Verify code signature" step**:
   - Verifies CLI binary signature with `codesign -vvv --strict`
   - Verifies Developer ID signing identity
   - Verifies hardened runtime flag is present

3. **Enhanced "Verify app bundle inside DMG" step**:
   - Verifies CLI binary exists in DMG
   - Verifies signature and Developer ID
   - Verifies hardened runtime flag

### Why this is needed

The `CodeSignOnCopy` attribute in Xcode only performs basic code signing without hardened runtime or secure timestamp, which is insufficient for Homebrew Cask/Gatekeeper requirements.

## Related Issue

Related to #238

## Manual Testing Plan

### Phase 1: Workflow Verification
- Trigger release workflow with a test tag
- Verify workflow completes without errors in CLI signing steps

### Phase 2: Code Signature Verification
```bash
# Verify CLI binary after mounting DMG
CLI_PATH="/Volumes/MacDown 3000/MacDown 3000.app/Contents/SharedSupport/bin/macdown"
codesign -vvv --strict "$CLI_PATH"
codesign -dvv "$CLI_PATH" 2>&1 | grep "Authority="  # Should show Developer ID
codesign -dvv "$CLI_PATH" 2>&1 | grep "flags="      # Should contain "runtime"
```

### Phase 3: Homebrew Cask Verification
- Update the Homebrew Cask PR at https://github.com/Homebrew/homebrew-cask/pull/242810
- Verify CI passes code signing checks

## Review Notes

- **Groucho (Architecture)**: Recommended adding explicit signing step after build with `--options runtime --timestamp`
- **Chico (Code Review)**: Identified critical path issue (SharedSupport vs MacOS) and need to re-sign app bundle; both issues fixed
- **Harpo (Docs)**: No documentation updates needed - existing docs describe signing at appropriate level
- **Zeppo (Testing)**: Provided comprehensive manual testing plan for verifying signatures