### PR TITLE
Fix drag & drop

### DIFF
--- a/MacDown/Code/View/MPEditorView.m
+++ b/MacDown/Code/View/MPEditorView.m
@@ -55,6 +55,7 @@ NS_INLINE BOOL MPAreRectsEqual(NSRect r1, NSRect r2)
     sourceDragMask = [sender draggingSourceOperationMask];
     pboard = [sender draggingPasteboard];
     
+    // TODO this seems to be a NOOP
     if ([pboard canReadItemWithDataConformingToTypes:[NSArray arrayWithObjects:@"public.jpeg", nil]]) {
         if (sourceDragMask & NSDragOperationLink) {
             return NSDragOperationLink;
@@ -73,6 +74,8 @@ NS_INLINE BOOL MPAreRectsEqual(NSRect r1, NSRect r2)
     sourceDragMask = [sender draggingSourceOperationMask];
     pboard = [sender draggingPasteboard];
     
+    // TODO since above method doesn't filter, this inlines all file types ATM
+    // TODO this isn't undo-able
     if ( [[pboard types] containsObject:NSFilenamesPboardType] ) {
         NSArray *files = [pboard propertyListForType:NSFilenamesPboardType];
         
@@ -90,7 +93,7 @@ NS_INLINE BOOL MPAreRectsEqual(NSRect r1, NSRect r2)
         NSInteger insertionPoint = [[[self selectedRanges] objectAtIndex:0] rangeValue].location;
         [self setString:[NSString stringWithFormat:@"%@![](data:image/jpeg;base64,%@)%@", [[self string] substringToIndex:insertionPoint], dataString, [[self string] substringFromIndex:insertionPoint]]];
         [self didChangeText];
-    }
+    } else return [super performDragOperation:sender];
     return YES;
 }
 


### PR DESCRIPTION
The original author changed the default behavior of drag & drop to allow inlining JPEG images as *data:image* blocks when they are dragged into the text editor.

Unfortunately, the implementation as it was overwrote the default drag behavior completely, bit this is easily fixed with a message to _super_.

While testing this, I noticed that the code has some other quirks. It inlines all file types, not just JPEGs, and the inlining isn't undo-able; I made some comments so that someone may pick this up at some point.