### PR TITLE
Add continue-on-error for fork PR security limitations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,6 +239,7 @@ jobs:
 
     - name: Post coverage comment
       if: github.event_name == 'pull_request' && always()
+      continue-on-error: true  # Fork PRs may have limited GITHUB_TOKEN permissions
       uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -309,9 +310,10 @@ jobs:
 
     - name: Upload test results
       if: failure()
+      continue-on-error: true  # May fail on fork PRs or artifact name conflicts
       uses: actions/upload-artifact@v4
       with:
-        name: test-results
+        name: test-results-${{ matrix.os }}
         path: |
           ~/Library/Logs/DiagnosticReports/
           DerivedData/Logs/Test/


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to "Post coverage comment" step to handle fork PRs with limited `GITHUB_TOKEN` permissions
- Add `continue-on-error: true` to "Upload test results" step to handle fork PRs and artifact conflicts
- Fix artifact name collision by adding `${{ matrix.os }}` suffix to test results artifact name

## Context
GitHub Actions run #20617879418 failed with "Resource not accessible by integration" errors because PRs from forks have restricted token permissions. This prevents the coverage comment and artifact upload steps from working, but these failures shouldn't break the entire CI run since the actual tests passed.

## Test plan
- [x] Fork PR workflows will now complete successfully even if coverage comment step fails
- [x] Artifact names are now unique per matrix job, preventing "Conflict: an artifact with this name already exists" errors