### PR TITLE
Fix persistence of Substitutions and Spelling settings

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -56,7 +56,8 @@ NS_INLINE NSDictionary *MPEditorKeysToObserve()
                  @"automaticTextReplacementEnabled": @NO,
                  @"continuousSpellCheckingEnabled": @NO,
                  @"enabledTextCheckingTypes": @(NSTextCheckingAllTypes),
-                 @"grammarCheckingEnabled": @NO};
+                 @"grammarCheckingEnabled": @NO,
+                 @"smartInsertDeleteEnabled": @NO};
     });
     return keys;
 }

--- a/MacDown/Localization/Base.lproj/MPDocument.xib
+++ b/MacDown/Localization/Base.lproj/MPDocument.xib
@@ -48,7 +48,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="509" height="578"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="bar" allowsDocumentBackgroundColorChange="YES" allowsUndo="YES" dashSubstitution="YES" smartInsertDelete="YES" id="VLv-r5-dZU" customClass="MPEditorView">
+                                                <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="bar" allowsDocumentBackgroundColorChange="YES" allowsUndo="YES" id="VLv-r5-dZU" customClass="MPEditorView">
                                                     <rect key="frame" x="0.0" y="0.0" width="509" height="578"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <touchBar key="touchBar" id="uyf-zu-EdK">


### PR DESCRIPTION
## Summary

Fixes persistence bugs for Edit → Substitutions and Edit → Spelling and Grammar settings that were preventing them from being saved across application launches.

**Changes:**
- Removed hardcoded XIB defaults (`dashSubstitution="YES" smartInsertDelete="YES"`) that were overriding NSUserDefaults values
- Added missing `smartInsertDeleteEnabled` key to `MPEditorKeysToObserve()` so Smart Copy/Paste is now saved/restored like other settings

**Behavior change:** All substitution and spelling/grammar settings now default to OFF on fresh install (previously Smart Dashes and Smart Copy/Paste defaulted to ON from XIB).

## Related Issue

Related to #250

## Manual Testing Plan

### Prerequisites
- Clean build with fixes applied
- macOS 10.14+ system

### Key Test Scenarios

1. **Verify Default State** - All 8 settings should be OFF on fresh install (after `defaults delete com.macdown.MacDown`)

2. **Smart Copy/Paste Persistence** - Enable via Edit → Substitutions → Smart Copy/Paste, quit, relaunch - setting should remain checked

3. **Smart Dashes Persistence** - Enable via Edit → Substitutions → Smart Dashes, type `--`, quit, relaunch - setting should persist and dashes should still convert

4. **Toggle OFF Persistence** - Enable a setting, quit/relaunch, disable it, quit/relaunch - should remain OFF

5. **Multi-Document** - Settings apply globally to all documents (not per-document)

### Settings to Test
- Smart Copy/Paste, Smart Quotes, Smart Dashes, Data Detectors, Text Replacement
- Check Spelling While Typing, Check Grammar With Spelling, Correct Spelling Automatically

## Review Notes

- **Groucho (Architect):** Confirmed the fix approach - removing XIB overrides and adding the missing key follows the existing pattern
- **Chico (Code Review):** Approved - implementation is correct, complete, and follows project conventions
- **Harpo (Documentation):** No documentation updates needed
- **Zeppo (Testing):** Provided comprehensive manual testing plan