### PR TITLE
Fix tab characters causing unexpected line breaks near line end

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1646,8 +1646,28 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     {
         NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
         style.lineSpacing = self.preferences.editorLineSpacing;
-        self.editor.defaultParagraphStyle = [style copy];
+
+        // Configure tab stops to match 4-space tab width (fixes #195)
         NSFont *font = [self.preferences.editorBaseFont copy];
+        if (font)
+        {
+            NSDictionary *attrs = @{NSFontAttributeName: font};
+            CGFloat spaceWidth = [@" " sizeWithAttributes:attrs].width;
+            CGFloat tabInterval = spaceWidth * 4;
+
+            NSMutableArray *tabStops = [NSMutableArray array];
+            for (NSInteger i = 1; i <= 100; i++)
+            {
+                NSTextTab *tab = [[NSTextTab alloc]
+                    initWithTextAlignment:NSTextAlignmentLeft
+                                 location:tabInterval * i
+                                  options:@{}];
+                [tabStops addObject:tab];
+            }
+            style.tabStops = tabStops;
+        }
+
+        self.editor.defaultParagraphStyle = [style copy];
         if (font)
             self.editor.font = font;
         self.editor.textColor = nil;


### PR DESCRIPTION
## Summary

Configure explicit tab stops in `NSParagraphStyle` to fix unexpected line breaks when tab characters are added near the editor's line boundary.

**Root Cause:** The editor used vanilla `NSTextView` without explicit tab stop configuration. `NSLayoutManager` calculates tab width based on default tab stop positions (not remaining visual space), causing premature line wrapping when a tab was added near the end of a line.

**Fix:** Set tab stops at regular intervals based on the editor font's space width × 4, matching the existing 4-space tab convention used throughout the codebase.

## Related Issue

Related to #195

## Changes

- **MacDown/Code/Document/MPDocument.m**: Added tab stop configuration in `setupEditor:` method
  - Calculates tab interval based on the editor font's space character width × 4
  - Creates 100 tab stops at regular intervals (sufficient for wide documents)
  - Automatically recalculates when font changes

## Manual Testing Plan

### Setup
1. Build and launch MacDown 3000
2. Create a new document

### Primary Test Scenario
1. Type a line that approaches (but doesn't exceed) the editor width
2. Press Tab at the end of the line
3. **Expected:** Tab renders on the same line without forcing a line break

### Additional Test Scenarios
- **Font size changes:** Verify tabs recalculate when changing font size in Preferences
- **Font family changes:** Verify tabs work with different monospace fonts (Menlo, Courier, Monaco)
- **Window resizing:** Verify consistent tab behavior when resizing editor pane
- **Multiple tabs:** Verify multiple consecutive tabs accumulate width correctly
- **Tab-based indentation:** Verify indented lines work correctly

### Edge Cases
- Very large/small font sizes (8pt to 48pt)
- Documents with many tabs (100+)
- Preference changes while document is open
- Document load/reload

### Verification Checklist
- [ ] Tab characters no longer cause unexpected line breaks
- [ ] Tab width is visually consistent with 4-space indentation
- [ ] Tab stops recalculate when font changes
- [ ] No crashes or errors
- [ ] No regressions in existing tab functionality

## Review Notes

- **Groucho (Architect):** Recommended minimal change in `setupEditor:` method
- **Chico (Code Review):** Approved - no critical issues found
- **Harpo (Documentation):** No documentation updates needed
- **Zeppo (Testing):** Provided manual testing plan above