### PR TITLE
Disable text substitutions by default for all users

### DIFF
--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -451,6 +451,26 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
         self.htmlTemplateName = @"Default";
     if (![defaults objectForKey:@"extensionStrikethough"])
         self.extensionStrikethough = YES;
+
+    // One-time fix for users who migrated with incorrect substitution defaults.
+    // Text substitutions (smart dashes, smart quotes, etc.) break Markdown syntax
+    // and should be OFF by default. This resets them for all users, then marks
+    // the fix as applied so future explicit user choices are preserved.
+    // Related to GitHub issue #263.
+    static NSString * const kMPDidApplySubstitutionDefaultsFix =
+        @"MPDidApplySubstitutionDefaultsFix";
+    if (![defaults boolForKey:kMPDidApplySubstitutionDefaultsFix])
+    {
+        [defaults setBool:NO forKey:@"editorAutomaticDashSubstitutionEnabled"];
+        [defaults setBool:NO forKey:@"editorAutomaticQuoteSubstitutionEnabled"];
+        [defaults setBool:NO forKey:@"editorAutomaticTextReplacementEnabled"];
+        [defaults setBool:NO forKey:@"editorAutomaticSpellingCorrectionEnabled"];
+        [defaults setBool:NO forKey:@"editorSmartInsertDeleteEnabled"];
+        [defaults setBool:NO forKey:@"editorAutomaticDataDetectionEnabled"];
+        [defaults setBool:NO forKey:@"editorContinuousSpellCheckingEnabled"];
+        [defaults setBool:NO forKey:@"editorGrammarCheckingEnabled"];
+        [defaults setBool:YES forKey:kMPDidApplySubstitutionDefaultsFix];
+    }
 }
 
 @end


### PR DESCRIPTION
## Summary

This PR adds a one-time migration fix that resets all text substitution settings to OFF for all users. This addresses issue #263 where smart dashes (and other text substitutions) break Markdown syntax.

**Changes:**
- Added code to `loadDefaultUserDefaults` in `MPPreferences.m` that:
  - Checks for the `MPDidApplySubstitutionDefaultsFix` flag
  - If not set, resets all 8 text substitution settings to OFF
  - Sets the flag to prevent future overrides

**Settings disabled:**
- Smart Dashes (breaks `---` horizontal rules and table syntax)
- Smart Quotes (breaks inline code and YAML)
- Text Replacement, Spelling Correction, Smart Insert/Delete
- Data Detectors, Spell Checking, Grammar Checking

**Behavior:**
- New users: All substitutions OFF by default
- Migrated users with broken defaults: Get fixed
- Users who explicitly enable after fix: Their choice preserved

## Related Issue

Related to #263

## Manual Testing Plan

### Scenario 1: Fresh Installation
1. Remove all MacDown preferences: `defaults delete app.macdown.macdown3000`
2. Launch MacDown 3000
3. Check Edit > Substitutions - all options should be unchecked

### Scenario 2: Migrated User with Bad Defaults
1. Set bad defaults: `defaults write app.macdown.macdown3000 editorAutomaticDashSubstitutionEnabled -bool YES`
2. Remove fix flag: `defaults delete app.macdown.macdown3000 MPDidApplySubstitutionDefaultsFix`
3. Launch MacDown 3000
4. Check Edit > Substitutions - all options should now be unchecked

### Scenario 3: User Choices Preserved
1. Complete Scenario 1
2. Enable Smart Quotes via Edit > Substitutions
3. Quit and relaunch MacDown
4. Smart Quotes should remain enabled

### Scenario 4: Functional Verification
1. Type `---` - should remain as dashes (not convert to em-dash)
2. Type `| Col1 | Col2 |` then `|---|---|` - table syntax should work
3. Type `"text"` - should remain straight quotes

## Review Notes

- Code review passed (follows existing project conventions)
- No documentation updates needed
- CI tests pass on all macOS versions (14, 15, 26, 15-intel)