### PR TITLE
Add GitHub Tomorrow dark preview theme

### DIFF
--- a/MacDown/Resources/Styles/GitHub Tomorrow.css
+++ b/MacDown/Resources/Styles/GitHub Tomorrow.css
@@ -30,7 +30,7 @@ em {
 
 strong {
     color: #f99157;
-    font-style: bold;
+    font-weight: bold;
 }
 
 em strong,
@@ -222,9 +222,9 @@ dl dd > :last-child {
 }
 
 blockquote {
-    border-left: 4px solid #cc99cc;
+    border-left: 4px solid #f2777a;
     padding: 0 15px;
-    color: #cc99cc;
+    color: #f2777a;
 }
 
 blockquote > :first-child {
@@ -373,7 +373,6 @@ code, tt {
     font-size: 85%;
     border-radius: 6px;
     white-space: nowrap;
-    border-radius: 6px;
 }
 
 a code,


### PR DESCRIPTION
## Summary

Add a new preview-pane stylesheet called "GitHub Tomorrow" that combines GitHub formatting structure with the Tomorrow color scheme, providing a dark-mode preview theme that pairs well with the Tomorrow editor theme.

Key features:
- Dark background (#464646) lighter than editor (#2d2d2d) for visual contrast
- Tomorrow color palette: cyan headings (#66cccc), green links (#99cc99), orange bold (#f99157), yellow italic (#ffcc66), pink blockquotes (#f2777a)
- Full GitHub formatting: tables, code blocks, blockquotes, lists, images
- Responsive design with print support
- Auto-discovered by the theme system - no code changes required

Based on PR #1289 from MacDownApp/macdown by @elsiehupp

## Related Issue

Related to #106

## Manual Testing Plan

### Setup
1. Open MacDown 3000
2. Go to Preferences → Rendering → CSS → select "GitHub Tomorrow"

### Key Test Scenarios
- **Background/Text**: Dark gray (#464646) background, light gray (#cccccc) text
- **Headings**: All H1-H6 in cyan (#66cccc), H1/H2 have underlines
- **Emphasis**: Bold in orange (#f99157), italic in yellow (#ffcc66)
- **Links**: Green (#99cc99)
- **Blockquotes**: Pink (#f2777a) text and left border
- **Code**: Gray (#999999) on darker background (#2D2D2D)
- **Tables**: Alternating row backgrounds (#2d2d2d / #1c1c1c)
- **Lists**: Blue markers (#6699cc)

### Edge Cases
- Text selection (white on dark)
- Responsive width behavior (centered at 854px for screens ≥914px)
- Print preview (colors preserved)
- Theme switching (no artifacts)

## Review Notes

- **Groucho (Architect)**: Confirmed CSS-only addition, auto-discovered by theme system
- **Chico (Code Review)**: Fixed 4 issues - CSS syntax error, blockquote color, duplicate property, file permissions
- **Harpo (Documentation)**: No documentation updates needed
- **Zeppo (Testing)**: Provided comprehensive manual testing plan