### PR TITLE
Replace M13OrderedDictionary with native NSMutableDictionary

### DIFF
--- a/Dependency/YAML-framework/YAMLSerialization.m
+++ b/Dependency/YAML-framework/YAMLSerialization.m
@@ -8,7 +8,6 @@
 //
 
 #import "YAMLSerialization.h"
-#import <M13OrderedDictionary/M13OrderedDictionary.h>
 
 NSString *const YAMLErrorDomain = @"com.github.mirek.yaml";
 
@@ -47,11 +46,11 @@ __YAMLSerializationObjectWithYAMLDocument (yaml_document_t *document, YAMLReadOp
 
     // Mutability options
     Class arrayClass = [NSMutableArray class]; // TODO: FIXME:
-    Class dictionaryClass = [M13MutableOrderedDictionary class]; // TODO: FIXME:
+    Class dictionaryClass = [NSMutableDictionary class];
     Class stringClass = [NSString class];
     if (opt & kYAMLReadOptionMutableContainers) {
         arrayClass = [NSMutableArray class];
-        dictionaryClass = [M13MutableOrderedDictionary class];
+        dictionaryClass = [NSMutableDictionary class];
         if (opt & kYAMLReadOptionMutableContainersAndLeaves) {
             stringClass = [NSMutableString class];
         }

--- a/MacDown/Code/Extension/NSObject+HTMLTabularize.m
+++ b/MacDown/Code/Extension/NSObject+HTMLTabularize.m
@@ -8,7 +8,6 @@
 
 #import "NSObject+HTMLTabularize.h"
 #import <HBHandlebars/HBHandlebars.h>
-#import <M13OrderedDictionary/M13OrderedDictionary.h>
 
 
 @implementation NSObject (HTMLTabularize)
@@ -86,32 +85,6 @@
     for (id key in keys)
         [objects addObject:self[key]];
     NSDictionary *context = @{@"keys": keys, @"objects": objects};
-    return [HBHandlebars renderTemplateString:template withContext:context
-                             withHelperBlocks:helpers error:NULL];
-}
-
-@end
-
-
-@implementation M13OrderedDictionary (HTMLTabularize)
-
-- (NSString *)HTMLTable
-{
-    static NSString *template =
-        @"<table><thead><tr>"
-        @"{{#each keys}}<th>{{{HTMLTable this}}}</th>{{/each}}"
-        @"</tr></thead><tbody><tr>"
-        @"{{#each objects}}<td>{{{HTMLTable this}}}</td>{{/each}}"
-        @"</tr></tbody></table>";
-    static NSDictionary *helpers = nil;
-    static dispatch_once_t token;
-    dispatch_once(&token, ^{
-        helpers = @{@"HTMLTable": ^NSString *(HBHelperCallingInfo *info) {
-            return [info.positionalParameters[0] HTMLTable];
-        }};
-    });
-    NSDictionary *context = @{@"keys": self.allKeys,
-                              @"objects": self.allObjects};
     return [HBHandlebars renderTemplateString:template withContext:context
                              withHelperBlocks:helpers error:NULL];
 }

--- a/MacDown/Localization/ar.lproj/Credits.rtf
+++ b/MacDown/Localization/ar.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/de.lproj/Credits.rtf
+++ b/MacDown/Localization/de.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/en.lproj/Credits.rtf
+++ b/MacDown/Localization/en.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/es.lproj/Credits.rtf
+++ b/MacDown/Localization/es.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/fr.lproj/Credits.rtf
+++ b/MacDown/Localization/fr.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/is.lproj/Credits.rtf
+++ b/MacDown/Localization/is.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/it-IT.lproj/Credits.rtf
+++ b/MacDown/Localization/it-IT.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/ja.lproj/Credits.rtf
+++ b/MacDown/Localization/ja.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/ko-KR.lproj/Credits.rtf
+++ b/MacDown/Localization/ko-KR.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/pt-BR.lproj/Credits.rtf
+++ b/MacDown/Localization/pt-BR.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/sk.lproj/Credits.rtf
+++ b/MacDown/Localization/sk.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/sv.lproj/Credits.rtf
+++ b/MacDown/Localization/sv.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/zh-Hans.lproj/Credits.rtf
+++ b/MacDown/Localization/zh-Hans.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/MacDown/Localization/zh-Hant.lproj/Credits.rtf
+++ b/MacDown/Localization/zh-Hant.lproj/Credits.rtf
@@ -195,18 +195,6 @@ The above copyright notice and this permission notice shall be included in all c
 \
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
 \
-\pard\pardeftab720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/Marxon13/M13OrderedDictionary"}}{\fldrslt 
-\b\fs28 \cf0 M13OrderedDictionary}}\
-Copyright \'a9 2013 Brandon McQuilkin\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "https://github.com/junjie/JJPluralForm"}}{\fldrslt 
 \b\fs28 \cf0 JJPluralForm}}

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,6 @@ target "MacDown" do
   pod 'hoedown', '~> 3.0.7', :inhibit_warnings => false
   pod 'JJPluralForm', '~> 2.1'
   pod 'LibYAML', '~> 0.1'
-  pod 'M13OrderedDictionary', '~> 1.1'
   pod 'MASPreferences', '~> 1.4'
   # Temporarily disabled - will upgrade to 2.8.1 later
   # pod 'Sparkle', '~> 1.18', :inhibit_warnings => false

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,6 @@ PODS:
   - hoedown/standard (3.0.7)
   - JJPluralForm (2.1)
   - LibYAML (0.1.4)
-  - M13OrderedDictionary (1.1.0)
   - MASPreferences (1.4.1)
   - PAPreferences (0.5)
 
@@ -16,7 +15,6 @@ DEPENDENCIES:
   - hoedown (~> 3.0.7)
   - JJPluralForm (~> 2.1)
   - LibYAML (~> 0.1)
-  - M13OrderedDictionary (~> 1.1)
   - MASPreferences (~> 1.4)
   - PAPreferences (~> 0.5)
 
@@ -28,7 +26,6 @@ SPEC REPOS:
   trunk:
     - GBCli
     - JJPluralForm
-    - M13OrderedDictionary
     - MASPreferences
     - PAPreferences
 
@@ -38,10 +35,9 @@ SPEC CHECKSUMS:
   hoedown: 8141833441f6430686c06bbc5159d7ce615155fb
   JJPluralForm: 9a6235813990a33a63fb3eff457eb2c633af6acd
   LibYAML: dee5c31dcab47b168425083c2b0a6baeacdf499e
-  M13OrderedDictionary: 6e157fe9c82aa6b3cd7198f5c5c30c7a6834c4a6
   MASPreferences: 1ba2deb14086792857af44d22846fc4aae477fd9
   PAPreferences: 9f0ffb1e67174a0df001af9d3320166ceb9ee6f5
 
-PODFILE CHECKSUM: 9feb752b3e32e9399d9f753e2da9ba974d1f877d
+PODFILE CHECKSUM: b7a03464c7d3517d67f2e665587ff0a5531bf2b1
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Summary

- Remove M13OrderedDictionary third-party dependency
- Replace with native NSMutableDictionary in YAML parsing code
- Remove M13OrderedDictionary category from HTMLTabularize extension
- Remove library attribution from Credits.rtf (14 localizations)

macOS 10.13+ preserves dictionary insertion order natively, making this dependency unnecessary. Deployment target is 11.0.

## Related Issue

Related to #187

## Changes

| File | Change |
|------|--------|
| `YAMLSerialization.m` | Use NSMutableDictionary instead of M13MutableOrderedDictionary |
| `NSObject+HTMLTabularize.m` | Remove M13OrderedDictionary category (NSDictionary category handles it) |
| `Podfile` | Remove M13OrderedDictionary dependency |
| `Credits.rtf` (14 files) | Remove license attribution |

## Test Results

All 418 tests pass locally.

## Review Notes

- Groucho: Confirmed only 2 source files needed changes
- Chico: Ready to merge (minor cosmetic suggestions noted)
- Harpo: No documentation updates needed