### PR TITLE
Fix Graphviz and Mermaid button positioning in Compilation Settings

### DIFF
--- a/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
@@ -114,7 +114,7 @@
                         <binding destination="-2" name="enabled" keyPath="self.preferences.htmlSyntaxHighlighting" id="zSJ-H9-kjZ"/>
                     </connections>
                 </button>
-                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qe1-sK-Yxe">
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="Qe1-sK-Yxe">
                     <rect key="frame" x="247" y="221" width="69" height="18"/>
                     <buttonCell key="cell" type="check" title="Graphviz" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="Lnj-HG-QHi">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -125,7 +125,7 @@
                         <binding destination="-2" name="value" keyPath="self.preferences.htmlGraphviz" id="28T-6A-JOn"/>
                     </connections>
                 </button>
-                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bWg-uC-6W8">
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="bWg-uC-6W8">
                     <rect key="frame" x="318" y="221" width="68" height="18"/>
                     <buttonCell key="cell" type="check" title="Mermaid" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="bda-Ft-ecb">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -246,7 +246,14 @@
             <constraints>
                 <constraint firstItem="lxX-Pm-dhn" firstAttribute="leading" secondItem="RCL-iK-kgx" secondAttribute="leading" id="0LF-WD-jr9"/>
                 <constraint firstItem="RCL-iK-kgx" firstAttribute="trailing" secondItem="5mI-gS-xH9" secondAttribute="trailing" id="2Au-ZO-sN1"/>
-                <constraint firstItem="ysT-Br-eSf" firstAttribute="trailing" secondItem="Zna-RM-nBO" secondAttribute="trailing" id="2Dv-QD-tU1"/>
+                <!-- Graphviz button vertical alignment with "Show line numbers" -->
+                <constraint firstItem="Qe1-sK-Yxe" firstAttribute="centerY" secondItem="ysT-Br-eSf" secondAttribute="centerY" id="gvz-CY-aln"/>
+                <!-- Graphviz button positioned after "Show line numbers" -->
+                <constraint firstItem="Qe1-sK-Yxe" firstAttribute="leading" secondItem="ysT-Br-eSf" secondAttribute="trailing" constant="8" id="gvz-LD-pos"/>
+                <!-- Mermaid button vertical alignment with "Show line numbers" -->
+                <constraint firstItem="bWg-uC-6W8" firstAttribute="centerY" secondItem="ysT-Br-eSf" secondAttribute="centerY" id="mmd-CY-aln"/>
+                <!-- Mermaid button positioned after Graphviz -->
+                <constraint firstItem="bWg-uC-6W8" firstAttribute="leading" secondItem="Qe1-sK-Yxe" secondAttribute="trailing" constant="8" id="mmd-LD-pos"/>
                 <constraint firstItem="vVI-g8-EhH" firstAttribute="trailing" secondItem="Dd4-T9-cLi" secondAttribute="trailing" id="3CP-t8-TSZ"/>
                 <constraint firstItem="vVI-g8-EhH" firstAttribute="leading" secondItem="Zna-RM-nBO" secondAttribute="leading" id="3e9-8I-C7O"/>
                 <constraint firstItem="5mI-gS-xH9" firstAttribute="top" secondItem="ysT-Br-eSf" secondAttribute="bottom" constant="11" id="4eS-8i-EmI"/>


### PR DESCRIPTION
## Summary

- Fixed Graphviz and Mermaid checkbox buttons in the Compilation Settings (HTML Preferences) window to properly reflow when the window is resized
- Removed `fixedFrame="YES"` from both buttons which was locking them to fixed positions
- Added proper auto-layout constraints to position buttons relative to "Show line numbers" checkbox

## Related Issue

Related to #277

## Manual Testing Plan

### Setup Steps
1. Build the MacDown project in Xcode
2. Launch the built MacDown application
3. Open **MacDown → Preferences** (or **MacDown → Settings** depending on macOS version)
4. Navigate to the **Markdown** tab
5. Click the **Compilation Settings** button to open the HTML Preferences window

### Test Scenarios

**1. Normal State Verification**
- Verify the "Show line numbers" checkbox is visible
- Verify the Graphviz checkbox appears immediately to the right of "Show line numbers" (with ~8pt spacing)
- Verify the Mermaid checkbox appears immediately to the right of Graphviz (with ~8pt spacing)
- Verify all three buttons are vertically centered on the same line

**2. Window Resize Behavior**
- Resize the Compilation Settings window to smaller widths
- Verify the buttons maintain their relative positions and spacing
- Verify the buttons reflow smoothly without jumping or snapping
- Resize the window to larger widths
- Verify the buttons expand/shift appropriately with the window

**3. Button Functionality**
- Click each checkbox - verify it toggles and the layout remains correct
- Verify the buttons respond to enabled/disabled binding (disabled when "Syntax highlighted code block" is unchecked)

### Edge Cases
- **Minimum Window Size** - Verify buttons remain visible and properly positioned
- **Maximum Window Size** - Verify buttons don't have excessive gaps
- **Dynamic Enable/Disable** - Uncheck "Syntax highlighted code block"; verify all three buttons become disabled and layout doesn't break

## Review Notes

- **Groucho (Architecture)**: Identified root cause as fixedFrame attribute and recommended constraint-based positioning
- **Chico (Code Review)**: Approved - no critical issues, constraints are complete and follow macOS/Cocoa conventions
- **Harpo (Documentation)**: No documentation updates needed
- **Zeppo (Testing)**: Provided manual testing plan above