### PR TITLE
Fix new document windows opening at bottom-left

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -406,6 +406,8 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         rectString = MPRectStringForAutosaveName(kMPDefaultAutosaveName);
     if (rectString)
         [controller.window setFrameFromString:rectString];
+    else
+        [controller.window center];  // No saved position;
 
     self.highlighter =
         [[HGMarkdownHighlighter alloc] initWithTextView:self.editor
@@ -1234,6 +1236,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     self.currentHighlightingThemeName = newHighlightingTheme;
 }
 
+#pragma mark - Window Controller
+
+- (void)makeWindowControllers
+{
+    [super makeWindowControllers];
+}
 
 #pragma mark - Notification handler
 
@@ -2646,3 +2654,4 @@ current file somewhere to enable this feature.", \
 }
 
 @end
+


### PR DESCRIPTION
## Summary                                                                                                                                               
  - Fix new document windows opening at bottom-left screen position when no saved window position exists                                                         
  - Center the window as a fallback only when frame restoration fails, preserving saved positions for all other cases                                      
                                                                                                                                                           
  ## Solution                                                                                                                                              
  Added a fallback in `windowControllerDidLoadNib:` to center the window when no saved frame position is found. This preserves the existing behavior for:  
  - Saved documents (restore position from file URL autosave)                                                                                              
  - New documents with a saved default (restore from "Untitled" autosave)                                                                                  
                                                                                                                                                           
  Only windows with no saved position at all get centered.                                                                                                 
                                                                                                                                                           
  ## Test plan                                                                                                                                             
  - [ ] Open an existing document → restores to last saved position                                                                                        
  - [ ] Create new document, move window, close, create another → restores default position                                                                
  - [ ] Clear saved default with `defaults delete app.macdown.macdown3000 "NSWindow Frame Untitled"`, create new document → centers on screen              
  - [ ] Test on multiple monitors             