### PR TITLE
Add automatic file reload when externally modified

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2920,13 +2920,11 @@ current file somewhere to enable this feature.", \
         @"File Modified Externally",
         @"External file change alert title");
     alert.informativeText = NSLocalizedString(
-        @"The file has been modified by another application. "
-        @"Do you want to reload it and lose your unsaved changes, "
-        @"or keep your version?",
+        @"This file has been changed by another application. Do you want to discard your changes?",
         @"External file change alert message");
 
-    [alert addButtonWithTitle:NSLocalizedString(@"Reload", @"Reload button")];
-    [alert addButtonWithTitle:NSLocalizedString(@"Keep Mine", @"Keep local version button")];
+    [alert addButtonWithTitle:NSLocalizedString(@"Discard", @"Discard changes button")];
+    [alert addButtonWithTitle:NSLocalizedString(@"Keep", @"Keep local changes button")];
 
     NSWindow *window = self.windowForSheet;
     if (window)
@@ -2936,7 +2934,7 @@ current file somewhere to enable this feature.", \
             {
                 [self reloadFromDisk];
             }
-            // If "Keep Mine" - do nothing, user keeps their changes
+            // If "Keep" - do nothing, user keeps their changes
         }];
     }
     else

--- a/MacDown/Localization/ar.lproj/Localizable.strings
+++ b/MacDown/Localization/ar.lproj/Localizable.strings
@@ -1,0 +1,5 @@
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "تم تعديل الملف خارجياً";
+"This file has been changed by another application. Do you want to discard your changes?" = "تم تعديل هذا الملف بواسطة تطبيق آخر. هل تريد تجاهل تغييراتك؟";
+"Discard" = "تجاهل";
+"Keep" = "احتفظ";

--- a/MacDown/Localization/cs.lproj/Localizable.strings
+++ b/MacDown/Localization/cs.lproj/Localizable.strings
@@ -140,3 +140,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ slovo;%@ slov";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Soubor byl externě změněn";
+"This file has been changed by another application. Do you want to discard your changes?" = "Tento soubor byl změněn jinou aplikací. Chcete zahodit své změny?";
+"Discard" = "Zahodit";
+"Keep" = "Ponechat";

--- a/MacDown/Localization/da-DK.lproj/Localizable.strings
+++ b/MacDown/Localization/da-DK.lproj/Localizable.strings
@@ -140,3 +140,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ ord;%@ ord";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Filen er ændret eksternt";
+"This file has been changed by another application. Do you want to discard your changes?" = "Denne fil er blevet ændret af et andet program. Vil du kassere dine ændringer?";
+"Discard" = "Kassér";
+"Keep" = "Behold";

--- a/MacDown/Localization/de.lproj/Localizable.strings
+++ b/MacDown/Localization/de.lproj/Localizable.strings
@@ -140,3 +140,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ Wort;%@ Wörter";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Datei extern geändert";
+"This file has been changed by another application. Do you want to discard your changes?" = "Diese Datei wurde von einer anderen Anwendung geändert. Möchten Sie Ihre Änderungen verwerfen?";
+"Discard" = "Verwerfen";
+"Keep" = "Behalten";

--- a/MacDown/Localization/en.lproj/Localizable.strings
+++ b/MacDown/Localization/en.lproj/Localizable.strings
@@ -33,6 +33,6 @@
 
 /* External file change detection (Issue #290) */
 "File Modified Externally" = "File Modified Externally";
-"The file has been modified by another application. Do you want to reload it and lose your unsaved changes, or keep your version?" = "The file has been modified by another application. Do you want to reload it and lose your unsaved changes, or keep your version?";
-"Reload" = "Reload";
-"Keep Mine" = "Keep Mine";
+"This file has been changed by another application. Do you want to discard your changes?" = "This file has been changed by another application. Do you want to discard your changes?";
+"Discard" = "Discard";
+"Keep" = "Keep";

--- a/MacDown/Localization/es.lproj/Localizable.strings
+++ b/MacDown/Localization/es.lproj/Localizable.strings
@@ -140,3 +140,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ palabra;%@ palabras";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Archivo modificado externamente";
+"This file has been changed by another application. Do you want to discard your changes?" = "Este archivo ha sido modificado por otra aplicación. ¿Desea descartar sus cambios?";
+"Discard" = "Descartar";
+"Keep" = "Conservar";

--- a/MacDown/Localization/et.lproj/Localizable.strings
+++ b/MacDown/Localization/et.lproj/Localizable.strings
@@ -110,3 +110,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ sõna;%@ sõna";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Fail on väliselt muudetud";
+"This file has been changed by another application. Do you want to discard your changes?" = "Seda faili on muudetud teise rakenduse poolt. Kas soovite oma muudatused tühistada?";
+"Discard" = "Tühista";
+"Keep" = "Säilita";

--- a/MacDown/Localization/fr.lproj/Localizable.strings
+++ b/MacDown/Localization/fr.lproj/Localizable.strings
@@ -140,3 +140,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ mot;%@ mots";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Fichier modifié extérieurement";
+"This file has been changed by another application. Do you want to discard your changes?" = "Ce fichier a été modifié par une autre application. Voulez-vous abandonner vos modifications ?";
+"Discard" = "Abandonner";
+"Keep" = "Conserver";

--- a/MacDown/Localization/is.lproj/Localizable.strings
+++ b/MacDown/Localization/is.lproj/Localizable.strings
@@ -62,3 +62,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ orð;%@ orð";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Skrá breytt utan frá";
+"This file has been changed by another application. Do you want to discard your changes?" = "Þessi skrá hefur verið breytt af öðru forriti. Viltu henda breytingunum þínum?";
+"Discard" = "Henda";
+"Keep" = "Halda";

--- a/MacDown/Localization/it-IT.lproj/Localizable.strings
+++ b/MacDown/Localization/it-IT.lproj/Localizable.strings
@@ -110,3 +110,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ parola;%@ parole";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "File modificato esternamente";
+"This file has been changed by another application. Do you want to discard your changes?" = "Questo file è stato modificato da un'altra applicazione. Vuoi scartare le tue modifiche?";
+"Discard" = "Scarta";
+"Keep" = "Mantieni";

--- a/MacDown/Localization/ja.lproj/Localizable.strings
+++ b/MacDown/Localization/ja.lproj/Localizable.strings
@@ -140,3 +140,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ word;%@ words";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "ファイルが外部で変更されました";
+"This file has been changed by another application. Do you want to discard your changes?" = "このファイルは他のアプリケーションで変更されました。変更を破棄しますか？";
+"Discard" = "破棄";
+"Keep" = "保持";

--- a/MacDown/Localization/ko-KR.lproj/Localizable.strings
+++ b/MacDown/Localization/ko-KR.lproj/Localizable.strings
@@ -80,3 +80,8 @@
 /* default filename if no title can be determined */
 "Untitled" = "제목없음";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "외부에서 파일이 수정됨";
+"This file has been changed by another application. Do you want to discard your changes?" = "이 파일이 다른 응용 프로그램에 의해 변경되었습니다. 변경 사항을 취소하시겠습니까?";
+"Discard" = "취소";
+"Keep" = "유지";

--- a/MacDown/Localization/nb-NO.lproj/Localizable.strings
+++ b/MacDown/Localization/nb-NO.lproj/Localizable.strings
@@ -140,3 +140,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ ord;%@ ord";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Filen er endret eksternt";
+"This file has been changed by another application. Do you want to discard your changes?" = "Denne filen har blitt endret av et annet program. Vil du forkaste endringene dine?";
+"Discard" = "Forkast";
+"Keep" = "Behold";

--- a/MacDown/Localization/nl-NL.lproj/Localizable.strings
+++ b/MacDown/Localization/nl-NL.lproj/Localizable.strings
@@ -140,3 +140,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ woord;%@ woorden";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Bestand extern gewijzigd";
+"This file has been changed by another application. Do you want to discard your changes?" = "Dit bestand is gewijzigd door een andere applicatie. Wilt u uw wijzigingen annuleren?";
+"Discard" = "Annuleren";
+"Keep" = "Behouden";

--- a/MacDown/Localization/pt-BR.lproj/Localizable.strings
+++ b/MacDown/Localization/pt-BR.lproj/Localizable.strings
@@ -140,3 +140,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ palavra;%@ palavras";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Arquivo modificado externamente";
+"This file has been changed by another application. Do you want to discard your changes?" = "Este arquivo foi modificado por outro aplicativo. Deseja descartar suas alterações?";
+"Discard" = "Descartar";
+"Keep" = "Manter";

--- a/MacDown/Localization/ru-RU.lproj/Localizable.strings
+++ b/MacDown/Localization/ru-RU.lproj/Localizable.strings
@@ -19,3 +19,8 @@
 /* Unordered list toolbar button */
 "Unordered List" = "Маркированный список";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Файл изменён извне";
+"This file has been changed by another application. Do you want to discard your changes?" = "Этот файл был изменён другим приложением. Хотите отменить свои изменения?";
+"Discard" = "Отменить";
+"Keep" = "Сохранить";

--- a/MacDown/Localization/sk.lproj/Localizable.strings
+++ b/MacDown/Localization/sk.lproj/Localizable.strings
@@ -89,3 +89,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ slovo;%@ slov";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Súbor bol externe zmenený";
+"This file has been changed by another application. Do you want to discard your changes?" = "Tento súbor bol zmenený inou aplikáciou. Chcete zahodiť svoje zmeny?";
+"Discard" = "Zahodiť";
+"Keep" = "Ponechať";

--- a/MacDown/Localization/sv.lproj/Localizable.strings
+++ b/MacDown/Localization/sv.lproj/Localizable.strings
@@ -37,3 +37,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ ord;%@ ord";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Filen har ändrats externt";
+"This file has been changed by another application. Do you want to discard your changes?" = "Den här filen har ändrats av ett annat program. Vill du förkasta dina ändringar?";
+"Discard" = "Förkasta";
+"Keep" = "Behåll";

--- a/MacDown/Localization/tr.lproj/Localizable.strings
+++ b/MacDown/Localization/tr.lproj/Localizable.strings
@@ -62,3 +62,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ kelime;%@ kelime";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "Dosya harici olarak değiştirildi";
+"This file has been changed by another application. Do you want to discard your changes?" = "Bu dosya başka bir uygulama tarafından değiştirildi. Değişikliklerinizi iptal etmek istiyor musunuz?";
+"Discard" = "İptal";
+"Keep" = "Sakla";

--- a/MacDown/Localization/zh-Hans.lproj/Localizable.strings
+++ b/MacDown/Localization/zh-Hans.lproj/Localizable.strings
@@ -140,3 +140,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ 个词;%@ 个词";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "文件已被外部修改";
+"This file has been changed by another application. Do you want to discard your changes?" = "此文件已被其他应用程序修改。是否放弃您的更改？";
+"Discard" = "放弃";
+"Keep" = "保留";

--- a/MacDown/Localization/zh-Hant.lproj/Localizable.strings
+++ b/MacDown/Localization/zh-Hant.lproj/Localizable.strings
@@ -137,3 +137,8 @@
 /* (No Comment) */
 "WORDS_PLURAL_STRING" = "%@ 個字;%@ 個字";
 
+/* External file change detection (Issue #290) */
+"File Modified Externally" = "檔案已被外部修改";
+"This file has been changed by another application. Do you want to discard your changes?" = "此檔案已被其他應用程式修改。是否放棄您的更改？";
+"Discard" = "放棄";
+"Keep" = "保留";


### PR DESCRIPTION
## Summary

Implements fswatch-style file monitoring to automatically detect and reload files when modified by external applications (e.g., Claude Code, vim, or other editors).

**Behavior:**
- **Clean document:** Automatically reloads silently
- **Dirty document:** Prompts user with "Reload" or "Keep Mine" options

**Implementation:**
- Uses GCD `dispatch_source` with `DISPATCH_VNODE_WRITE` events for efficient monitoring
- Handles file deletion/rename by stopping the watcher gracefully
- Uses `isSelfSaving` flag to prevent false triggers during our own saves
- Properly cleans up file watcher on document close

## Related Issue

Related to #290

## Files Changed

- `MacDown/Code/Document/MPDocument.m` - Core file watching implementation
- `MacDown/Localization/en.lproj/Localizable.strings` - Alert dialog strings

## Manual Testing Plan

### Quick Smoke Tests

1. **Clean document auto-reload:**
   - Open a file in MacDown (don't edit)
   - Modify the file in another editor and save
   - MacDown should reload silently

2. **Dirty document prompt:**
   - Open a file and make edits (don't save)
   - Modify the file in another editor and save
   - MacDown should show "File Modified Externally" alert
   - Test both "Reload" and "Keep Mine" buttons

3. **Self-save doesn't trigger:**
   - Open a file, make edits
   - Press Cmd+S to save
   - No reload prompt should appear

4. **Save As restarts watcher:**
   - Open a file
   - File > Save As to new location
   - Modify the new file externally
   - New file should be monitored

5. **Cleanup on close:**
   - Open multiple files
   - Close them one by one
   - No resource leaks or errors

## Review Notes

- Code review by Chico found and fixed critical bug in Save As URL detection
- Fixed fileModificationDate not being updated after reload
- Simplified cancel handler by capturing fd directly