### PR TITLE
Fix PDF/print margins: respect Page Setup, remove double margins

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -721,10 +721,6 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     info.horizontalPagination = NSAutoPagination;
     info.verticalPagination = NSAutoPagination;
     info.verticallyCentered = NO;
-    info.topMargin = 50.0;
-    info.leftMargin = 0.0;
-    info.rightMargin = 0.0;
-    info.bottomMargin = 50.0;
     return info;
 }
 

--- a/MacDown/Resources/Extensions/print.css
+++ b/MacDown/Resources/Extensions/print.css
@@ -65,8 +65,9 @@
         overflow-wrap: break-word !important;
     }
 
-    /* Body margins - consistent across all themes */
+    /* Body margins - zeroed out so NSPrintInfo (File > Page Setup) is the
+     * single source of truth for PDF/print margins. */
     body {
-        padding: 2cm;
+        padding: 0;
     }
 }

--- a/MacDown/Resources/Styles/Clearness Dark.css
+++ b/MacDown/Resources/Styles/Clearness Dark.css
@@ -154,6 +154,6 @@ kbd {
 		page-break-inside: avoid;
 	}
   body {
-    margin: 2cm; 
+    margin: 0;
   }
 }

--- a/MacDown/Resources/Styles/Clearness.css
+++ b/MacDown/Resources/Styles/Clearness.css
@@ -155,6 +155,6 @@ kbd {
 		page-break-inside: avoid;
 	}
   body {
-    margin: 2cm; 
+    margin: 0;
   }
 }

--- a/MacDown/Resources/Styles/GitHub Tomorrow.css
+++ b/MacDown/Resources/Styles/GitHub Tomorrow.css
@@ -463,6 +463,6 @@ kbd {
 		word-wrap: break-word;
 	}
     body {
-        padding: 2cm;
+        padding: 0;
     }
 }

--- a/MacDown/Resources/Styles/GitHub.css
+++ b/MacDown/Resources/Styles/GitHub.css
@@ -91,6 +91,6 @@ kbd {
 		word-wrap: break-word;
 	}
   body {
-    padding: 2cm; 
+    padding: 0;
   }
 }

--- a/MacDown/Resources/Styles/GitHub2.css
+++ b/MacDown/Resources/Styles/GitHub2.css
@@ -310,6 +310,6 @@ kbd {
 		word-wrap: break-word;
 	}
   body {
-    padding: 2cm; 
+    padding: 0;
   }
 }

--- a/MacDown/Resources/Styles/Solarized (Dark).css
+++ b/MacDown/Resources/Styles/Solarized (Dark).css
@@ -191,6 +191,6 @@ kbd {
 
 @media print {
   body {
-    margin: 2cm; 
+    margin: 0;
   }
 }

--- a/MacDown/Resources/Styles/Solarized (Light).css
+++ b/MacDown/Resources/Styles/Solarized (Light).css
@@ -191,6 +191,6 @@ kbd {
 
 @media print {
   body {
-    margin: 2cm; 
+    margin: 0;
   }
 }


### PR DESCRIPTION
## Summary

Port of [MacDownApp/macdown PR #1363](https://github.com/MacDownApp/macdown/pull/1363), adapted for MacDown 3000:

- **Removes hardcoded margins** from `printInfo` in `MPDocument.m` — the method was overwriting all four margins (top/bottom 50pt, left/right 0pt) every time, making the `File > Page Setup...` dialog non-functional for margin control
- **Zeros out `@media print` body padding/margin** in all 8 bundled CSS stylesheets (the original 6, plus `GitHub Tomorrow.css` and the centralized `print.css` which are MacDown 3000 additions)
- Users can now control PDF export and print margins via `File > Page Setup...` (Cmd+Shift+P), with NSPrintInfo as the single source of truth

## Changes beyond the original PR

The original PR touched 7 files (1 `.m` + 6 CSS). This port touches 9 files because MacDown 3000 has:
- `GitHub Tomorrow.css` — a new theme stylesheet with the same `padding: 2cm` issue
- `Extensions/print.css` — a centralized print stylesheet (from PR #1349 port) that also had `padding: 2cm`, which would compound with NSPrintInfo margins

`GitHub-2020.css` has no `@media print` block, so no changes needed there.

## Test plan

- [ ] Build the project
- [ ] Open a markdown file, use `File > Page Setup...` to set custom margins
- [ ] `File > Export > PDF...` — verify PDF reflects the configured margins
- [ ] `File > Print...` — verify print preview shows the configured margins
- [ ] Verify no double-margin compounding (margins should match Page Setup values)

Related to MacDownApp/macdown#1363