### PR TITLE
Add zoom keyboard shortcuts (Cmd+, Cmd-, Cmd+0)

### DIFF
--- a/MacDown/Code/Document/MPDocument.h
+++ b/MacDown/Code/Document/MPDocument.h
@@ -27,4 +27,8 @@
  */
 + (NSString *)toggleCheckboxAtIndex:(NSUInteger)index inMarkdown:(NSString *)markdown;
 
+- (IBAction)zoomIn:(id)sender;
+- (IBAction)zoomOut:(id)sender;
+- (IBAction)resetZoom:(id)sender;
+
 @end

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -37,6 +37,9 @@
 
 static NSString * const kMPDefaultAutosaveName = @"Untitled";
 
+static const CGFloat kMPMinZoom = 0.5;
+static const CGFloat kMPMaxZoom = 3.0;
+
 
 NS_INLINE NSString *MPEditorPreferenceKeyWithValueKey(NSString *key)
 {
@@ -782,17 +785,15 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     // Zoom menu validation
     if (action == @selector(zoomIn:))
     {
-        static const CGFloat kMaxZoom = 3.0;
-        return self.zoomMultiplier < kMaxZoom;
+        return self.zoomMultiplier < kMPMaxZoom;
     }
     else if (action == @selector(zoomOut:))
     {
-        static const CGFloat kMinZoom = 0.5;
-        return self.zoomMultiplier > kMinZoom;
+        return self.zoomMultiplier > kMPMinZoom;
     }
     else if (action == @selector(resetZoom:))
     {
-        return self.zoomMultiplier != 1.0;
+        return fabs(self.zoomMultiplier - 1.0) > 0.001;
     }
     else if (action == @selector(toggleToolbar:))
     {
@@ -2120,16 +2121,19 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 - (void)scaleWebview
 {
-    if (!self.preferences.previewZoomRelativeToBaseFontSize)
-        return;
+    CGFloat scale = self.zoomMultiplier;
 
-    CGFloat fontSize = self.preferences.editorBaseFontSize;
-    if (fontSize <= 0.0)
-        return;
+    if (self.preferences.previewZoomRelativeToBaseFontSize)
+    {
+        CGFloat fontSize = self.preferences.editorBaseFontSize;
+        if (fontSize > 0.0)
+        {
+            static const CGFloat defaultSize = 14.0;
+            scale = (fontSize / defaultSize)
+                    * self.zoomMultiplier;
+        }
+    }
 
-    static const CGFloat defaultSize = 14.0;
-    CGFloat scale = (fontSize / defaultSize) * self.zoomMultiplier;
-    
 #if 0
     // Sadly, this doesn’t work correctly.
     // It looks fine, but selections are offset relative to the mouse cursor.
@@ -2146,21 +2150,19 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 - (IBAction)zoomIn:(id)sender
 {
-    static const CGFloat kMaxZoom = 3.0;
-    if (self.zoomMultiplier >= kMaxZoom)
+    if (self.zoomMultiplier >= kMPMaxZoom)
         return;
     
-    self.zoomMultiplier = MIN(self.zoomMultiplier + 0.1, kMaxZoom);
+    self.zoomMultiplier = MIN(self.zoomMultiplier + 0.1, kMPMaxZoom);
     [self applyCurrentZoom];
 }
 
 - (IBAction)zoomOut:(id)sender
 {
-    static const CGFloat kMinZoom = 0.5;
-    if (self.zoomMultiplier <= kMinZoom)
+    if (self.zoomMultiplier <= kMPMinZoom)
         return;
     
-    self.zoomMultiplier = MAX(self.zoomMultiplier - 0.1, kMinZoom);
+    self.zoomMultiplier = MAX(self.zoomMultiplier - 0.1, kMPMinZoom);
     [self applyCurrentZoom];
 }
 

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -247,6 +247,9 @@ typedef NS_ENUM(NSUInteger, MPWordCountType) {
 // Store file content in initializer until nib is loaded.
 @property (copy) NSString *loadedString;
 
+// Transient per-document zoom level (not saved to preferences)
+@property CGFloat zoomMultiplier;
+
 - (void)scaleWebview;
 - (void)syncScrollers;
 - (void)syncScrollersReverse;
@@ -394,6 +397,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     self.shouldHandleBoundsChange = YES;
     self.shouldHandlePreviewBoundsChange = YES;
     self.previousSplitRatio = -1.0;
+    self.zoomMultiplier = 1.0;
     
     return self;
 }
@@ -774,7 +778,23 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 {
     BOOL result = [super validateUserInterfaceItem:item];
     SEL action = item.action;
-    if (action == @selector(toggleToolbar:))
+    
+    // Zoom menu validation
+    if (action == @selector(zoomIn:))
+    {
+        static const CGFloat kMaxZoom = 3.0;
+        return self.zoomMultiplier < kMaxZoom;
+    }
+    else if (action == @selector(zoomOut:))
+    {
+        static const CGFloat kMinZoom = 0.5;
+        return self.zoomMultiplier > kMinZoom;
+    }
+    else if (action == @selector(resetZoom:))
+    {
+        return self.zoomMultiplier != 1.0;
+    }
+    else if (action == @selector(toggleToolbar:))
     {
         NSMenuItem *it = ((NSMenuItem *)item);
         it.title = self.toolbarVisible ?
@@ -2108,7 +2128,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         return;
 
     static const CGFloat defaultSize = 14.0;
-    CGFloat scale = fontSize / defaultSize;
+    CGFloat scale = (fontSize / defaultSize) * self.zoomMultiplier;
     
 #if 0
     // Sadly, this doesn’t work correctly.
@@ -2122,6 +2142,45 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     // Warning: this is private webkit API and NOT App Store-safe!
     [self.preview setPageSizeMultiplier:scale];
 #endif
+}
+
+- (IBAction)zoomIn:(id)sender
+{
+    static const CGFloat kMaxZoom = 3.0;
+    if (self.zoomMultiplier >= kMaxZoom)
+        return;
+    
+    self.zoomMultiplier = MIN(self.zoomMultiplier + 0.1, kMaxZoom);
+    [self applyCurrentZoom];
+}
+
+- (IBAction)zoomOut:(id)sender
+{
+    static const CGFloat kMinZoom = 0.5;
+    if (self.zoomMultiplier <= kMinZoom)
+        return;
+    
+    self.zoomMultiplier = MAX(self.zoomMultiplier - 0.1, kMinZoom);
+    [self applyCurrentZoom];
+}
+
+- (IBAction)resetZoom:(id)sender
+{
+    self.zoomMultiplier = 1.0;
+    [self applyCurrentZoom];
+}
+
+- (void)applyCurrentZoom
+{
+    NSFont *baseFont = self.preferences.editorBaseFont;
+    CGFloat zoomedSize = baseFont.pointSize * self.zoomMultiplier;
+    
+    // Apply zoom to editor (transient, not saved to preferences)
+    [self.editor setFont:[NSFont fontWithName:baseFont.fontName
+                                         size:zoomedSize]];
+    
+    // Apply zoom to preview
+    [self scaleWebview];
 }
 
 /**

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -405,6 +405,22 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="QMZ-Ld-Nza"/>
+                            <menuItem title="Zoom In" keyEquivalent="+" id="zIn-01-ABC">
+                                <connections>
+                                    <action selector="zoomIn:" target="-1" id="zIn-02-DEF"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Zoom Out" keyEquivalent="-" id="zOt-01-GHI">
+                                <connections>
+                                    <action selector="zoomOut:" target="-1" id="zOt-02-JKL"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Actual Size" keyEquivalent="0" id="zRs-01-PQR">
+                                <connections>
+                                    <action selector="resetZoom:" target="-1" id="zRs-02-STU"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="zSp-01-MNO"/>
                             <menuItem title="Enter Full Screen" keyEquivalent="f" id="1gz-YB-DZE">
                                 <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                 <connections>


### PR DESCRIPTION
Implements per-document zoom as requested in #335.

This PR adds standard macOS zoom shortcuts:
- Cmd+ zooms in (10% increments, max 300%)
- Cmd- zooms out (10% decrements, min 50%)
- Cmd+0 resets to actual size

Implementation:
- Uses a transient per-document zoom multiplier (not saved to preferences)
- Zoom applies to both editor and preview when the preference is enabled
- Menu items validate and disable at zoom limits
- Does not modify the base font preference
- Preserves existing Cmd+Shift+0 shortcut for split view

Fixes #335