### PR TITLE
Fix editor scroll jump during typing at end of long documents

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1319,7 +1319,10 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
                     __weak MPDocument *weakSelf = self;
                     [listener addCallback:^{
                         [weakSelf updateHeaderLocations];
-                        if (weakSelf.preferences.editorSyncScrolling)
+                        // Issue #342: Skip sync during active editing to prevent
+                        // scroll jumping after MathJax typesetting completes.
+                        if (weakSelf.preferences.editorSyncScrolling
+                            && !weakSelf.inEditing)
                         {
                             [weakSelf syncScrollers];
                         }
@@ -1490,10 +1493,16 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     {
         @synchronized(self) {
             self.shouldHandlePreviewBoundsChange = NO;
-            if (!_inLiveScroll) {
+            // Issue #342: Skip reverse sync during active editing to prevent
+            // scroll jumping. When typing triggers a preview re-render, the DOM
+            // replacement's window.scrollTo() fires this notification. Without
+            // this guard, syncScrollersReverse moves the editor to the wrong
+            // position. The sync will happen after editing pauses via
+            // performDelayedSyncScrollers.
+            if (!_inLiveScroll && !_inEditing) {
                 [self updateHeaderLocations];
+                [self syncScrollersReverse];
             }
-            [self syncScrollersReverse];
             self.shouldHandlePreviewBoundsChange = YES;
         }
     }

--- a/MacDownTests/MPScrollSyncTests.m
+++ b/MacDownTests/MPScrollSyncTests.m
@@ -25,6 +25,7 @@
 - (void)syncScrollers;
 - (void)syncScrollersReverse;
 - (void)performDelayedSyncScrollers;  // Issue #282: Delayed sync after editing
+- (void)previewBoundsDidChange:(NSNotification *)notification;  // Issue #342
 @end
 
 @interface MPScrollSyncTests : XCTestCase
@@ -1543,6 +1544,75 @@
     // This tests the bounds check fix - shouldn't crash on edge cases
     XCTAssertNoThrow([doc updateHeaderLocations],
                      @"updateHeaderLocations should handle four backticks without crashing");
+}
+
+#pragma mark - Issue #342: Preview bounds change during editing
+
+/**
+ * Test that previewBoundsDidChange: does NOT call syncScrollersReverse when
+ * _inEditing is YES. This is the primary fix for issue #342: preview scroll
+ * restoration during DOM replacement was feeding back into the editor via
+ * syncScrollersReverse, causing the editor to jump.
+ *
+ * We verify indirectly: shouldHandleBoundsChange on the editor side should
+ * remain untouched (syncScrollersReverse temporarily sets it to NO then YES).
+ * If syncScrollersReverse is skipped, shouldHandleBoundsChange stays at its
+ * initial value throughout.
+ */
+- (void)testPreviewBoundsDidChangeSkipsSyncWhenInEditing
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.shouldHandlePreviewBoundsChange = YES;
+    doc.shouldHandleBoundsChange = YES;
+    doc.inEditing = YES;
+
+    // Simulate a preview bounds change notification (as would be triggered by
+    // window.scrollTo() during DOM replacement)
+    [doc previewBoundsDidChange:nil];
+
+    // shouldHandleBoundsChange should be untouched because syncScrollersReverse
+    // was never called (it temporarily toggles this flag)
+    XCTAssertTrue(doc.shouldHandleBoundsChange,
+                  @"shouldHandleBoundsChange should remain YES when inEditing prevents reverse sync");
+    XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
+                  @"shouldHandlePreviewBoundsChange should be restored to YES after handler completes");
+}
+
+/**
+ * Test that previewBoundsDidChange: DOES call syncScrollersReverse when
+ * _inEditing is NO. This ensures the guard doesn't over-suppress —
+ * user-initiated preview scrolling should still sync back to the editor.
+ */
+- (void)testPreviewBoundsDidChangeSyncsWhenNotInEditing
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.shouldHandlePreviewBoundsChange = YES;
+    doc.shouldHandleBoundsChange = YES;
+    doc.inEditing = NO;
+
+    // Should not crash; syncScrollersReverse should be called
+    XCTAssertNoThrow([doc previewBoundsDidChange:nil],
+                     @"previewBoundsDidChange: should work normally when not in editing");
+    XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
+                  @"shouldHandlePreviewBoundsChange should be restored to YES");
+}
+
+/**
+ * Test that previewBoundsDidChange: respects the shouldHandlePreviewBoundsChange
+ * guard even when inEditing is NO. This verifies the early-return path.
+ */
+- (void)testPreviewBoundsDidChangeRespectsGuardFlag
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.shouldHandlePreviewBoundsChange = NO;
+    doc.shouldHandleBoundsChange = YES;
+    doc.inEditing = NO;
+
+    XCTAssertNoThrow([doc previewBoundsDidChange:nil],
+                     @"previewBoundsDidChange: should early-return when guard is NO");
+    // shouldHandlePreviewBoundsChange should remain NO (handler returned early)
+    XCTAssertFalse(doc.shouldHandlePreviewBoundsChange,
+                   @"shouldHandlePreviewBoundsChange should remain NO after early return");
 }
 
 @end


### PR DESCRIPTION
## Summary

- Guard `previewBoundsDidChange:` with `_inEditing` to break the feedback loop where DOM replacement's `window.scrollTo()` triggers reverse scroll sync back into the editor, causing the scroll jump reported in #342
- Guard the MathJax `DOMReplacementDone` completion callback's `syncScrollers` call with the same `_inEditing` check, preventing the same cascade via the async MathJax path
- Fix secondary inconsistency where `syncScrollersReverse` was called outside the `!_inLiveScroll` guard with stale header data

Both fixes follow the established `_inEditing` pattern from the #282 fix in `editorBoundsDidChange:`.

Related to #342

## Test plan

- [x] CI passes on all 4 macOS runners (macos-14, macos-15, macos-15-intel, macos-26)
- [x] New test: `testPreviewBoundsDidChangeSkipsSyncWhenInEditing` — verifies reverse sync is suppressed during editing
- [x] New test: `testPreviewBoundsDidChangeSyncsWhenNotInEditing` — verifies no over-suppression of legitimate preview scrolling
- [x] New test: `testPreviewBoundsDidChangeRespectsGuardFlag` — verifies early-return path
- [ ] Manual: Open a long document, type at the end, confirm no scroll jumping
- [ ] Manual: Scroll the preview pane manually, confirm editor follows (reverse sync still works)
- [ ] Manual: Enable MathJax, type math at the end of a long document, confirm no jumping

