### PR TITLE
Feature: Add Github2 (Dark) style

### DIFF
--- a/MacDown/Resources/Styles/Github2 (dark).css
+++ b/MacDown/Resources/Styles/Github2 (dark).css
@@ -1,0 +1,478 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  font-size: 16px;
+  line-height: 1.6;
+  background-color: #0d1117;
+  color: #e6edf3;
+  padding: 30px;
+}
+
+body>*:first-child {
+  margin-top: 0 !important;
+}
+
+body>*:last-child {
+  margin-bottom: 0 !important;
+}
+
+a {
+  color: #58a6ff;
+}
+
+a.absent {
+  color: #f85149;
+}
+
+a.anchor {
+  display: block;
+  padding-left: 30px;
+  margin-left: -30px;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 20px 0 10px;
+  padding: 0;
+  font-weight: 600;
+  -webkit-font-smoothing: antialiased;
+  cursor: text;
+  position: relative;
+  color: #e6edf3;
+}
+
+h1:hover a.anchor,
+h2:hover a.anchor,
+h3:hover a.anchor,
+h4:hover a.anchor,
+h5:hover a.anchor,
+h6:hover a.anchor {
+  text-decoration: none;
+}
+
+h1 tt,
+h1 code {
+  font-size: inherit;
+}
+
+h2 tt,
+h2 code {
+  font-size: inherit;
+}
+
+h3 tt,
+h3 code {
+  font-size: inherit;
+}
+
+h4 tt,
+h4 code {
+  font-size: inherit;
+}
+
+h5 tt,
+h5 code {
+  font-size: inherit;
+}
+
+h6 tt,
+h6 code {
+  font-size: inherit;
+}
+
+h1 {
+  font-size: 2em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid #21262d;
+}
+
+h2 {
+  font-size: 1.5em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid #21262d;
+}
+
+h3 {
+  font-size: 1.25em;
+}
+
+h4 {
+  font-size: 1em;
+}
+
+h5 {
+  font-size: 0.875em;
+}
+
+h6 {
+  color: #8b949e;
+  font-size: 0.85em;
+}
+
+p,
+blockquote,
+ul,
+ol,
+dl,
+li,
+table,
+pre {
+  margin: 15px 0;
+}
+
+hr {
+  background-color: #30363d;
+  border: 0 none;
+  color: #30363d;
+  height: 1px;
+  padding: 0;
+  margin: 24px 0;
+}
+
+body>h2:first-child {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+body>h1:first-child {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+body>h1:first-child+h2 {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+body>h3:first-child,
+body>h4:first-child,
+body>h5:first-child,
+body>h6:first-child {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+a:first-child h1,
+a:first-child h2,
+a:first-child h3,
+a:first-child h4,
+a:first-child h5,
+a:first-child h6 {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+h1 p,
+h2 p,
+h3 p,
+h4 p,
+h5 p,
+h6 p {
+  margin-top: 0;
+}
+
+li p.first {
+  display: inline-block;
+}
+
+li {
+  margin: 0;
+}
+
+ul,
+ol {
+  padding-left: 30px;
+}
+
+ul :first-child,
+ol :first-child {
+  margin-top: 0;
+}
+
+dl {
+  padding: 0;
+}
+
+dl dt {
+  font-size: 16px;
+  font-weight: bold;
+  font-style: italic;
+  padding: 0;
+  margin: 15px 0 5px;
+}
+
+dl dt:first-child {
+  padding: 0;
+}
+
+dl dt> :first-child {
+  margin-top: 0;
+}
+
+dl dt> :last-child {
+  margin-bottom: 0;
+}
+
+dl dd {
+  margin: 0 0 15px;
+  padding: 0 15px;
+}
+
+dl dd> :first-child {
+  margin-top: 0;
+}
+
+dl dd> :last-child {
+  margin-bottom: 0;
+}
+
+blockquote {
+  border-left: 4px solid #3b434b;
+  padding: 0 15px;
+  color: #8b949e;
+}
+
+blockquote> :first-child {
+  margin-top: 0;
+}
+
+blockquote> :last-child {
+  margin-bottom: 0;
+}
+
+table {
+  padding: 0;
+  border-collapse: collapse;
+}
+
+table tr {
+  border-top: 1px solid #30363d;
+  background-color: #0d1117;
+  margin: 0;
+  padding: 0;
+}
+
+table tr:nth-child(2n) {
+  background-color: #161b22;
+}
+
+table tr th {
+  font-weight: 600;
+  border: 1px solid #30363d;
+  margin: 0;
+  padding: 6px 13px;
+}
+
+table tr td {
+  border: 1px solid #30363d;
+  margin: 0;
+  padding: 6px 13px;
+}
+
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
+}
+
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
+}
+
+img {
+  max-width: 100%;
+}
+
+span.frame {
+  display: block;
+  overflow: hidden;
+}
+
+span.frame>span {
+  border: 1px solid #30363d;
+  display: block;
+  float: left;
+  overflow: hidden;
+  margin: 13px 0 0;
+  padding: 7px;
+  width: auto;
+}
+
+span.frame span img {
+  display: block;
+  float: left;
+}
+
+span.frame span span {
+  clear: both;
+  color: #e6edf3;
+  display: block;
+  padding: 5px 0 0;
+}
+
+span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+span.align-center>span {
+  display: block;
+  overflow: hidden;
+  margin: 13px auto 0;
+  text-align: center;
+}
+
+span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+
+span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+span.align-right>span {
+  display: block;
+  overflow: hidden;
+  margin: 13px 0 0;
+  text-align: right;
+}
+
+span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+
+span.float-left {
+  display: block;
+  margin-right: 13px;
+  overflow: hidden;
+  float: left;
+}
+
+span.float-left span {
+  margin: 13px 0 0;
+}
+
+span.float-right {
+  display: block;
+  margin-left: 13px;
+  overflow: hidden;
+  float: right;
+}
+
+span.float-right>span {
+  display: block;
+  overflow: hidden;
+  margin: 13px auto 0;
+  text-align: right;
+}
+
+code,
+tt {
+  margin: 0 2px;
+  padding: 0.2em 0.4em;
+  white-space: nowrap;
+  border: none;
+  background-color: rgba(110, 118, 129, 0.4);
+  border-radius: 6px;
+  font-size: 85%;
+  color: #e6edf3;
+}
+
+pre code {
+  margin: 0;
+  padding: 0;
+  white-space: pre;
+  border: none;
+  background: transparent;
+  font-size: 100%;
+}
+
+.highlight pre {
+  background-color: #161b22;
+  border: 1px solid #30363d;
+  font-size: 13px;
+  line-height: 19px;
+  overflow: auto;
+  padding: 16px;
+  border-radius: 6px;
+}
+
+pre {
+  background-color: #161b22;
+  border: none;
+  font-size: 14px;
+  line-height: 19px;
+  overflow: auto;
+  padding: 16px;
+  border-radius: 6px;
+}
+
+pre tt {
+  background-color: transparent;
+  border: none;
+}
+
+sup {
+  font-size: 0.83em;
+  vertical-align: super;
+  line-height: 0;
+}
+
+kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  font-size: 11px;
+  line-height: 10px;
+  color: #e6edf3;
+  vertical-align: middle;
+  background-color: #161b22;
+  border: solid 1px #30363d;
+  border-bottom-color: #21262d;
+  border-radius: 6px;
+  box-shadow: inset 0 -1px 0 #21262d;
+}
+
+mark {
+  background-color: rgba(187, 128, 9, 0.15);
+  color: #e6edf3;
+}
+
+* {
+  -webkit-print-color-adjust: exact;
+}
+
+@media screen and (min-width: 914px) {
+  body {
+    width: 854px;
+    margin: 0 auto;
+  }
+}
+
+@media print {
+
+  table,
+  pre {
+    page-break-inside: avoid;
+  }
+
+  pre {
+    word-wrap: break-word;
+  }
+
+  body {
+    padding: 2cm;
+  }
+}


### PR DESCRIPTION
Adds a new style 'GitHub2 (Dark)' to Macdown 3000. 

This is an approximation of the current github.com dark theme adapted from the `Github2.css` style already found in Macdown 3000. 

**This is an AI assisted change** Opus 4.6 did the majority of the work, I then manually checked, formatted and hand tweaked some minor details related to the borders on the `pre` tag. I used Copilot to integrate the change.

## Changes

- **New file:** `MacDown/Resources/Styles/Github2 (dark).css`
  - Dark background (`#0d1117`) with light text (`#e6edf3`) matching GitHub's dark mode palette
  - Styled headings, blockquotes, tables, code blocks, `kbd`, `mark`, and inline code with dark-appropriate colors
  - Alternating table row shading (`#0d1117` / `#161b22`)
  - Responsive width cap at 854px and print-safe overrides

<img width="1890" height="1250" alt="Screenshot 2026-03-26 at 06 15 50" src="https://github.com/user-attachments/assets/f5409cf2-4e79-4c1c-b843-6d9c50e0e6fc" />
