### PR TITLE
Fix file watcher dropping after atomic save by external editors

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2922,7 +2922,20 @@ current file somewhere to enable this feature.", \
                  [weakSelf handleExternalFileChange];
              }
        cancelHandler:^(NSString *path) {
-                 // File was deleted or renamed — watcher auto-stopped
+                 // File was deleted or renamed (e.g. atomic save by external editor).
+                 // Wait briefly for the rename to complete, then restart watching
+                 // the new inode at the same path.
+                 dispatch_after(
+                     dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)),
+                     dispatch_get_main_queue(), ^{
+                     MPDocument *s = weakSelf;
+                     if (!s) return;                                       // document closed
+                     if (![s.fileURL.path isEqualToString:path]) return;  // Save As changed URL
+                     if (s.fileWatcher.isWatching) return;                // already restarted
+                     if (![[NSFileManager defaultManager] fileExistsAtPath:path]) return;
+                     [s startFileWatching];
+                     [s handleExternalFileChange];
+                 });
        }];
 
     // Initialize resource watcher set


### PR DESCRIPTION
## Summary

- Editors like Sublime Text, VSCode, vim, and nano use **atomic saves**: they write to a temp file then `rename()` over the original
- This causes the VNODE watcher to receive a `DELETE`/`RENAME` event and **stop watching entirely**, so subsequent external changes go undetected
- The cancel handler now schedules a 0.3s restart, re-attaches to the new inode, and checks for a content change

## Guards against spurious restarts

| Check | Prevents |
|---|---|
| `weakSelf` nil | Restart after document is closed |
| `fileURL.path != path` | Restart after Save As to a different path |
| `fileWatcher.isWatching` | Double-restart (startFileWatching calls stopFileWatching internally) |
| File doesn't exist | Restart after a genuine deletion |

## Test plan

- [ ] Open a file in MacDown, edit and save from Sublime Text → silent reload
- [ ] Open a file in MacDown, edit and save from VSCode → silent reload
- [ ] Open a file, make unsaved edits, then save externally → prompt appears
- [ ] Save As to a new file, edit the new file externally → reloads correctly
- [ ] Close document while watcher is active → no crash or spurious reload

## Related

Related to #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)