### PR TITLE
Add MutationObserver to viz.init.js for live-edit Graphviz re-rendering

### DIFF
--- a/MacDown 3000.xcodeproj/project.pbxproj
+++ b/MacDown 3000.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		E087CFBB2125A4D2B37C132F /* MPHTMLResourceURLsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8552820CEE8D00E83AEE3897 /* MPHTMLResourceURLsTests.m */; };
 		ISSUE318STYLERELBUILDFILE /* MPDocumentStyleUpdateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE318STYLERELFILEREF /* MPDocumentStyleUpdateTests.m */; };
 		ISSUE331MRMDRNDRBUILDFILE /* MPMermaidRenderingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE331MRMDRNDRFILEREF /* MPMermaidRenderingTests.m */; };
+		ISSUE332GVIZRNDRBUILDFILE /* MPGraphvizRenderingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE332GVIZRNDRFILEREF /* MPGraphvizRenderingTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -597,6 +598,7 @@
 		8552820CEE8D00E83AEE3897 /* MPHTMLResourceURLsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPHTMLResourceURLsTests.m; sourceTree = "<group>"; };
 		ISSUE318STYLERELFILEREF /* MPDocumentStyleUpdateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPDocumentStyleUpdateTests.m; sourceTree = "<group>"; };
 		ISSUE331MRMDRNDRFILEREF /* MPMermaidRenderingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPMermaidRenderingTests.m; sourceTree = "<group>"; };
+		ISSUE332GVIZRNDRFILEREF /* MPGraphvizRenderingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPGraphvizRenderingTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -957,6 +959,7 @@
 				ISSUE313TOOLBARFILEREF /* MPToolbarControllerTests.m */,
 				ISSUE318STYLERELFILEREF /* MPDocumentStyleUpdateTests.m */,
 				ISSUE331MRMDRNDRFILEREF /* MPMermaidRenderingTests.m */,
+				ISSUE332GVIZRNDRFILEREF /* MPGraphvizRenderingTests.m */,
 			);
 			path = MacDownTests;
 			sourceTree = "<group>";
@@ -1402,6 +1405,7 @@
 				E087CFBB2125A4D2B37C132F /* MPHTMLResourceURLsTests.m in Sources */,
 				ISSUE318STYLERELBUILDFILE /* MPDocumentStyleUpdateTests.m in Sources */,
 				ISSUE331MRMDRNDRBUILDFILE /* MPMermaidRenderingTests.m in Sources */,
+				ISSUE332GVIZRNDRBUILDFILE /* MPGraphvizRenderingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacDown/Resources/Extensions/viz.init.js
+++ b/MacDown/Resources/Extensions/viz.init.js
@@ -1,12 +1,13 @@
 // graphviz init
+// MutationObserver for DOM replacement re-rendering (GitHub issue #332)
 (function () {
- var graphviz_engines = ["circo",
-                         "dot",
-                         "fdp",
-                         "neato",
-                         "osage",
-                         "twopi"];
- 
+  var graphviz_engines = ["circo",
+                          "dot",
+                          "fdp",
+                          "neato",
+                          "osage",
+                          "twopi"];
+
   function doGraphviz(engine) {
     var domAllDot = document.querySelectorAll("code.language-" + engine);
     for (var i = 0; i < domAllDot.length; i++) {
@@ -20,15 +21,67 @@
       }
     }
   }
- 
+
+  // Guard against re-entrant calls (e.g. MutationObserver firing during render).
+  // The primary safety net is the length === 0 check below, which prevents
+  // unnecessary re-renders once all .language-{engine} elements have been
+  // replaced with SVGs. This flag is an additional belt-and-suspenders measure.
+  var rendering = false;
+
   var init = function() {
-    for (var i = 0; i < graphviz_engines.length; i++) {
-      doGraphviz(graphviz_engines[i]);
+    if (rendering) return;
+
+    var hasGraphviz = false;
+    for (var e = 0; e < graphviz_engines.length; e++) {
+      if (document.querySelectorAll("code.language-" + graphviz_engines[e]).length > 0) {
+        hasGraphviz = true;
+        break;
+      }
+    }
+    if (!hasGraphviz) return;
+
+    rendering = true;
+    try {
+      for (var i = 0; i < graphviz_engines.length; i++) {
+        doGraphviz(graphviz_engines[i]);
+      }
+    } finally {
+      rendering = false;
     }
   };
+
+  // Initial render on page load
   if (typeof window.addEventListener != "undefined") {
     window.addEventListener("load", init, false);
   } else {
     window.attachEvent("onload", init);
+  }
+
+  // Re-render on DOM replacement (GitHub issue #332).
+  // When MPDocument.m replaces body.innerHTML, the window.load event does not
+  // fire again. A MutationObserver detects new .language-{engine} elements and
+  // triggers rendering automatically. After rendering, those elements are
+  // replaced with SVGs, so there is no risk of infinite re-trigger loops.
+  if (typeof MutationObserver !== 'undefined') {
+    var observer = new MutationObserver(function() {
+      for (var e = 0; e < graphviz_engines.length; e++) {
+        if (document.querySelectorAll("code.language-" + graphviz_engines[e]).length > 0) {
+          init();
+          return;
+        }
+      }
+    });
+
+    var startObserving = function() {
+      if (document.body) {
+        observer.observe(document.body, { childList: true, subtree: true });
+      }
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', startObserving);
+    } else {
+      startObserving();
+    }
   }
 })();

--- a/MacDownTests/MPGraphvizRenderingTests.m
+++ b/MacDownTests/MPGraphvizRenderingTests.m
@@ -1,0 +1,342 @@
+//
+//  MPGraphvizRenderingTests.m
+//  MacDownTests
+//
+//  Tests for Graphviz diagram rendering in the Obj-C pipeline.
+//  Verifies that graphviz scripts are included/excluded correctly,
+//  code blocks get the proper language class, and rendering
+//  survives preference changes and re-renders.
+//
+//  Related to #332
+//
+
+#import <XCTest/XCTest.h>
+#import "MPRenderer.h"
+#import "MPRendererTestHelpers.h"
+#import "hoedown/document.h"
+
+
+#pragma mark - Test Class
+
+@interface MPGraphvizRenderingTests : XCTestCase
+@property (nonatomic, strong) MPRenderer *renderer;
+@property (nonatomic, strong) MPMockRendererDataSource *dataSource;
+@property (nonatomic, strong) MPMockRendererDelegate *delegate;
+@end
+
+
+@implementation MPGraphvizRenderingTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.dataSource = [[MPMockRendererDataSource alloc] init];
+    self.delegate = [[MPMockRendererDelegate alloc] init];
+
+    self.renderer = [[MPRenderer alloc] init];
+    self.renderer.dataSource = self.dataSource;
+    self.renderer.delegate = self.delegate;
+}
+
+- (void)tearDown
+{
+    self.renderer = nil;
+    self.dataSource = nil;
+    self.delegate = nil;
+    [super tearDown];
+}
+
+
+#pragma mark - Basic Graphviz Code Block Rendering
+
+- (void)testDotCodeBlockProducesLanguageClass
+{
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.graphviz = YES;
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    XCTAssertTrue([html containsString:@"language-dot"],
+                  @"Dot code block should have language-dot class");
+}
+
+- (void)testDotCodeBlockPreservesGraphSource
+{
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.graphviz = YES;
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    XCTAssertTrue([html containsString:@"digraph G"],
+                  @"Graph source text should be preserved in HTML output");
+    XCTAssertTrue([html containsString:@"A -&gt; B"] ||
+                  [html containsString:@"A -> B"],
+                  @"Graph edges should be preserved (escaped or literal)");
+}
+
+- (void)testDotCodeBlockWithoutFencedCodeExtension
+{
+    self.delegate.extensions = 0;  // No fenced code extension
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.graphviz = YES;
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    XCTAssertFalse([html containsString:@"language-dot"],
+                   @"Without fenced code extension, no language-dot class");
+}
+
+
+#pragma mark - Graphviz Script Inclusion
+
+- (void)testGraphvizScriptsIncludedWhenEnabled
+{
+    self.delegate.graphviz = YES;
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+
+    // Use render (MPAssetFullLink) so script URLs contain filenames
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"viz.js"],
+                  @"Should include Graphviz library");
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"viz.init.js"],
+                  @"Should include Graphviz init script");
+}
+
+- (void)testGraphvizScriptsExcludedWhenDisabled
+{
+    self.delegate.graphviz = NO;
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+
+    // Use render (MPAssetFullLink) so script URLs contain filenames
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+
+    XCTAssertFalse([self.delegate.lastHTML containsString:@"viz.init.js"],
+                   @"Should NOT include Graphviz init script when disabled");
+}
+
+- (void)testGraphvizScriptsExcludedWhenSyntaxHighlightingDisabled
+{
+    self.delegate.graphviz = YES;
+    self.delegate.syntaxHighlighting = NO;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+
+    // Use render (MPAssetFullLink) so script URLs contain filenames
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+
+    XCTAssertFalse([self.delegate.lastHTML containsString:@"viz.init.js"],
+                   @"Graphviz requires syntax highlighting to be enabled");
+}
+
+
+#pragma mark - Preference Change Detection
+
+- (void)testRenderIfPreferencesChangedDetectsGraphvizToggle
+{
+    self.delegate.graphviz = NO;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+
+    // Initial render to cache state
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+    self.delegate.lastHTML = nil;
+
+    // Toggle graphviz on
+    self.delegate.graphviz = YES;
+    [self.renderer renderIfPreferencesChanged];
+
+    XCTAssertNotNil(self.delegate.lastHTML,
+                    @"Toggling graphviz should trigger a re-render");
+}
+
+- (void)testRenderIfPreferencesChangedIgnoresWhenGraphvizUnchanged
+{
+    self.delegate.graphviz = YES;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+
+    // Initial render to cache state
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+    self.delegate.lastHTML = nil;
+
+    // No change
+    [self.renderer renderIfPreferencesChanged];
+
+    XCTAssertNil(self.delegate.lastHTML,
+                 @"Should NOT re-render when graphviz preference is unchanged");
+}
+
+- (void)testStyleNameChangeTriggersReRender
+{
+    self.delegate.graphviz = YES;
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.delegate.styleName = @"GitHub2";
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+
+    // Initial render
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+    self.delegate.lastHTML = nil;
+
+    // Change theme
+    self.delegate.styleName = @"Clearness";
+    [self.renderer renderIfPreferencesChanged];
+
+    XCTAssertNotNil(self.delegate.lastHTML,
+                    @"Changing theme should trigger re-render (full reload path)");
+}
+
+
+#pragma mark - Multiple Diagrams and Mixed Content
+
+- (void)testMultipleGraphvizDiagramsInSameDocument
+{
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.graphviz = YES;
+    self.dataSource.markdown =
+        @"```dot\ndigraph G { A -> B }\n```\n\n"
+        @"Some text\n\n"
+        @"```dot\ndigraph H { C -> D }\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    // Count occurrences of language-dot
+    NSUInteger count = 0;
+    NSRange searchRange = NSMakeRange(0, html.length);
+    while (searchRange.location < html.length) {
+        NSRange found = [html rangeOfString:@"language-dot"
+                                   options:0
+                                     range:searchRange];
+        if (found.location == NSNotFound) break;
+        count++;
+        searchRange.location = found.location + found.length;
+        searchRange.length = html.length - searchRange.location;
+    }
+
+    XCTAssertEqual(count, 2,
+                   @"Both dot blocks should have language-dot class");
+}
+
+- (void)testGraphvizWithOtherFencedCodeBlocks
+{
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.graphviz = YES;
+    self.dataSource.markdown =
+        @"```dot\ndigraph G { A -> B }\n```\n\n"
+        @"```javascript\nconst x = 1;\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    XCTAssertTrue([html containsString:@"language-dot"],
+                  @"Should contain graphviz code block");
+    XCTAssertTrue([html containsString:@"language-javascript"],
+                  @"Should contain javascript code block alongside graphviz");
+}
+
+
+#pragma mark - Edge Cases
+
+- (void)testEmptyDotCodeBlock
+{
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.graphviz = YES;
+    self.dataSource.markdown = @"```dot\n\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    XCTAssertNotNil(html, @"Should not crash on empty dot block");
+    XCTAssertTrue([html containsString:@"language-dot"],
+                  @"Empty dot block should still have language class");
+}
+
+- (void)testGraphvizAfterReparse
+{
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.graphviz = YES;
+
+    // First parse: plain markdown
+    self.dataSource.markdown = @"# Hello";
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+
+    // Second parse: graphviz
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    XCTAssertTrue([html containsString:@"language-dot"],
+                  @"Re-parse should produce graphviz content");
+    XCTAssertFalse([html containsString:@"Hello"],
+                   @"Previous parse content should be gone");
+}
+
+- (void)testGraphvizDisabledAfterBeingEnabled
+{
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.delegate.syntaxHighlighting = YES;
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+
+    // First: enabled — use render (MPAssetFullLink) for filename checks
+    self.delegate.graphviz = YES;
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"viz.init.js"],
+                  @"Should include graphviz scripts when enabled");
+
+    // Second: disabled
+    self.delegate.graphviz = NO;
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+    XCTAssertFalse([self.delegate.lastHTML containsString:@"viz.init.js"],
+                   @"Should exclude graphviz scripts after disabling");
+}
+
+
+#pragma mark - Graphviz with Other Features
+
+- (void)testGraphvizWithMermaid
+{
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.graphviz = YES;
+    self.delegate.mermaid = YES;
+    self.dataSource.markdown =
+        @"```dot\ndigraph G { A -> B }\n```\n\n"
+        @"```mermaid\ngraph TD;\n    A-->B;\n```";
+
+    // Use render (MPAssetFullLink) for filename checks
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"viz.init.js"],
+                  @"Should include graphviz init script");
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"mermaid.init.js"],
+                  @"Should include mermaid init script alongside graphviz");
+}
+
+@end


### PR DESCRIPTION
## Summary

- `viz.init.js`: adds a `rendering` guard flag and a `MutationObserver` that watches for `.language-{engine}` elements across all 6 Graphviz engines; calls `init()` when any are found after `body.innerHTML` replacement. Loop prevention is structural — `doGraphviz()` replaces the triggering `<code>` element with SVG before the observer can fire again.
- `MPGraphvizRenderingTests.m`: new test file mirroring `MPMermaidRenderingTests.m`; 15 tests covering code block rendering, script inclusion/exclusion, preference change detection, style changes, multiple diagrams, mixed content, edge cases, and graphviz+mermaid coexistence.
- `project.pbxproj`: registers new test file in the `MacDownTests` target.

This is the same class of bug fixed for Mermaid in #331 / PR #333.

## Test plan

- [x] All four CI runners passed (macos-14, macos-15, macos-15-intel, macos-26)
- [ ] Manual: open a doc with a `dot` fence, edit it — diagram re-renders without full reload

Related to #332