### PR TITLE
Add Inline HTML section to The Basics

### DIFF
--- a/MacDown/Resources/help.md
+++ b/MacDown/Resources/help.md
@@ -198,6 +198,24 @@ If you type three asterisks `***` or three dashes `---` on a line, I'll display 
 
 ***
 
+### Inline HTML
+
+Standard Markdown passes raw HTML through to the rendered output, so you can use HTML tags for things Markdown doesn't natively support.
+
+For example, to insert a **page break** (useful when printing or exporting to PDF):
+
+```html
+<div style="page-break-after: always;"></div>
+```
+
+To **center text**:
+
+```html
+<div style="text-align: center;">
+  This text will be centered.
+</div>
+```
+
 ## <a name="markdown-pane"></a>The Markdown Preference Pane
 
 This is where I keep all preferences related to how I parse markdown into html.  


### PR DESCRIPTION
## Summary

- Adds an **Inline HTML** section to The Basics in `help.md`, placed after Horizontal Rules
- Explains that Markdown passes raw HTML through to the rendered output
- Provides page breaks and text centering as concrete examples (code-only, no live examples)

## Related Issue

Related to #345

## Manual Testing Plan

Open `help.md` in MacDown 3000 and verify:
1. The new "Inline HTML" section appears in The Basics, after Horizontal Rules
2. The two code blocks render correctly
3. The section appears in the preview at the expected location in the document flow