### PR TITLE
Fix scroll sync jump bug during typing (Issue #342)

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -195,6 +195,14 @@ typedef NS_ENUM(NSUInteger, MPWordCountType) {
     MPWordCountTypeCharacterNoSpaces,
 };
 
+// Issue #342: Scroll ownership model — replaces four boolean flags.
+// Controls which pane is authoritative for the current scroll operation.
+typedef NS_ENUM(NSUInteger, MPScrollOwner) {
+    MPScrollOwnerEditor  = 0,  // Editor is authoritative; preview follows
+    MPScrollOwnerPreview = 1,  // User is live-scrolling preview; editor follows
+    MPScrollOwnerNeither = 2,  // Quiescent; sync in either direction is valid
+};
+
 @property (weak) IBOutlet NSToolbar *toolbar;
 @property (weak) IBOutlet MPDocumentSplitView *splitView;
 @property (weak) IBOutlet NSView *editorContainer;
@@ -209,8 +217,6 @@ typedef NS_ENUM(NSUInteger, MPWordCountType) {
 @property CGFloat previousSplitRatio;
 @property BOOL manualRender;
 @property BOOL printing;
-@property BOOL shouldHandleBoundsChange;
-@property BOOL shouldHandlePreviewBoundsChange;
 @property BOOL isPreviewReady;
 @property (strong) NSURL *currentBaseUrl;
 @property (copy) NSString *currentStyleName;
@@ -228,8 +234,7 @@ typedef NS_ENUM(NSUInteger, MPWordCountType) {
 @property (nonatomic) BOOL renderToWebPending;
 @property (strong) NSArray<NSNumber *> *webViewHeaderLocations;
 @property (strong) NSArray<NSNumber *> *editorHeaderLocations;
-@property (nonatomic) BOOL inLiveScroll;
-@property (nonatomic) BOOL inEditing;  // Issue #282: Track active editing to prevent scroll jumping
+@property (nonatomic) MPScrollOwner scrollOwner;  // Issue #342: Scroll ownership model
 @property (strong) NSOperationQueue *wordCountUpdateQueue;  // Issue #294: Debounced word count updates
 
 // Issue #290: File watching for auto-reload
@@ -253,7 +258,8 @@ typedef NS_ENUM(NSUInteger, MPWordCountType) {
 - (void)syncScrollersReverse;
 - (void)updateHeaderLocations;
 - (void)invokeRenderCompletionHandlers;
-- (void)performDelayedSyncScrollers;  // Issue #282: Delayed sync after editing
+- (void)willStartPreviewLiveScroll:(NSNotification *)notification;
+- (void)didEndPreviewLiveScroll:(NSNotification *)notification;
 
 @end
 
@@ -272,8 +278,10 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
         [weakObj scaleWebview];
 
-        // If sync scrolling is enabled, refine position based on current editor scroll
-        if (weakObj.preferences.editorSyncScrolling)
+        // Issue #342: Only sync if editor is not currently authoritative.
+        // A full reload during active typing must not overwrite the editor's position.
+        if (weakObj.preferences.editorSyncScrolling
+            && weakObj.scrollOwner != MPScrollOwnerEditor)
         {
             [weakObj updateHeaderLocations];
             [weakObj syncScrollers];
@@ -392,8 +400,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         return nil;
 
     self.isPreviewReady = NO;
-    self.shouldHandleBoundsChange = YES;
-    self.shouldHandlePreviewBoundsChange = YES;
+    _scrollOwner = MPScrollOwnerNeither;
     self.previousSplitRatio = -1.0;
     
     return self;
@@ -480,6 +487,13 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     [center addObserver:self selector:@selector(didEndLiveScroll:)
                    name:NSScrollViewDidEndLiveScrollNotification
                  object:self.editor.enclosingScrollView];
+    // Issue #342: Observers for preview live-scroll ownership model
+    [center addObserver:self selector:@selector(willStartPreviewLiveScroll:)
+                   name:NSScrollViewWillStartLiveScrollNotification
+                 object:self.preview.enclosingScrollView];
+    [center addObserver:self selector:@selector(didEndPreviewLiveScroll:)
+                   name:NSScrollViewDidEndLiveScrollNotification
+                 object:self.preview.enclosingScrollView];
     if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber10_9)
     {
         [center addObserver:self selector:@selector(previewDidLiveScroll:)
@@ -549,12 +563,6 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         // Close can be called multiple times, but this can only be done once.
         // http://www.cocoabuilder.com/archive/cocoa/240166-nsdocument-close-method-calls-itself.html
         self.needsToUnregister = NO;
-
-        // Issue #282: Cancel any pending delayed sync to prevent crash if document
-        // is closed while editing (within 200ms of last keystroke).
-        [NSObject cancelPreviousPerformRequestsWithTarget:self
-                                                 selector:@selector(performDelayedSyncScrollers)
-                                                   object:nil];
 
         // Issue #294: Cancel any pending word count updates
         [self.wordCountUpdateQueue cancelAllOperations];
@@ -1346,17 +1354,13 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
                     MPMathJaxListener *listener = [[MPMathJaxListener alloc] init];
                     __weak MPDocument *weakSelf = self;
                     [listener addCallback:^{
-                        [weakSelf updateHeaderLocations];
-                        // Issue #342: Skip sync during active editing to prevent
-                        // scroll jumping after MathJax typesetting completes.
-                        if (weakSelf.preferences.editorSyncScrolling
-                            && !weakSelf.inEditing)
+                        // Issue #342: Sync at render completion, then transition ownership to Neither.
+                        if (weakSelf.preferences.editorSyncScrolling)
                         {
+                            [weakSelf updateHeaderLocations];
                             [weakSelf syncScrollers];
                         }
-                        CGFloat newScrollY = NSMinY(
-                            weakSelf.preview.enclosingScrollView.contentView.bounds);
-                        weakSelf.lastPreviewScrollTop = newScrollY;
+                        weakSelf->_scrollOwner = MPScrollOwnerNeither;
                     } forKey:@"DOMReplacementDone"];
                     [self.preview.windowScriptObject setValue:listener
                                                       forKey:@"MathJaxListener"];
@@ -1364,11 +1368,18 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
                 [context evaluateScript:updateScript];
 
-                // Save scroll position for non-MathJax DOM replacement.
-                // MathJax case is handled in the completion callback above.
+                // Issue #342: For non-MathJax, sync at render completion and
+                // transition ownership to Neither. The deferred window.scrollTo
+                // notification will arrive while scrollOwner is Editor (if user
+                // typed again) or Neither (if not) — both suppress syncScrollersReverse.
                 if (!self.preferences.htmlMathJax)
                 {
-                    self.lastPreviewScrollTop = scrollBefore;
+                    if (self.preferences.editorSyncScrolling)
+                    {
+                        [self updateHeaderLocations];
+                        [self syncScrollers];
+                    }
+                    _scrollOwner = MPScrollOwnerNeither;
                 }
 
                 // Mark rendering as complete so next edit will be processed
@@ -1421,18 +1432,10 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     if (self.needsHtml)
         [self.renderer parseAndRenderLater];
 
-    // Issue #282: Mark editing state to prevent scroll jumping during typing.
-    // Schedule delayed sync to run after editing pauses.
+    // Issue #342: Claim editor ownership so that deferred WebKit notifications
+    // from DOM replacement do not trigger syncScrollersReverse while typing.
     if (self.preferences.editorSyncScrolling)
-    {
-        _inEditing = YES;
-        [NSObject cancelPreviousPerformRequestsWithTarget:self
-                                                 selector:@selector(performDelayedSyncScrollers)
-                                                   object:nil];
-        [self performSelector:@selector(performDelayedSyncScrollers)
-                   withObject:nil
-                   afterDelay:0.2];
-    }
+        _scrollOwner = MPScrollOwnerEditor;
 }
 
 - (void)userDefaultsDidChange:(NSNotification *)notification
@@ -1464,31 +1467,43 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 - (void)willStartLiveScroll:(NSNotification *)notification
 {
     [self updateHeaderLocations];
-    _inLiveScroll = YES;
 }
 
 -(void)didEndLiveScroll:(NSNotification *)notification
 {
-    _inLiveScroll = NO;
+    // No ownership change needed: editor live-scroll runs while scrollOwner == Neither,
+    // and editorBoundsDidChange: handles syncing in that state.
+}
+
+// Issue #342: Preview live-scroll handlers for ownership model (Gap 1).
+
+- (void)willStartPreviewLiveScroll:(NSNotification *)notification
+{
+    // Update header locations before claiming ownership so that
+    // syncScrollersReverse (called at end of live-scroll) uses current positions.
+    [self updateHeaderLocations];
+    _scrollOwner = MPScrollOwnerPreview;
+}
+
+- (void)didEndPreviewLiveScroll:(NSNotification *)notification
+{
+    // Perform one final reverse sync at scroll-end, then return to quiescent state.
+    if (self.preferences.editorSyncScrolling)
+        [self syncScrollersReverse];
+    _scrollOwner = MPScrollOwnerNeither;
 }
 
 - (void)editorBoundsDidChange:(NSNotification *)notification
 {
-    if (!self.shouldHandleBoundsChange)
+    // Issue #342: Only sync in quiescent state. Editor ownership means the render
+    // pipeline is active (typing); preview ownership means the user is live-scrolling
+    // the preview. Both cases must not trigger forward sync here.
+    if (_scrollOwner != MPScrollOwnerNeither)
         return;
 
     if (self.preferences.editorSyncScrolling)
     {
-        @synchronized(self) {
-            self.shouldHandleBoundsChange = NO;
-            // Issue #282: Skip sync during active editing to prevent scroll jumping.
-            // The sync will be performed after editing pauses via performDelayedSyncScrollers.
-            if (!_inLiveScroll && !_inEditing) {
-                [self updateHeaderLocations];
-                [self syncScrollers];
-            }
-            self.shouldHandleBoundsChange = YES;
-        }
+        [self syncScrollers];
     }
 }
 
@@ -1514,25 +1529,16 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 - (void)previewBoundsDidChange:(NSNotification *)notification
 {
-    if (!self.shouldHandlePreviewBoundsChange)
+    // Issue #342: Only trigger reverse sync when the user is explicitly scrolling
+    // the preview. Editor ownership and Neither ownership both suppress this to
+    // prevent deferred WebKit notifications (from DOM replacement window.scrollTo)
+    // from causing the editor to jump.
+    if (_scrollOwner != MPScrollOwnerPreview)
         return;
 
     if (self.preferences.editorSyncScrolling)
     {
-        @synchronized(self) {
-            self.shouldHandlePreviewBoundsChange = NO;
-            // Issue #342: Skip reverse sync during active editing to prevent
-            // scroll jumping. When typing triggers a preview re-render, the DOM
-            // replacement's window.scrollTo() fires this notification. Without
-            // this guard, syncScrollersReverse moves the editor to the wrong
-            // position. The sync will happen after editing pauses via
-            // performDelayedSyncScrollers.
-            if (!_inLiveScroll && !_inEditing) {
-                [self updateHeaderLocations];
-                [self syncScrollersReverse];
-            }
-            self.shouldHandlePreviewBoundsChange = YES;
-        }
+        [self syncScrollersReverse];
     }
 }
 
@@ -2202,7 +2208,6 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
  */
 -(void) updateHeaderLocations
 {
-    CGFloat offset = NSMinY(self.preview.enclosingScrollView.contentView.bounds);
     NSMutableArray<NSNumber *> *locations = [NSMutableArray array];
 
     // Load JavaScript from resource file for better maintainability
@@ -2215,20 +2220,15 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         }
     });
 
+    // Issue #342 (Bug B): JS now returns document-absolute coordinates via
+    // window.scrollY + rect.top. No ObjC-side offset correction is needed.
     if (script) {
         _webViewHeaderLocations = [[self.preview.mainFrame.javaScriptContext evaluateScript:script] toArray];
     } else {
         _webViewHeaderLocations = @[];
     }
 
-    // add offset to all numbers
-    for (NSNumber *location in _webViewHeaderLocations)
-    {
-        [locations addObject:@([location floatValue] + offset)];
-    }
 
-    _webViewHeaderLocations = [locations copy];
-    
 
     // Next, cache the locations of all of the reference nodes in the editor view.
     NSInteger characterCount = 0;
@@ -2280,9 +2280,6 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     //   2. If no previous content OR current line matches HR pattern
     //      → It's a horizontal rule (or standalone dashes)
     BOOL previousLineHadContent = NO;
-    
-    CGFloat editorContentHeight = ceilf(NSHeight(self.editor.enclosingScrollView.documentView.bounds));
-    CGFloat editorVisibleHeight = ceilf(NSHeight(self.editor.enclosingScrollView.contentView.bounds));
 
     // We start by splitting our document into lines, and then searching
     // line by line for headers or images.
@@ -2315,9 +2312,11 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             NSRect topRect = [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:[self.editor textContainer]];
             CGFloat headerY = NSMidY(topRect);
 
-            if(headerY <= editorContentHeight - editorVisibleHeight){
-                [locations addObject:@(headerY)];
-            }
+            // Issue #342 (Bug D): Add all headers unconditionally to keep
+            // _editorHeaderLocations and _webViewHeaderLocations aligned.
+            // The runtime filters in syncScrollers/syncScrollersReverse already
+            // handle end-of-document interpolation.
+            [locations addObject:@(headerY)];
         }
 
         // Update previousLineHadContent flag for next iteration.
@@ -2333,41 +2332,6 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     }
 
     _editorHeaderLocations = [locations copy];
-}
-
-/**
- * Issue #282: Perform delayed scroll synchronization after editing pauses.
- *
- * This method is called 200ms after the last text change to synchronize
- * the preview pane with the editor position. The delay allows the layout
- * to stabilize after typing, preventing the editor from jumping during
- * active editing.
- */
-- (void)performDelayedSyncScrollers
-{
-    // Issue #282: DON'T clear _inEditing here - wait until after sync completes
-
-    if (!self.preferences.editorSyncScrolling)
-    {
-        _inEditing = NO;
-        return;
-    }
-
-    if (!_inLiveScroll)
-    {
-        @synchronized(self) {
-            // Issue #282: Guard BOTH bounds change handlers to prevent cascade
-            self.shouldHandleBoundsChange = NO;
-            self.shouldHandlePreviewBoundsChange = NO;
-            [self updateHeaderLocations];
-            [self syncScrollers];
-            self.shouldHandleBoundsChange = YES;
-            self.shouldHandlePreviewBoundsChange = YES;
-        }
-    }
-
-    // Issue #282: Clear editing flag AFTER sync block completes
-    _inEditing = NO;
 }
 
 /**
@@ -2462,10 +2426,10 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     NSRect contentBounds = self.preview.enclosingScrollView.contentView.bounds;
     contentBounds.origin.y = previewY;
 
-    // Prevent reverse sync from triggering while we programmatically scroll preview
-    self.shouldHandlePreviewBoundsChange = NO;
+    // Issue #342: No flag toggles needed — previewBoundsDidChange: is guarded
+    // by scrollOwner != MPScrollOwnerPreview, which suppresses the synchronous
+    // NSViewBoundsDidChangeNotification fired by this bounds assignment.
     self.preview.enclosingScrollView.contentView.bounds = contentBounds;
-    self.shouldHandlePreviewBoundsChange = YES;
 
     // Save this scroll position so it persists across preview refreshes
     self.lastPreviewScrollTop = previewY;
@@ -2561,10 +2525,11 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     NSRect contentBounds = self.editor.enclosingScrollView.contentView.bounds;
     contentBounds.origin.y = editorY;
 
-    // Prevent forward sync from triggering while we programmatically scroll editor
-    self.shouldHandleBoundsChange = NO;
+    // Issue #342: No flag toggles needed — editorBoundsDidChange: is guarded
+    // by scrollOwner == MPScrollOwnerNeither, which suppresses the synchronous
+    // NSViewBoundsDidChangeNotification fired by this bounds assignment
+    // (scroll owner is Preview while this runs).
     self.editor.enclosingScrollView.contentView.bounds = contentBounds;
-    self.shouldHandleBoundsChange = YES;
 }
 
 - (void)setSplitViewDividerLocation:(CGFloat)ratio

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1355,7 +1355,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
                     __weak MPDocument *weakSelf = self;
                     [listener addCallback:^{
                         // Issue #342: Sync at render completion, then transition ownership to Neither.
-                        typeof(self) strongSelf = weakSelf;
+                        __strong typeof(weakSelf) strongSelf = weakSelf;
                         if (!strongSelf)
                             return;
                         if (strongSelf.preferences.editorSyncScrolling)

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1355,12 +1355,15 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
                     __weak MPDocument *weakSelf = self;
                     [listener addCallback:^{
                         // Issue #342: Sync at render completion, then transition ownership to Neither.
-                        if (weakSelf.preferences.editorSyncScrolling)
+                        typeof(self) strongSelf = weakSelf;
+                        if (!strongSelf)
+                            return;
+                        if (strongSelf.preferences.editorSyncScrolling)
                         {
-                            [weakSelf updateHeaderLocations];
-                            [weakSelf syncScrollers];
+                            [strongSelf updateHeaderLocations];
+                            [strongSelf syncScrollers];
                         }
-                        weakSelf->_scrollOwner = MPScrollOwnerNeither;
+                        strongSelf->_scrollOwner = MPScrollOwnerNeither;
                     } forKey:@"DOMReplacementDone"];
                     [self.preview.windowScriptObject setValue:listener
                                                       forKey:@"MathJaxListener"];
@@ -1432,10 +1435,10 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     if (self.needsHtml)
         [self.renderer parseAndRenderLater];
 
-    // Issue #342: Claim editor ownership so that deferred WebKit notifications
-    // from DOM replacement do not trigger syncScrollersReverse while typing.
-    if (self.preferences.editorSyncScrolling)
-        _scrollOwner = MPScrollOwnerEditor;
+    // Issue #342: Claim editor ownership unconditionally so that deferred WebKit
+    // notifications from DOM replacement do not trigger syncScrollersReverse
+    // while typing. Sync calls are separately gated by the pref.
+    _scrollOwner = MPScrollOwnerEditor;
 }
 
 - (void)userDefaultsDidChange:(NSNotification *)notification

--- a/MacDown/Resources/updateHeaderLocations.js
+++ b/MacDown/Resources/updateHeaderLocations.js
@@ -72,11 +72,12 @@
             return 0;  // Same node or disconnected
         });
 
-        // Return y-coordinates (viewport-relative) for all reference points.
+        // Return y-coordinates (document-absolute) for all reference points.
+        // Uses window.scrollY + rect.top so the result is independent of current scroll position.
         // No pre-filtering - the syncScrollers algorithm handles end-of-document cases.
         return result.map(function(item) {
             var rect = item.node.getBoundingClientRect();
-            return rect.top;
+            return window.scrollY + rect.top;
         });
     } catch (e) {
         return [];

--- a/MacDownTests/MPScrollSyncTests.m
+++ b/MacDownTests/MPScrollSyncTests.m
@@ -12,20 +12,26 @@
 #import "MPDocument.h"
 #import "MPPreferences.h"
 
+// Issue #342: Scroll ownership enum constants (must match MPScrollOwner in MPDocument.m)
+static const NSUInteger MPScrollOwnerEditor  = 0;
+static const NSUInteger MPScrollOwnerPreview = 1;
+static const NSUInteger MPScrollOwnerNeither = 2;
+
 // Category to expose private properties/methods for testing
 @interface MPDocument (ScrollSyncTesting)
 @property (nonatomic) CGFloat lastPreviewScrollTop;
 @property (strong) NSArray<NSNumber *> *webViewHeaderLocations;
 @property (strong) NSArray<NSNumber *> *editorHeaderLocations;
 @property (weak) WebView *preview;
-@property BOOL shouldHandleBoundsChange;
-@property BOOL shouldHandlePreviewBoundsChange;
-@property (nonatomic) BOOL inEditing;  // Issue #282: Track active editing state
+@property (nonatomic) NSUInteger scrollOwner;  // Issue #342: MPScrollOwner enum
 - (void)updateHeaderLocations;
 - (void)syncScrollers;
 - (void)syncScrollersReverse;
-- (void)performDelayedSyncScrollers;  // Issue #282: Delayed sync after editing
-- (void)previewBoundsDidChange:(NSNotification *)notification;  // Issue #342
+- (void)editorTextDidChange:(NSNotification *)notification;
+- (void)previewBoundsDidChange:(NSNotification *)notification;
+- (void)editorBoundsDidChange:(NSNotification *)notification;
+- (void)willStartPreviewLiveScroll:(NSNotification *)notification;
+- (void)didEndPreviewLiveScroll:(NSNotification *)notification;
 @end
 
 @interface MPScrollSyncTests : XCTestCase
@@ -1091,43 +1097,6 @@
 }
 
 /**
- * Test that shouldHandlePreviewBoundsChange property is initialized correctly.
- * Regression test for Issue #258 - loop prevention flag.
- */
-- (void)testPreviewBoundsChangeFlagInitialized
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-    XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
-                  @"shouldHandlePreviewBoundsChange should be YES by default");
-}
-
-/**
- * Test that both loop prevention flags are independent.
- * Regression test for Issue #258 - ensures bidirectional sync doesn't loop.
- */
-- (void)testLoopPreventionFlagsAreIndependent
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-
-    // Initially both should be YES
-    XCTAssertTrue(doc.shouldHandleBoundsChange,
-                  @"shouldHandleBoundsChange should be YES initially");
-    XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
-                  @"shouldHandlePreviewBoundsChange should be YES initially");
-
-    // Setting one should not affect the other
-    doc.shouldHandleBoundsChange = NO;
-    XCTAssertFalse(doc.shouldHandleBoundsChange,
-                   @"shouldHandleBoundsChange should be NO after setting");
-    XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
-                  @"shouldHandlePreviewBoundsChange should still be YES");
-
-    doc.shouldHandlePreviewBoundsChange = NO;
-    XCTAssertFalse(doc.shouldHandlePreviewBoundsChange,
-                   @"shouldHandlePreviewBoundsChange should be NO after setting");
-}
-
-/**
  * Test that syncScrollersReverse handles empty header locations gracefully.
  * Regression test for Issue #258 - edge case handling.
  */
@@ -1201,284 +1170,6 @@
                      @"syncScrollersReverse should handle many headers");
 }
 
-#pragma mark - Issue #282: Editing State Tests
-
-/**
- * Test that inEditing property is initialized to NO.
- * Issue #282: Editing state should be NO by default.
- */
-- (void)testInEditingInitializedToNo
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-    XCTAssertFalse(doc.inEditing,
-                   @"inEditing should be NO by default");
-}
-
-/**
- * Test that performDelayedSyncScrollers method exists and doesn't crash.
- * Issue #282: Delayed sync method should exist.
- */
-- (void)testPerformDelayedSyncScrollersExists
-{
-    XCTAssertNoThrow([self.document performDelayedSyncScrollers],
-                     @"performDelayedSyncScrollers should exist and not crash");
-}
-
-/**
- * Test that performDelayedSyncScrollers clears inEditing flag.
- * Issue #282: Delayed sync should reset editing state.
- */
-- (void)testPerformDelayedSyncScrollersClearsInEditing
-{
-    self.document.inEditing = YES;
-    XCTAssertTrue(self.document.inEditing, @"inEditing should be YES before test");
-
-    [self.document performDelayedSyncScrollers];
-
-    XCTAssertFalse(self.document.inEditing,
-                   @"performDelayedSyncScrollers should set inEditing to NO");
-}
-
-/**
- * Test that inEditing flag can be set and read.
- * Issue #282: Editing state should be settable.
- */
-- (void)testInEditingFlagCanBeToggled
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-
-    doc.inEditing = YES;
-    XCTAssertTrue(doc.inEditing, @"inEditing should be YES after setting to YES");
-
-    doc.inEditing = NO;
-    XCTAssertFalse(doc.inEditing, @"inEditing should be NO after setting to NO");
-}
-
-/**
- * Test that performDelayedSyncScrollers handles empty header locations.
- * Issue #282: Delayed sync should handle edge cases.
- */
-- (void)testPerformDelayedSyncScrollersWithEmptyLocations
-{
-    self.document.webViewHeaderLocations = @[];
-    self.document.editorHeaderLocations = @[];
-    self.document.inEditing = YES;
-
-    XCTAssertNoThrow([self.document performDelayedSyncScrollers],
-                     @"performDelayedSyncScrollers should handle empty header locations");
-    XCTAssertFalse(self.document.inEditing,
-                   @"inEditing should be NO after performDelayedSyncScrollers");
-}
-
-/**
- * Test that performDelayedSyncScrollers handles nil header locations.
- * Issue #282: Delayed sync should handle nil safely.
- */
-- (void)testPerformDelayedSyncScrollersWithNilLocations
-{
-    self.document.webViewHeaderLocations = nil;
-    self.document.editorHeaderLocations = nil;
-    self.document.inEditing = YES;
-
-    XCTAssertNoThrow([self.document performDelayedSyncScrollers],
-                     @"performDelayedSyncScrollers should handle nil header locations");
-    XCTAssertFalse(self.document.inEditing,
-                   @"inEditing should be NO after performDelayedSyncScrollers");
-}
-
-/**
- * Test that inEditing and shouldHandleBoundsChange are independent.
- * Issue #282: Editing state should not affect loop prevention flags.
- */
-- (void)testInEditingIndependentFromBoundsChangeFlag
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-
-    // Initially both should have their default values
-    XCTAssertFalse(doc.inEditing, @"inEditing should be NO initially");
-    XCTAssertTrue(doc.shouldHandleBoundsChange, @"shouldHandleBoundsChange should be YES initially");
-
-    // Setting inEditing should not affect shouldHandleBoundsChange
-    doc.inEditing = YES;
-    XCTAssertTrue(doc.inEditing, @"inEditing should be YES after setting");
-    XCTAssertTrue(doc.shouldHandleBoundsChange,
-                  @"shouldHandleBoundsChange should still be YES");
-
-    // Setting shouldHandleBoundsChange should not affect inEditing
-    doc.shouldHandleBoundsChange = NO;
-    XCTAssertTrue(doc.inEditing, @"inEditing should still be YES");
-    XCTAssertFalse(doc.shouldHandleBoundsChange,
-                   @"shouldHandleBoundsChange should be NO after setting");
-}
-
-/**
- * Test that pending performDelayedSyncScrollers is cancelled on document close.
- * Issue #282: Prevents crash from message to deallocated object when document
- * is closed during active editing (within 200ms of last keystroke).
- */
-- (void)testPendingDelayedSyncCancelledOnClose
-{
-    // This test verifies the close method properly cancels pending selectors
-    // to prevent crashes when document is closed during editing.
-    // Note: In headless tests the document may not have full window setup,
-    // but the cancel call should still execute without crashing.
-    MPDocument *doc = [[MPDocument alloc] init];
-    doc.inEditing = YES;  // Simulate editing state
-    XCTAssertNoThrow([doc close], @"close should not crash with pending delayed sync");
-}
-
-#pragma mark - Issue #282: Cascade Prevention Tests
-
-/**
- * Test that performDelayedSyncScrollers sets both bounds change guards.
- * Issue #282: Both guards must be set to prevent cascade effect.
- * The guards should be YES after the method completes (restored state).
- */
-- (void)testPerformDelayedSyncScrollersSetsPreviewBoundsGuard
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-
-    // Both guards should be YES initially
-    XCTAssertTrue(doc.shouldHandleBoundsChange,
-                  @"shouldHandleBoundsChange should be YES initially");
-    XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
-                  @"shouldHandlePreviewBoundsChange should be YES initially");
-
-    // After performDelayedSyncScrollers, both guards should still be YES
-    // (they're set to NO during sync, then restored to YES)
-    [doc performDelayedSyncScrollers];
-
-    XCTAssertTrue(doc.shouldHandleBoundsChange,
-                  @"shouldHandleBoundsChange should be YES after sync completes");
-    XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
-                  @"shouldHandlePreviewBoundsChange should be YES after sync completes");
-}
-
-/**
- * Test that inEditing is cleared AFTER sync operations complete.
- * Issue #282: Clearing inEditing before sync causes cascade.
- */
-- (void)testInEditingClearedAfterSync
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-    doc.inEditing = YES;
-
-    // After performDelayedSyncScrollers, inEditing should be NO
-    [doc performDelayedSyncScrollers];
-
-    XCTAssertFalse(doc.inEditing,
-                   @"inEditing should be NO after performDelayedSyncScrollers completes");
-}
-
-/**
- * Test that syncScrollers doesn't crash when both guards are already NO.
- * Issue #282: Edge case where guards might be set by outer scope.
- */
-- (void)testSyncScrollersWithGuardsAlreadySet
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-
-    // Simulate outer scope setting guards
-    doc.shouldHandleBoundsChange = NO;
-    doc.shouldHandlePreviewBoundsChange = NO;
-
-    // syncScrollers should not crash
-    XCTAssertNoThrow([doc syncScrollers],
-                     @"syncScrollers should not crash when guards are already NO");
-
-    // Guards should still be NO (syncScrollers sets them internally but we set them first)
-    // Actually, syncScrollers will set shouldHandlePreviewBoundsChange = YES at the end
-    // This tests that the method runs without crashing
-}
-
-/**
- * Test that syncScrollersReverse doesn't crash when both guards are already NO.
- * Issue #282: Edge case where guards might be set by outer scope.
- */
-- (void)testSyncScrollersReverseWithGuardsAlreadySet
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-
-    // Simulate outer scope setting guards
-    doc.shouldHandleBoundsChange = NO;
-    doc.shouldHandlePreviewBoundsChange = NO;
-
-    // syncScrollersReverse should not crash
-    XCTAssertNoThrow([doc syncScrollersReverse],
-                     @"syncScrollersReverse should not crash when guards are already NO");
-}
-
-/**
- * Test that cascade prevention works with rapid sync calls.
- * Issue #282: Simulates rapid editing scenario.
- */
-- (void)testRapidSyncCallsDoNotCrash
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-    doc.markdown = @"# Header 1\n\n## Header 2\n\n### Header 3";
-
-    // Simulate rapid sync calls (like rapid typing)
-    for (int i = 0; i < 10; i++) {
-        doc.inEditing = YES;
-        [doc performDelayedSyncScrollers];
-    }
-
-    XCTAssertFalse(doc.inEditing,
-                   @"inEditing should be NO after rapid sync calls");
-    XCTAssertTrue(doc.shouldHandleBoundsChange,
-                  @"shouldHandleBoundsChange should be YES after rapid sync calls");
-    XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
-                  @"shouldHandlePreviewBoundsChange should be YES after rapid sync calls");
-}
-
-/**
- * Test that guards are properly restored even if sync throws.
- * Issue #282: Guards should be restored in all code paths.
- */
-- (void)testGuardsRestoredAfterSyncWithNilLocations
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-
-    // Set up nil locations (edge case)
-    doc.webViewHeaderLocations = nil;
-    doc.editorHeaderLocations = nil;
-    doc.inEditing = YES;
-
-    // performDelayedSyncScrollers should complete without crashing
-    XCTAssertNoThrow([doc performDelayedSyncScrollers],
-                     @"performDelayedSyncScrollers should handle nil locations");
-
-    // Guards should be restored
-    XCTAssertTrue(doc.shouldHandleBoundsChange,
-                  @"shouldHandleBoundsChange should be YES after sync with nil locations");
-    XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
-                  @"shouldHandlePreviewBoundsChange should be YES after sync with nil locations");
-    XCTAssertFalse(doc.inEditing,
-                   @"inEditing should be NO after sync with nil locations");
-}
-
-/**
- * Test that alternating sync calls maintain correct guard state.
- * Issue #282: Regression test for ping-pong effect.
- */
-- (void)testAlternatingSyncCallsMaintainGuardState
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-    doc.webViewHeaderLocations = @[@(100), @(200), @(300)];
-    doc.editorHeaderLocations = @[@(50), @(100), @(150)];
-
-    // Alternate between forward and reverse sync
-    for (int i = 0; i < 5; i++) {
-        [doc syncScrollers];
-        XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
-                      @"shouldHandlePreviewBoundsChange should be YES after syncScrollers");
-
-        [doc syncScrollersReverse];
-        XCTAssertTrue(doc.shouldHandleBoundsChange,
-                      @"shouldHandleBoundsChange should be YES after syncScrollersReverse");
-    }
-}
-
 #pragma mark - Code Fence Edge Case Tests
 
 /**
@@ -1546,73 +1237,485 @@
                      @"updateHeaderLocations should handle four backticks without crashing");
 }
 
-#pragma mark - Issue #342: Preview bounds change during editing
+#pragma mark - Issue #342: Group A — Ownership State Machine
 
 /**
- * Test that previewBoundsDidChange: does NOT call syncScrollersReverse when
- * _inEditing is YES. This is the primary fix for issue #342: preview scroll
- * restoration during DOM replacement was feeding back into the editor via
- * syncScrollersReverse, causing the editor to jump.
- *
- * We verify indirectly: shouldHandleBoundsChange on the editor side should
- * remain untouched (syncScrollersReverse temporarily sets it to NO then YES).
- * If syncScrollersReverse is skipped, shouldHandleBoundsChange stays at its
- * initial value throughout.
+ * A1 — Initial scrollOwner is MPScrollOwnerNeither (2).
+ * Issue #342: Document starts in quiescent state.
  */
-- (void)testPreviewBoundsDidChangeSkipsSyncWhenInEditing
+- (void)testScrollOwnerInitializedToNeither
 {
     MPDocument *doc = [[MPDocument alloc] init];
-    doc.shouldHandlePreviewBoundsChange = YES;
-    doc.shouldHandleBoundsChange = YES;
-    doc.inEditing = YES;
-
-    // Simulate a preview bounds change notification (as would be triggered by
-    // window.scrollTo() during DOM replacement)
-    [doc previewBoundsDidChange:nil];
-
-    // shouldHandleBoundsChange should be untouched because syncScrollersReverse
-    // was never called (it temporarily toggles this flag)
-    XCTAssertTrue(doc.shouldHandleBoundsChange,
-                  @"shouldHandleBoundsChange should remain YES when inEditing prevents reverse sync");
-    XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
-                  @"shouldHandlePreviewBoundsChange should be restored to YES after handler completes");
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerNeither,
+                   @"scrollOwner should be MPScrollOwnerNeither (2) at init");
 }
 
 /**
- * Test that previewBoundsDidChange: DOES call syncScrollersReverse when
- * _inEditing is NO. This ensures the guard doesn't over-suppress —
- * user-initiated preview scrolling should still sync back to the editor.
+ * A2 — editorTextDidChange: sets scrollOwner to MPScrollOwnerEditor.
+ * Issue #342: Typing must claim editor ownership.
  */
-- (void)testPreviewBoundsDidChangeSyncsWhenNotInEditing
+- (void)testEditorTextDidChangeSetsEditorOwnership
 {
     MPDocument *doc = [[MPDocument alloc] init];
-    doc.shouldHandlePreviewBoundsChange = YES;
-    doc.shouldHandleBoundsChange = YES;
-    doc.inEditing = NO;
+    doc.scrollOwner = MPScrollOwnerNeither;
 
-    // Should not crash; syncScrollersReverse should be called
-    XCTAssertNoThrow([doc previewBoundsDidChange:nil],
-                     @"previewBoundsDidChange: should work normally when not in editing");
-    XCTAssertTrue(doc.shouldHandlePreviewBoundsChange,
-                  @"shouldHandlePreviewBoundsChange should be restored to YES");
+    [doc editorTextDidChange:nil];
+
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerEditor,
+                   @"editorTextDidChange: should set scrollOwner to MPScrollOwnerEditor (0)");
 }
 
 /**
- * Test that previewBoundsDidChange: respects the shouldHandlePreviewBoundsChange
- * guard even when inEditing is NO. This verifies the early-return path.
+ * A3 — willStartPreviewLiveScroll: sets scrollOwner to MPScrollOwnerPreview.
+ * Issue #342: User-initiated preview scroll must claim preview ownership.
  */
-- (void)testPreviewBoundsDidChangeRespectsGuardFlag
+- (void)testWillStartPreviewLiveScrollSetsPreviewOwnership
 {
     MPDocument *doc = [[MPDocument alloc] init];
-    doc.shouldHandlePreviewBoundsChange = NO;
-    doc.shouldHandleBoundsChange = YES;
-    doc.inEditing = NO;
+    doc.scrollOwner = MPScrollOwnerNeither;
+
+    [doc willStartPreviewLiveScroll:nil];
+
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerPreview,
+                   @"willStartPreviewLiveScroll: should set scrollOwner to MPScrollOwnerPreview (1)");
+}
+
+/**
+ * A4 — didEndPreviewLiveScroll: resets scrollOwner to MPScrollOwnerNeither.
+ * Issue #342: End of live scroll returns to quiescent state.
+ */
+- (void)testDidEndPreviewLiveScrollResetsToNeither
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.scrollOwner = MPScrollOwnerPreview;
+
+    [doc didEndPreviewLiveScroll:nil];
+
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerNeither,
+                   @"didEndPreviewLiveScroll: should set scrollOwner to MPScrollOwnerNeither (2)");
+}
+
+/**
+ * A5 — Repeated editorTextDidChange: calls keep scrollOwner as MPScrollOwnerEditor.
+ * Issue #342: Multiple keystrokes must not change ownership away from Editor.
+ */
+- (void)testRepeatedEditorTextDidChangeStaysEditor
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    [doc editorTextDidChange:nil];
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerEditor,
+                   @"scrollOwner should be Editor after first call");
+
+    [doc editorTextDidChange:nil];
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerEditor,
+                   @"scrollOwner should remain Editor after second call");
+}
+
+/**
+ * A6 — editorTextDidChange: overrides MPScrollOwnerPreview.
+ * Issue #342: Typing while preview-owned must transfer ownership to editor.
+ */
+- (void)testEditorTextDidChangeOverridesPreviewOwnership
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.scrollOwner = MPScrollOwnerPreview;
+
+    [doc editorTextDidChange:nil];
+
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerEditor,
+                   @"editorTextDidChange: should override MPScrollOwnerPreview with MPScrollOwnerEditor");
+}
+
+#pragma mark - Issue #342: Group B — Guard Logic
+
+/**
+ * B1 — previewBoundsDidChange: is suppressed when scrollOwner is Editor.
+ * Issue #342: Deferred WebKit notification during editing must not trigger reverse sync.
+ */
+- (void)testPreviewBoundsDidChangeSuppressedDuringEditorOwnership
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.scrollOwner = MPScrollOwnerEditor;
+
+    // Must not crash; scrollOwner must remain Editor (reverse sync was suppressed)
+    XCTAssertNoThrow([doc previewBoundsDidChange:nil],
+                     @"previewBoundsDidChange: should not crash when scrollOwner is Editor");
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerEditor,
+                   @"scrollOwner should remain Editor after suppressed previewBoundsDidChange:");
+}
+
+/**
+ * B2 — previewBoundsDidChange: is passed through when scrollOwner is Preview.
+ * Issue #342: Live preview scroll must trigger reverse sync.
+ */
+- (void)testPreviewBoundsDidChangePassesDuringPreviewOwnership
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.scrollOwner = MPScrollOwnerPreview;
+    doc.webViewHeaderLocations = @[];
+    doc.editorHeaderLocations = @[];
 
     XCTAssertNoThrow([doc previewBoundsDidChange:nil],
-                     @"previewBoundsDidChange: should early-return when guard is NO");
-    // shouldHandlePreviewBoundsChange should remain NO (handler returned early)
-    XCTAssertFalse(doc.shouldHandlePreviewBoundsChange,
-                   @"shouldHandlePreviewBoundsChange should remain NO after early return");
+                     @"previewBoundsDidChange: should not crash when scrollOwner is Preview");
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerPreview,
+                   @"scrollOwner should remain Preview after previewBoundsDidChange: with Preview ownership");
+}
+
+/**
+ * B3 — editorBoundsDidChange: is suppressed when scrollOwner is Editor.
+ * Issue #342: Editor scroll during typing must not re-trigger forward sync.
+ */
+- (void)testEditorBoundsDidChangeSuppressedDuringEditorOwnership
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.scrollOwner = MPScrollOwnerEditor;
+
+    XCTAssertNoThrow([doc editorBoundsDidChange:nil],
+                     @"editorBoundsDidChange: should not crash when scrollOwner is Editor");
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerEditor,
+                   @"scrollOwner should remain Editor after suppressed editorBoundsDidChange:");
+}
+
+/**
+ * B4 — editorBoundsDidChange: is passed through when scrollOwner is Neither.
+ * Issue #342: Manual editor scroll in quiescent state must trigger forward sync.
+ */
+- (void)testEditorBoundsDidChangePassesDuringNeitherOwnership
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.scrollOwner = MPScrollOwnerNeither;
+    doc.webViewHeaderLocations = @[];
+    doc.editorHeaderLocations = @[];
+
+    XCTAssertNoThrow([doc editorBoundsDidChange:nil],
+                     @"editorBoundsDidChange: should not crash when scrollOwner is Neither");
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerNeither,
+                   @"scrollOwner should remain Neither after editorBoundsDidChange: with Neither ownership");
+}
+
+/**
+ * B5 — editorBoundsDidChange: is suppressed when scrollOwner is Preview.
+ * Issue #342: The guard is scrollOwner == MPScrollOwnerNeither, so Preview
+ * ownership must also suppress forward sync (not just Editor ownership).
+ */
+- (void)testEditorBoundsDidChangeSuppressedDuringPreviewOwnership
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.scrollOwner = MPScrollOwnerPreview;
+
+    XCTAssertNoThrow([doc editorBoundsDidChange:nil],
+                     @"editorBoundsDidChange: should not crash when scrollOwner is Preview");
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerPreview,
+                   @"scrollOwner should remain Preview after suppressed editorBoundsDidChange:");
+}
+
+#pragma mark - Issue #342: Group C — JS Coordinate Fix
+
+/**
+ * Helper: loads updateHeaderLocations.js source from the main bundle.
+ */
+- (NSString *)loadUpdateHeaderLocationsScript
+{
+    NSBundle *bundle = [NSBundle mainBundle];
+    NSString *path = [bundle pathForResource:@"updateHeaderLocations" ofType:@"js"];
+    if (!path) return nil;
+    return [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
+}
+
+/**
+ * Helper: constructs a JSContext with a mock DOM for testing the JS script.
+ * scrollY:      simulated window.scrollY
+ * headerTops:   array of NSNumber; each becomes a header with that rect.top
+ */
+- (JSContext *)jsContextWithScrollY:(CGFloat)scrollY headerTops:(NSArray<NSNumber *> *)headerTops
+{
+    JSContext *context = [[JSContext alloc] init];
+    context.exceptionHandler = ^(JSContext *ctx, JSValue *exception) { };
+
+    NSMutableString *headersJS = [NSMutableString stringWithString:@"["];
+    for (NSUInteger i = 0; i < headerTops.count; i++) {
+        CGFloat top = [headerTops[i] floatValue];
+        [headersJS appendFormat:
+            @"{getBoundingClientRect:function(){return {top:%g};}"
+            @",compareDocumentPosition:function(o){return 4;}"
+            @",tagName:'H1',parentElement:null}",
+            top];
+        if (i + 1 < headerTops.count) [headersJS appendString:@","];
+    }
+    [headersJS appendString:@"]"];
+
+    NSString *setup = [NSString stringWithFormat:
+        @"var window = {scrollY: %g};\n"
+        @"var Node = {DOCUMENT_POSITION_FOLLOWING: 4, DOCUMENT_POSITION_PRECEDING: 2};\n"
+        @"var _headers = %@;\n"
+        @"var document = {\n"
+        @"    body: {},\n"
+        @"    querySelectorAll: function(sel) {\n"
+        @"        if (sel === 'h1, h2, h3, h4, h5, h6') return _headers;\n"
+        @"        return [];\n"
+        @"    }\n"
+        @"};\n",
+        scrollY, headersJS];
+
+    [context evaluateScript:setup];
+    return context;
+}
+
+/**
+ * C1 — Scrolled page: result is window.scrollY + rect.top (document-absolute).
+ * Issue #342: After JS fix, header at viewport top 100 with scrollY 200 = 300.
+ */
+- (void)testJSHeaderLocationScrolledPage
+{
+    NSString *script = [self loadUpdateHeaderLocationsScript];
+    if (!script) {
+        XCTFail(@"updateHeaderLocations.js not found in bundle");
+        return;
+    }
+
+    JSContext *context = [self jsContextWithScrollY:200 headerTops:@[@100]];
+    JSValue *result = [context evaluateScript:script];
+    NSArray *locations = [result toArray];
+
+    XCTAssertEqual(locations.count, 1U, @"Should return one location");
+    XCTAssertEqualWithAccuracy([[locations firstObject] floatValue], 300.0, 0.5,
+                               @"Scrolled page: scrollY(200) + rect.top(100) should equal 300");
+}
+
+/**
+ * C2 — Unscrolled page: result equals rect.top directly.
+ * Issue #342: At scrollY=0, document-absolute equals viewport-relative.
+ */
+- (void)testJSHeaderLocationUnscrolledPage
+{
+    NSString *script = [self loadUpdateHeaderLocationsScript];
+    if (!script) {
+        XCTFail(@"updateHeaderLocations.js not found in bundle");
+        return;
+    }
+
+    JSContext *context = [self jsContextWithScrollY:0 headerTops:@[@150]];
+    JSValue *result = [context evaluateScript:script];
+    NSArray *locations = [result toArray];
+
+    XCTAssertEqual(locations.count, 1U, @"Should return one location");
+    XCTAssertEqualWithAccuracy([[locations firstObject] floatValue], 150.0, 0.5,
+                               @"Unscrolled page: scrollY(0) + rect.top(150) should equal 150");
+}
+
+/**
+ * C3 — Multiple headers: each gets scrollY added.
+ * Issue #342: All returned values must be document-absolute.
+ */
+- (void)testJSHeaderLocationsMultipleHeaders
+{
+    NSString *script = [self loadUpdateHeaderLocationsScript];
+    if (!script) {
+        XCTFail(@"updateHeaderLocations.js not found in bundle");
+        return;
+    }
+
+    JSContext *context = [[JSContext alloc] init];
+    context.exceptionHandler = ^(JSContext *ctx, JSValue *exception) { };
+
+    [context evaluateScript:
+        @"var window = {scrollY: 500};\n"
+        @"var Node = {DOCUMENT_POSITION_FOLLOWING: 4, DOCUMENT_POSITION_PRECEDING: 2};\n"
+        @"var h0 = {getBoundingClientRect:function(){return {top:50};},  tagName:'H1', parentElement:null,\n"
+        @"          compareDocumentPosition:function(o){return o===h1?4:(o===h2?4:0);}};\n"
+        @"var h1 = {getBoundingClientRect:function(){return {top:100};}, tagName:'H2', parentElement:null,\n"
+        @"          compareDocumentPosition:function(o){return o===h0?2:(o===h2?4:0);}};\n"
+        @"var h2 = {getBoundingClientRect:function(){return {top:300};}, tagName:'H3', parentElement:null,\n"
+        @"          compareDocumentPosition:function(o){return o===h0?2:(o===h1?2:0);}};\n"
+        @"var document = {\n"
+        @"    body: {},\n"
+        @"    querySelectorAll: function(sel) {\n"
+        @"        if (sel === 'h1, h2, h3, h4, h5, h6') return [h0, h1, h2];\n"
+        @"        return [];\n"
+        @"    }\n"
+        @"};\n"];
+
+    JSValue *result = [context evaluateScript:script];
+    NSArray *locations = [result toArray];
+
+    XCTAssertEqual(locations.count, 3U, @"Should return three locations");
+    XCTAssertEqualWithAccuracy([locations[0] floatValue], 550.0, 0.5,
+                               @"First header: 500+50=550");
+    XCTAssertEqualWithAccuracy([locations[1] floatValue], 600.0, 0.5,
+                               @"Second header: 500+100=600");
+    XCTAssertEqualWithAccuracy([locations[2] floatValue], 800.0, 0.5,
+                               @"Third header: 500+300=800");
+}
+
+/**
+ * C4 — Empty body (no headers, no images): returns empty array.
+ * Issue #342: Script must handle documents with no reference points.
+ */
+- (void)testJSHeaderLocationsEmptyBody
+{
+    NSString *script = [self loadUpdateHeaderLocationsScript];
+    if (!script) {
+        XCTFail(@"updateHeaderLocations.js not found in bundle");
+        return;
+    }
+
+    JSContext *context = [[JSContext alloc] init];
+    context.exceptionHandler = ^(JSContext *ctx, JSValue *exception) { };
+
+    [context evaluateScript:
+        @"var window = {scrollY: 100};\n"
+        @"var Node = {DOCUMENT_POSITION_FOLLOWING: 4, DOCUMENT_POSITION_PRECEDING: 2};\n"
+        @"var document = {\n"
+        @"    body: {},\n"
+        @"    querySelectorAll: function(sel) { return []; }\n"
+        @"};\n"];
+
+    JSValue *result = [context evaluateScript:script];
+    NSArray *locations = [result toArray];
+
+    XCTAssertNotNil(locations, @"Result should not be nil for empty body");
+    XCTAssertEqual(locations.count, 0U, @"Empty body should return empty array");
+}
+
+/**
+ * C5 — Null document.body: returns empty array without crashing.
+ * Issue #342: Script must guard against missing body gracefully.
+ */
+- (void)testJSHeaderLocationsNullBody
+{
+    NSString *script = [self loadUpdateHeaderLocationsScript];
+    if (!script) {
+        XCTFail(@"updateHeaderLocations.js not found in bundle");
+        return;
+    }
+
+    JSContext *context = [[JSContext alloc] init];
+    context.exceptionHandler = ^(JSContext *ctx, JSValue *exception) { };
+
+    [context evaluateScript:
+        @"var window = {scrollY: 0};\n"
+        @"var Node = {DOCUMENT_POSITION_FOLLOWING: 4, DOCUMENT_POSITION_PRECEDING: 2};\n"
+        @"var document = {body: null, querySelectorAll: function(s){return [];}};\n"];
+
+    JSValue *result = [context evaluateScript:script];
+    XCTAssertNoThrow((void)[result toArray],
+                     @"Script with null document.body should not throw");
+    NSArray *locations = [result toArray];
+    XCTAssertEqual(locations.count, 0U, @"Null body should return empty array");
+}
+
+#pragma mark - Issue #342: Group D — Header Array Alignment Safety
+
+/**
+ * D1 — syncScrollers with equal-length arrays does not crash.
+ * Issue #342: Arrays of equal length must not produce out-of-bounds access.
+ */
+- (void)testSyncScrollersWithEqualLengthArraysDoesNotCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.webViewHeaderLocations = @[@100, @300, @600];
+    doc.editorHeaderLocations  = @[@100, @300, @600];
+
+    XCTAssertNoThrow([doc syncScrollers],
+                     @"syncScrollers should not crash with equal-length header arrays");
+}
+
+/**
+ * D2 — syncScrollersReverse with equal-length arrays does not crash.
+ * Issue #342: Reverse sync must also be safe with aligned arrays.
+ */
+- (void)testSyncScrollersReverseWithEqualLengthArraysDoesNotCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.webViewHeaderLocations = @[@100, @300, @600];
+    doc.editorHeaderLocations  = @[@100, @300, @600];
+
+    XCTAssertNoThrow([doc syncScrollersReverse],
+                     @"syncScrollersReverse should not crash with equal-length header arrays");
+}
+
+/**
+ * D3 — syncScrollers with empty arrays does not crash.
+ * Issue #342: Edge case with no reference points must not crash.
+ */
+- (void)testSyncScrollersWithEmptyArraysDoesNotCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.webViewHeaderLocations = @[];
+    doc.editorHeaderLocations  = @[];
+
+    XCTAssertNoThrow([doc syncScrollers],
+                     @"syncScrollers should not crash with empty header arrays");
+}
+
+#pragma mark - Issue #342: Group E — lastPreviewScrollTop Save Point
+
+/**
+ * E2 — syncScrollers overwrites lastPreviewScrollTop.
+ * Issue #342: syncScrollers must save its computed preview position,
+ * not preserve a stale value from a previous render cycle.
+ */
+- (void)testSyncScrollersOverwritesLastPreviewScrollTop
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.lastPreviewScrollTop = 999.0;
+    doc.webViewHeaderLocations = @[];
+    doc.editorHeaderLocations  = @[];
+
+    [doc syncScrollers];
+
+    // With no scroll view, syncScrollers writes 0.0 — the point is it overwrites the stale value
+    XCTAssertEqualWithAccuracy(doc.lastPreviewScrollTop, 0.0, 0.01,
+                               @"syncScrollers should overwrite stale lastPreviewScrollTop with computed value");
+}
+
+#pragma mark - Issue #342: Group F — Handler Method Existence
+
+/**
+ * F1 — willStartPreviewLiveScroll: method exists on MPDocument.
+ * Issue #342: New observer handler must be present after implementation.
+ */
+- (void)testWillStartPreviewLiveScrollMethodExists
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    XCTAssertTrue([doc respondsToSelector:@selector(willStartPreviewLiveScroll:)],
+                  @"MPDocument should respond to willStartPreviewLiveScroll:");
+}
+
+/**
+ * F2 — didEndPreviewLiveScroll: method exists on MPDocument.
+ * Issue #342: New observer handler must be present after implementation.
+ */
+- (void)testDidEndPreviewLiveScrollMethodExists
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    XCTAssertTrue([doc respondsToSelector:@selector(didEndPreviewLiveScroll:)],
+                  @"MPDocument should respond to didEndPreviewLiveScroll:");
+}
+
+#pragma mark - Issue #342: Group G — performDelayedSyncScrollers Removal
+
+/**
+ * G1 — performDelayedSyncScrollers method no longer exists.
+ * Issue #342: Delayed sync must be removed entirely; timer-based sync is the bug.
+ */
+- (void)testPerformDelayedSyncScrollersMethodRemoved
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    XCTAssertFalse([doc respondsToSelector:@selector(performDelayedSyncScrollers)],
+                   @"performDelayedSyncScrollers should not exist after Issue #342 fix");
+}
+
+/**
+ * G2 — close does not crash without performDelayedSyncScrollers cancellation.
+ * Issue #342: The cancelPreviousPerformRequests call must be removed along with
+ * the method itself; close must not crash.
+ */
+- (void)testCloseDoesNotCrashAfterDelayedSyncRemoval
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    XCTAssertNoThrow([doc close],
+                     @"close should not crash after performDelayedSyncScrollers is removed");
 }
 
 @end

--- a/plans/scroll-sync-fix-analysis.md
+++ b/plans/scroll-sync-fix-analysis.md
@@ -1,0 +1,453 @@
+# Scroll Sync Jump Bug — Analysis and Fix Design
+
+**Issue:** #342 (regression from #282 fix)
+**Symptom:** While typing at the end of a long document, the editor pane jumps upward to a mid-document position approximately 200ms after each keystroke.
+**Status:** Design verified; ready for implementation.
+
+---
+
+## Reproduction Case
+
+A document with:
+- One heading (`# Lorem Ipsum`) near the top
+- Long Lorem Ipsum paragraphs filling the middle
+- A labeled anchor location mid-document (user called it "-> REFOCUS" because that's where the jump consistently lands)
+- More paragraphs, then long lines like `123456789 123456789 123456789` at the bottom
+
+Trigger: type a space after the last number sequence. The editor scrolls upward to mid-document ~200ms later.
+
+---
+
+## What Was Previously "Fixed"
+
+Issue #282 introduced `_inEditing` / `_inLiveScroll` / `shouldHandleBoundsChange` / `shouldHandlePreviewBoundsChange` boolean flags and a 200ms delayed sync (`performDelayedSyncScrollers`). That approach reduced the frequency of jumping but did not eliminate it, because the flags cannot close a race with deferred WebKit scroll notifications.
+
+---
+
+## Root Cause Analysis
+
+Three rounds of independent analysis converged on the following findings.
+
+### The Exact Failure Sequence
+
+1. User types at the bottom of the document. `editorTextDidChange:` fires.
+2. `_inEditing = YES`. `performDelayedSyncScrollers` is scheduled for +200ms.
+3. The render pipeline fires asynchronously. `renderer:didProduceHTMLOutput:` runs.
+4. DOM replacement executes: `body.innerHTML = html`, then `window.scrollTo(0, scrollBefore)` in JS.
+5. `window.scrollTo` triggers a `NSViewBoundsDidChangeNotification` on the preview clip view. This notification is dispatched **asynchronously** by WebKit — it arrives on the next run loop turn, not during the JS evaluation.
+6. While the notification is queued, `previewBoundsDidChange:` has not fired yet. `_inEditing` is still YES, so if it fired now it would be blocked. It hasn't fired yet.
+7. **200ms later:** `performDelayedSyncScrollers` fires. It calls `updateHeaderLocations`, then `syncScrollers`, then restores `shouldHandlePreviewBoundsChange = YES`, then sets `_inEditing = NO`.
+8. The queued WebKit bounds notification from step 5 now fires. Both guards (`shouldHandlePreviewBoundsChange` and `_inEditing`) are now clear.
+9. `previewBoundsDidChange:` calls `syncScrollersReverse`.
+10. `syncScrollersReverse` reads the current preview scroll position — which is `scrollBefore`, the value passed to `window.scrollTo` in step 4. `scrollBefore` was captured before the DOM replacement from the *previous* render cycle, not derived from the current editor position.
+11. `syncScrollersReverse` maps `scrollBefore` (a stale mid-document position) back to the editor. The editor jumps to mid-document.
+
+**The mid-document position** is wherever `scrollBefore` was when the previous render ran — which is wherever the preview was when the user was last not at the bottom. The user labeled this "-> REFOCUS" because that was its consistent value in their test document.
+
+### Why the 200ms Delay Is the Wrong Fix
+
+The delay creates a guaranteed race window:
+- The delayed callback clears `_inEditing` *after* `shouldHandlePreviewBoundsChange` is restored to YES
+- The deferred WebKit notification from `window.scrollTo` can arrive in that window
+- No combination of boolean flag ordering can close this without canceling the pending notification explicitly — and there is no API to do that
+
+**Conclusion: time-based delays introduce the race condition they were meant to prevent. They must be eliminated entirely.**
+
+---
+
+## Identified Bugs
+
+### Bug A — Deferred WebKit notification bypasses guards
+
+**Location:** `performDelayedSyncScrollers` (~line 2346), `previewBoundsDidChange:` (~line 1515)
+
+`syncScrollers` sets `contentView.bounds` directly in ObjC, which fires `NSViewBoundsDidChangeNotification` *synchronously* — this is correctly suppressed by `shouldHandlePreviewBoundsChange = NO`. But `window.scrollTo(0, scrollBefore)` from the DOM replacement JS fires its notification *asynchronously* on the next run loop turn. By then all guards are down and `_inEditing` is NO.
+
+`@synchronized(self)` provides no protection here — all notification dispatch is on the main thread, and `@synchronized` is reentrant from the same thread. It does nothing useful in this context.
+
+### Bug B — ObjC/JS coordinate read is not atomic
+
+**Location:** `updateHeaderLocations` (~line 2203), `updateHeaderLocations.js`
+
+```objc
+// ObjC reads scroll position at time T1
+CGFloat offset = NSMinY(self.preview.enclosingScrollView.contentView.bounds);
+
+// JS evaluates getBoundingClientRect().top at time T2
+_webViewHeaderLocations = [[context evaluateScript:script] toArray];
+
+// Combined: assumes T1 == T2, which is not guaranteed
+[locations addObject:@([location floatValue] + offset)];
+```
+
+`getBoundingClientRect().top` is viewport-relative, measured at T2. `offset` is the scroll position at T1. If WebKit commits a pending scroll between T1 and T2 (e.g., processing the `window.scrollTo` from DOM replacement), `rect.top + offset` is wrong by the scroll delta. This corrupts `_webViewHeaderLocations`, causing both sync functions to map scroll percentages to wrong positions.
+
+### Bug C — `MPGetPreviewLoadingCompletionHandler` is unguarded
+
+**Location:** `MPGetPreviewLoadingCompletionHandler` (~line 276)
+
+On full page load (style changes, first open), the completion handler calls `syncScrollers` with no `_inEditing` check. If a full reload completes while the user is typing, `syncScrollers` fires unconditionally. Additionally, the direct `contentView.bounds` assignment at lines 270–271 lacks `shouldHandlePreviewBoundsChange = NO`, meaning it can trigger `syncScrollersReverse` while `_inEditing` is still YES if `_inEditing` happened to be cleared just before the assignment.
+
+### Bug D — Asymmetric header array filtering
+
+**Location:** `updateHeaderLocations` (~line 2318)
+
+```objc
+// Editor array: headers in the last visible screen are excluded
+if (headerY <= editorContentHeight - editorVisibleHeight) {
+    [locations addObject:@(headerY)];
+}
+```
+
+The JS in `updateHeaderLocations.js` applies no equivalent filter — all headers are returned regardless of position. For documents with a header near the bottom of the editor, `_editorHeaderLocations` and `_webViewHeaderLocations` have different lengths. `relativeHeaderIndex` computed against one array is used as an index into the other, producing off-by-one position lookups in both `syncScrollers` and `syncScrollersReverse`.
+
+### Bug E — `lastPreviewScrollTop` conflates two purposes
+
+`lastPreviewScrollTop` is used both to restore preview scroll after a full page reload and as the `scrollBefore` value passed to `window.scrollTo` in DOM replacement. The value stored is from the last render cycle — it reflects wherever the preview happened to be, not the position corresponding to the current editor cursor. When `scrollBefore` is stale, the deferred `window.scrollTo` notification (Bug A) moves the preview to the wrong location, and `syncScrollersReverse` maps that back to the editor.
+
+---
+
+## Three Structural Problems
+
+These bugs are symptoms of three deeper design problems that cannot be fixed by patching individual races.
+
+### 1. Dual-coordinate-system header locations
+
+`_webViewHeaderLocations` is assembled by combining an ObjC scroll read with a JS layout read. These are never guaranteed to be from the same instant. The correct approach: read document-absolute coordinates entirely from JS in one atomic evaluation.
+
+### 2. Boolean flags cannot close deferred-notification races
+
+WebKit dispatches `window.scrollTo` notifications asynchronously. Boolean flags lowered after `syncScrollers` completes will always be down when the deferred notification arrives. No reordering of flag assignments fixes this — the gap is structural.
+
+### 3. Time-based delay is the wrong synchronization primitive
+
+`performDelayedSyncScrollers` uses 200ms to let "rendering settle." This introduces a race window (Bug A) and provides no actual guarantee that layout is stable. The correct signal is render completion, not elapsed time.
+
+---
+
+## Fix Design
+
+### Principle
+
+Replace all timing-based synchronization with event-driven synchronization. Replace four boolean flags with a single scroll ownership model. Fix the coordinate read race. Align the two header arrays.
+
+### Step 1 — Fix the coordinate read race (Bug B)
+
+Change `updateHeaderLocations.js` to return document-absolute coordinates directly:
+
+```js
+// Before
+return rect.top;
+
+// After
+return window.scrollY + rect.top;
+```
+
+Remove the `+ offset` correction loop in `updateHeaderLocations` in `MPDocument.m`. Both reads are now from a single atomic JS evaluation — no ObjC/JS split.
+
+### Step 2 — Replace four boolean flags with a scroll ownership enum (Bugs A, C)
+
+Declare in the private interface:
+
+```objc
+typedef NS_ENUM(NSUInteger, MPScrollOwner) {
+    MPScrollOwnerEditor,   // Editor is authoritative; preview is a follower
+    MPScrollOwnerPreview,  // User is live-scrolling preview; editor follows
+    MPScrollOwnerNeither   // Quiescent; sync in either direction is valid
+};
+
+@property (nonatomic) MPScrollOwner scrollOwner;
+```
+
+Ownership rules:
+- `editorTextDidChange:` → `scrollOwner = MPScrollOwnerEditor`
+- Render completion (DOM replacement done, MathJax done) → sync editor→preview → `scrollOwner = MPScrollOwnerNeither`
+- User begins live-scrolling preview → `scrollOwner = MPScrollOwnerPreview`
+- User ends live-scrolling preview → sync preview→editor once → `scrollOwner = MPScrollOwnerNeither`
+- User scrolls editor (non-typing) → sync editor→preview → ownership unchanged
+
+Guard rules:
+- `previewBoundsDidChange:` → only calls `syncScrollersReverse` if `scrollOwner == MPScrollOwnerPreview`
+- `editorBoundsDidChange:` → only calls `syncScrollers` if `scrollOwner == MPScrollOwnerNeither`
+- `MPGetPreviewLoadingCompletionHandler` → only calls `syncScrollers` if `scrollOwner != MPScrollOwnerEditor`
+
+The deferred `window.scrollTo` notification (Bug A) now arrives while `scrollOwner == MPScrollOwnerEditor` — `previewBoundsDidChange:` ignores it. No race window.
+
+**Internal flag toggles inside `syncScrollers` and `syncScrollersReverse` must be removed.** The current code brackets the `contentView.bounds` assignment in each sync function with `shouldHandlePreviewBoundsChange = NO/YES` (in `syncScrollers`, ~lines 2466–2468) and `shouldHandleBoundsChange = NO/YES` (in `syncScrollersReverse`, ~lines 2565–2567). These toggle the old boolean flags to suppress the synchronous `NSViewBoundsDidChangeNotification` fired by the assignment. Under the new model, the ownership guard at the top of `previewBoundsDidChange:` (`scrollOwner != MPScrollOwnerPreview`) and `editorBoundsDidChange:` (`scrollOwner != MPScrollOwnerNeither`) already suppress the reverse sync — the toggles are redundant and must be deleted along with the flags they reference.
+
+**Access pattern:** Use ivar-direct access (`_scrollOwner`) consistent with how `_inEditing` and `_inLiveScroll` are used throughout the file. The `@property` declaration enables KVC/KVO if ever needed, but all internal accesses use the ivar.
+
+**Initial value:** `_scrollOwner` should be initialized to `MPScrollOwnerNeither` in `-init` (quiescent at document open).
+
+### Step 3 — Eliminate `performDelayedSyncScrollers` entirely (Bugs A, E)
+
+Remove the 200ms delayed sync. Instead, call `updateHeaderLocations` + `syncScrollers` at render completion:
+
+- **DOM replacement path (non-MathJax):** After `[context evaluateScript:updateScript]` returns (line 1365), call `updateHeaderLocations` + `syncScrollers` synchronously while `_scrollOwner == MPScrollOwnerEditor`. Then set `_scrollOwner = MPScrollOwnerNeither`. This must occur before the next run loop turn so the deferred `window.scrollTo` notification arrives while ownership is still being set — but since the transition happens before returning from the method, the notification will arrive either in `MPScrollOwnerEditor` (if user typed again) or `MPScrollOwnerNeither` (if not), both of which suppress `syncScrollersReverse`.
+- **MathJax path:** In the `DOMReplacementDone` callback, call `updateHeaderLocations` + `syncScrollers` after typesetting, then set `_scrollOwner = MPScrollOwnerNeither`.
+- **Full reload path:** In `MPGetPreviewLoadingCompletionHandler`, call `updateHeaderLocations` + `syncScrollers` after the preview is ready (already does this, just needs the ownership guard from Step 2).
+
+**Full reload during typing:** If a full reload fires while `_scrollOwner == MPScrollOwnerEditor`, `syncScrollers` is skipped in the completion handler. The preview may be briefly mispositioned. Recovery is automatic: the render debounce (500ms) fires on the next keystroke or after typing stops, triggering `renderer:didProduceHTMLOutput:` → DOM replacement path → `updateHeaderLocations` + `syncScrollers`. The preview corrects within one render cycle. No additional mechanism is needed.
+
+No timers anywhere in the sync path.
+
+### Step 4 — Fix asymmetric header filtering (Bug D)
+
+Remove the `editorContentHeight - editorVisibleHeight` filter from `_editorHeaderLocations` in `updateHeaderLocations`. Both arrays should contain all headers in document order. The `interpolateToEndOfDocument` logic in `syncScrollers` and `syncScrollersReverse` already handles the end-of-document case correctly; no pre-filtering is needed. This ensures `_editorHeaderLocations[n]` and `_webViewHeaderLocations[n]` always refer to the same heading.
+
+### Step 5 — Fix `lastPreviewScrollTop` (Bug E)
+
+After `syncScrollers` computes and applies the correct preview scroll position, save that value as `lastPreviewScrollTop`. This ensures that if a full reload fires shortly after, the preview restores to the position derived from the editor cursor, not a stale value from a previous render cycle.
+
+---
+
+## What This Does Not Touch
+
+- Hoedown renderer
+- WebView lifecycle
+- Scroll sync algorithm (`syncScrollers`, `syncScrollersReverse` internals)
+- Preview/editor pane split view
+- Any test infrastructure
+
+---
+
+## Open Questions — Resolved
+
+### OQ1 — Render debounce timing
+
+**Answer: Confirmed safe; fast typing is handled correctly.**
+
+`MPRenderer.parseAndRenderLater` debounces at **500ms** (`parseAndRenderWithMaxDelay:0.5`). A user typing at 8 chars/sec (125ms between keystrokes) accumulates ~4 keystrokes before the first render fires. During that window, `scrollOwner` stays `MPScrollOwnerEditor` continuously. When render completes, `syncScrollers` runs and ownership transitions to `MPScrollOwnerNeither`. If the user types again before the render, ownership immediately goes back to `MPScrollOwnerEditor`. Ownership never leaks into a state where `previewBoundsDidChange:` could call `syncScrollersReverse`. Confirmed correct.
+
+### OQ2 — `window.scrollTo` ordering in JS closure
+
+**Answer: Ordering is safe in both non-MathJax and MathJax paths.**
+
+In the non-MathJax path, `window.scrollTo(0, scrollY)` is called synchronously inside the JS closure at line 1335. When `[context evaluateScript:updateScript]` returns (line 1365), `window.scrollTo` has already been called but its `NSViewBoundsDidChangeNotification` has not yet fired — WebKit queues it for the next run loop turn. Calling `updateHeaderLocations` + `syncScrollers` synchronously after line 1365 executes before the notification fires. Safe.
+
+In the MathJax path, `window.scrollTo(0, scrollY)` and `invokeCallbackForKey_('DOMReplacementDone')` execute in the same MathJax queue callback. `invokeCallbackForKey_` is synchronous — the ObjC `DOMReplacementDone` block runs during JS evaluation, before the queue callback returns. The deferred WebKit notification from that same `window.scrollTo` call fires on the next run loop turn, after the callback block completes. The ObjC sync therefore runs before the notification. Safe.
+
+### OQ3 — MathJax `DOMReplacementDone` timing
+
+**Answer: No race; the guard model is correct as designed.**
+
+The concern was: after `DOMReplacementDone` transitions `scrollOwner = MPScrollOwnerNeither`, the deferred `window.scrollTo` notification arrives and `previewBoundsDidChange:` fires with `scrollOwner == MPScrollOwnerNeither`. This is safe because **`previewBoundsDidChange:` only calls `syncScrollersReverse` when `scrollOwner == MPScrollOwnerPreview`**. Neither → notification suppressed. No jump.
+
+The one edge case — user starts live-scrolling the preview in the window between the ownership transition and the deferred notification — is also safe. If that happens, `scrollOwner = MPScrollOwnerPreview` reflects the actual user intent, and the notification (which carries the user's actual scroll position) correctly triggers `syncScrollersReverse`. No bad state.
+
+**No timing delays are needed anywhere in the fix.**
+
+---
+
+## Verification Findings
+
+Conducted after multi-agent codebase review. All line numbers are from `MPDocument.m` unless noted.
+
+### Confirmed code references
+
+| Symbol | Actual line | Notes |
+|--------|-------------|-------|
+| `_inLiveScroll` property | 231 | ivar-direct access pattern throughout |
+| `_inEditing` property | 232 | ivar-direct access pattern throughout |
+| `shouldHandlePreviewBoundsChange` | 213 | plain `@property BOOL` |
+| `shouldHandleBoundsChange` | 212 | plain `@property BOOL` |
+| `lastPreviewScrollTop` | 218 | three save sites: 1359, 1371, 2471 |
+| `MPGetPreviewLoadingCompletionHandler` | 260 | analysis said ~276; close enough |
+| `performDelayedSyncScrollers` impl | 2346 | correct |
+| `previewBoundsDidChange:` | 1515 | correct |
+| `editorBoundsDidChange:` | 1475 | not given in analysis |
+| `updateHeaderLocations` | 2203 | correct |
+| DOM replacement / `scrollBefore` | 1312 | not given in analysis |
+| `DOMReplacementDone` callback | 1348–1360 | not given in analysis |
+| `willStartLiveScroll:` | 1464 | not given in analysis |
+| `didEndLiveScroll:` | 1470 | not given in analysis |
+
+### `updateHeaderLocations.js` confirmed
+
+Currently returns `rect.top` (viewport-relative). The Step 1 fix (`window.scrollY + rect.top`) is confirmed necessary.
+
+### `syncScrollers` and `syncScrollersReverse` have their own runtime filters
+
+`syncScrollers` applies a `headerY < editorContentHeight - editorVisibleHeight` filter during iteration (lines 2417–2422). `syncScrollersReverse` applies `headerY < previewContentHeight - previewVisibleHeight` similarly. The pre-filter removed by Step 4 in `updateHeaderLocations` is therefore redundant — the runtime filters handle end-of-document interpolation. Step 4 is safe.
+
+### `MPScrollOwner` visibility
+
+Nothing in `MPDocument.h` exposes the boolean flags. The enum can remain in the private `@interface MPDocument ()` extension in `MPDocument.m`.
+
+### `lastPreviewScrollTop` save sites
+
+- **Line 1359** (MathJax `DOMReplacementDone` callback): saves `newScrollY` — the actual post-MathJax scroll position. Post-sync; correct.
+- **Line 1371** (non-MathJax DOM replacement path): saves `scrollBefore` — the pre-replacement scroll position. **Stale; remove this.**
+- **Line 2471** (`syncScrollers` end): saves `previewY` — the correctly computed value. This is the canonical save site.
+
+### Identified gaps not in original analysis
+
+**Gap 1 — Missing preview `willStartLiveScroll:` observer registration**
+
+`willStartLiveScroll:` and `didEndLiveScroll:` (lines 1464, 1470) are registered only for `self.editor.enclosingScrollView` (lines 477–482). There is no `NSScrollViewWillStartLiveScrollNotification` observer for `self.preview.enclosingScrollView`. The ownership model requires `scrollOwner = MPScrollOwnerPreview` when the user begins live-scrolling the preview. A new observer registration must be added:
+
+```objc
+[center addObserver:self selector:@selector(willStartPreviewLiveScroll:)
+               name:NSScrollViewWillStartLiveScrollNotification
+             object:self.preview.enclosingScrollView];
+```
+
+And a handler:
+```objc
+- (void)willStartPreviewLiveScroll:(NSNotification *)notification {
+    [self updateHeaderLocations];   // Must come first: ensures fresh header locations
+    _scrollOwner = MPScrollOwnerPreview;
+}
+```
+
+`updateHeaderLocations` must be called before setting ownership, so that when `didEndPreviewLiveScroll:` calls `syncScrollersReverse`, it operates on current header positions. This mirrors what the existing `willStartLiveScroll:` (line 1464) does for the editor.
+
+The existing `previewDidLiveScroll:` (line 1509) only saves `lastPreviewScrollTop` — no change needed there. The existing `didEndLiveScroll:` (line 1470) sets `_inLiveScroll = NO`. Under the new model, the parallel `didEndPreviewLiveScroll:` must: call `syncScrollersReverse` once, then set `_scrollOwner = MPScrollOwnerNeither`.
+
+Note: the existing `didEndLiveScroll:` is registered for `self.editor.enclosingScrollView`. The new `didEndPreviewLiveScroll:` must be registered separately for `self.preview.enclosingScrollView`.
+
+**Gap 2 — `close` method cancels `performDelayedSyncScrollers`**
+
+Line 555–557 of `-close` calls:
+```objc
+[NSObject cancelPreviousPerformRequestsWithTarget:self
+                                         selector:@selector(performDelayedSyncScrollers)
+                                           object:nil];
+```
+
+When `performDelayedSyncScrollers` is removed, this cancellation call must also be removed. Otherwise it produces a misleading dead-code call (and possibly a runtime warning).
+
+**Gap 3 — `MPGetPreviewLoadingCompletionHandler` `contentView.bounds` assignment**
+
+Lines 270–271 directly assign `contentView.bounds` to restore `lastPreviewScrollTop`. This fires `NSViewBoundsDidChangeNotification` on the preview's clip view. Under the new ownership model, during a full reload the `scrollOwner` is typically `MPScrollOwnerNeither` (user not live-scrolling). `previewBoundsDidChange:` would receive this notification. Since `scrollOwner != MPScrollOwnerPreview`, `syncScrollersReverse` is NOT called — the notification is suppressed. **This gap is not actually a gap under the proposed guard model.** The fix for Bug C (guarding the subsequent `syncScrollers` call with `scrollOwner != MPScrollOwnerEditor`) is sufficient.
+
+### Confirmed: no timing delays needed
+
+The ownership enum's guard logic (`previewBoundsDidChange:` → only `MPScrollOwnerPreview` triggers `syncScrollersReverse`) means deferred WebKit notifications arriving in `MPScrollOwnerEditor` or `MPScrollOwnerNeither` states are both safely suppressed without any timer extension. No `dispatch_async`, no `performSelector:afterDelay:`, nothing.
+
+---
+
+## Revised Implementation Order
+
+1. **Step 1 + Step 4** — JS fix and asymmetric filter removal (independent; lowest risk)
+2. **Step 2 + Gap 1** — Enum declaration, four-flag replacement, guard logic, preview live-scroll observer registration
+3. **Step 3 + Gap 2** — Remove `performDelayedSyncScrollers` and its two call sites (line 1429–1434 in `editorTextDidChange:`, line 555–557 in `-close`); add sync call to non-MathJax DOM replacement completion (after line 1365); update MathJax `DOMReplacementDone` callback guard
+4. **Step 5** — Remove stale save at line 1371; `syncScrollers` at line 2471 already saves the correct value
+
+---
+
+## Files to Modify (Revised)
+
+| File | Changes |
+|------|---------|
+| `MacDown/Code/Document/MPDocument.m` | Replace 4 boolean flags with `MPScrollOwner` enum + property (private); remove `performDelayedSyncScrollers` and all scheduling/cancellation calls; add sync call to non-MathJax DOM replacement completion; guard `MPGetPreviewLoadingCompletionHandler`; remove stale `lastPreviewScrollTop` save (line 1371); remove asymmetric pre-filter from `updateHeaderLocations`; fix `previewBoundsDidChange:` and `editorBoundsDidChange:` guard logic; add preview `willStartLiveScroll` and `didEndLiveScroll` observer registration and handlers; update `DOMReplacementDone` callback guard |
+| `MacDown/Code/Document/MPDocument.h` | No changes needed (`MPScrollOwner` stays private) |
+| `MacDown/Resources/updateHeaderLocations.js` | Return `window.scrollY + rect.top` instead of `rect.top`; remove ObjC offset correction loop |
+
+---
+
+## Test Design
+
+All tests live in `MacDownTests/MPScrollSyncTests.m`. No new test file is needed.
+
+### Private category additions required
+
+```objc
+@interface MPDocument (ScrollSyncTesting)
+// Drop: shouldHandleBoundsChange, shouldHandlePreviewBoundsChange, inEditing,
+//       inLiveScroll, performDelayedSyncScrollers
+// Add:
+@property (nonatomic) NSUInteger scrollOwner;  // raw NSUInteger; compare to enum constants
+- (void)willStartPreviewLiveScroll:(NSNotification *)notification;
+- (void)didEndPreviewLiveScroll:(NSNotification *)notification;
+@end
+```
+
+`MPScrollOwner` stays private to `MPDocument.m`. Tests use raw `NSUInteger` values (0 = Editor, 1 = Preview, 2 = Neither) or redeclare matching integer constants in the test file.
+
+### Tests to delete (old contract, will fail after fix)
+
+- `testInEditingPropertyDefaultsToNO`
+- `testPerformDelayedSyncScrollersExists`
+- `testPerformDelayedSyncScrollersClearsInEditing`
+- `testPerformDelayedSyncScrollersWithEmptyLocations`
+- `testPerformDelayedSyncScrollersWithNilLocations`
+- `testInEditingAndShouldHandleBoundsChangeAreIndependent`
+- `testPendingDelayedSyncCancelledOnClose`
+- `testPerformDelayedSyncScrollersSetsGuards`
+- `testInEditingClearedAfterSync`
+- `testShouldHandlePreviewBoundsChangeDefaultsToYes`
+- `testBothGuardsCanBeSetIndependently`
+- `testCascadePreventionBothGuardsSetDuringSync`
+- `testCascadePreventionDirectSyncScrollersCleansUp`
+- `testRapidEditingCalls`
+- `testPreviewBoundsChangeGuardedByInEditing`
+
+### New tests — Group A: Ownership state machine
+
+| Test | Setup | Action | Assert |
+|------|-------|--------|--------|
+| A1 — initial ownership | fresh alloc/init | read scrollOwner | MPScrollOwnerNeither (2) |
+| A2 — editorTextDidChange sets Editor | scrollOwner = Neither | call `editorTextDidChange:nil` | scrollOwner == MPScrollOwnerEditor (0) |
+| A3 — willStartPreviewLiveScroll sets Preview | scrollOwner = Neither | call `willStartPreviewLiveScroll:nil` | scrollOwner == MPScrollOwnerPreview (1) |
+| A4 — didEndPreviewLiveScroll resets to Neither | scrollOwner = Preview | call `didEndPreviewLiveScroll:nil` | scrollOwner == Neither (2) |
+| A5 — repeated editorTextDidChange stays Editor | call once | call again | still MPScrollOwnerEditor |
+| A6 — editorTextDidChange during Preview overrides | scrollOwner = Preview | call `editorTextDidChange:nil` | scrollOwner == MPScrollOwnerEditor |
+
+### New tests — Group B: Guard logic
+
+| Test | Setup | Action | Assert |
+|------|-------|--------|--------|
+| B1 — previewBoundsDidChange suppressed during Editor | scrollOwner = Editor; sync pref on | call `previewBoundsDidChange:nil` | no throw; scrollOwner unchanged |
+| B2 — previewBoundsDidChange passes during Preview | scrollOwner = Preview; empty header arrays; sync pref on | call `previewBoundsDidChange:nil` | no throw; scrollOwner still Preview |
+| B3 — editorBoundsDidChange suppressed during Editor | scrollOwner = Editor; sync pref on | call `editorBoundsDidChange:nil` | no throw; scrollOwner unchanged |
+| B4 — editorBoundsDidChange passes during Neither | scrollOwner = Neither; empty header arrays; sync pref on | call `editorBoundsDidChange:nil` | no throw; scrollOwner still Neither |
+
+### New tests — Group C: JS coordinate fix (JSContext, no WebView)
+
+Mock DOM in JSContext: inject `window = {scrollY: N}`, `document = {body: ..., querySelectorAll: fn}`, `Node = {DOCUMENT_POSITION_FOLLOWING: 4, ...}`. Load and evaluate `updateHeaderLocations.js`.
+
+| Test | scrollY | header rect.top(s) | Expected result |
+|------|---------|-------------------|-----------------|
+| C1 — scrolled page | 200 | [100] | [300] |
+| C2 — unscrolled page | 0 | [150] | [150] |
+| C3 — multiple headers | 500 | [50, 100, 300] | [550, 600, 800] |
+| C4 — empty body | any | (none) | [] |
+| C5 — null body | any | (null document.body) | [] (no crash) |
+
+### New tests — Group D: Header array alignment safety
+
+Inject synthetic `_webViewHeaderLocations` / `_editorHeaderLocations` arrays of equal length.
+
+| Test | Setup | Action | Assert |
+|------|-------|--------|--------|
+| D1 — equal arrays no OOB | both = @[@100, @300, @600] | syncScrollers | no throw |
+| D2 — equal arrays no OOB reverse | both = @[@100, @300, @600] | syncScrollersReverse | no throw |
+| D3 — empty arrays | both empty | syncScrollers | no throw |
+
+### New tests — Group E: lastPreviewScrollTop save point
+
+| Test | Setup | Action | Assert |
+|------|-------|--------|--------|
+| E2 — syncScrollers overwrites lastPreviewScrollTop | lastPreviewScrollTop = 999.0; empty header arrays | syncScrollers | lastPreviewScrollTop != 999.0 (overwritten by sync) |
+
+### New tests — Group F: Handler method existence
+
+| Test | Assert |
+|------|--------|
+| F1 | `[doc respondsToSelector:@selector(willStartPreviewLiveScroll:)]` |
+| F2 | `[doc respondsToSelector:@selector(didEndPreviewLiveScroll:)]` |
+
+### New tests — Group G: performDelayedSyncScrollers removal
+
+| Test | Assert |
+|------|--------|
+| G1 — method removed | `![doc respondsToSelector:@selector(performDelayedSyncScrollers)]` |
+| G2 — close does not crash | `XCTAssertNoThrow([doc close])` |
+
+### Untestable without live WebView (manual verification only)
+
+- Bug A race (deferred WebKit notification) — requires actual WebKit dispatch
+- Bug D filter removal in `updateHeaderLocations` — `NSLayoutManager` returns zero-height in headless
+- Line 1371 stale save removal — requires `renderer:didProduceHTMLOutput:` which needs a live WebView
+- Observer registration for `willStartPreviewLiveScroll:` / `didEndPreviewLiveScroll:` — requires `windowControllerDidLoadNib:`


### PR DESCRIPTION
## Summary

- Replace four boolean flags (`shouldHandleBoundsChange`, `shouldHandlePreviewBoundsChange`, `_inEditing`, `_inLiveScroll`) with a single `MPScrollOwner` enum (`Editor`, `Preview`, `Neither`) that models scroll ownership explicitly
- Remove the 200ms `performDelayedSyncScrollers` timer that created a race window with deferred WebKit `NSViewBoundsDidChangeNotification`
- Fix `updateHeaderLocations.js` to return document-absolute coordinates (`window.scrollY + rect.top`) instead of viewport-relative, eliminating the ObjC/JS coordinate read race
- Remove asymmetric header array pre-filter that caused off-by-one position lookups between editor and preview arrays
- Remove stale `lastPreviewScrollTop` save site in non-MathJax DOM replacement path
- Add preview live-scroll observer registration (`willStartPreviewLiveScroll:`, `didEndPreviewLiveScroll:`)

## Related Issue

Related to #342

## Files Changed

| File | Changes |
|------|---------|
| `MPDocument.m` | Enum + property, guard logic, observer registration, timer removal, filter removal, stale save removal |
| `updateHeaderLocations.js` | `rect.top` → `window.scrollY + rect.top` |
| `MPScrollSyncTests.m` | 20 old tests deleted, 25 new tests added (Groups A-G) |

## Manual Testing Plan

1. Open a long Markdown document (e.g., the built-in help.md)
2. Scroll to the end of the document
3. Type several characters — editor should stay at cursor position (no jump)
4. Scroll the preview pane manually — editor should follow
5. Type again after preview scroll — editor should reclaim scroll ownership
6. Change editor style (triggers full reload) while typing — no crash, preview recovers on next render
7. Test with MathJax-heavy document — no jump after typesetting completes