### PR TITLE
Fix gaps in the scroll sync implementation

### DIFF
--- a/MacDown/Code/Document/MPDocument.h
+++ b/MacDown/Code/Document/MPDocument.h
@@ -11,6 +11,12 @@
 
 
 @interface MPDocument : NSDocument
+{
+    @package
+    // Commit 8 (gap 9): Generation counter for MathJax render callbacks.
+    // Exposed here (not @interface ()) so that the test category can access it via ->.
+    NSUInteger _mathJaxRenderGeneration;
+}
 
 @property (nonatomic, readonly) MPPreferences *preferences;
 @property (readonly) BOOL previewVisible;

--- a/MacDown/Code/Document/MPDocument.h
+++ b/MacDown/Code/Document/MPDocument.h
@@ -11,12 +11,6 @@
 
 
 @interface MPDocument : NSDocument
-{
-    @package
-    // Commit 8 (gap 9): Generation counter for MathJax render callbacks.
-    // Exposed here (not @interface ()) so that the test category can access it via ->.
-    NSUInteger _mathJaxRenderGeneration;
-}
 
 @property (nonatomic, readonly) MPPreferences *preferences;
 @property (readonly) BOOL previewVisible;

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -261,6 +261,10 @@ typedef NS_ENUM(NSUInteger, MPScrollOwner) {
 - (void)invokeRenderCompletionHandlers;
 - (void)willStartPreviewLiveScroll:(NSNotification *)notification;
 - (void)didEndPreviewLiveScroll:(NSNotification *)notification;
+// Commit 6 (gaps 1+3): layout-change sync
+- (void)refreshHeaderCacheAfterResize;
+- (void)windowDidEndLiveResize:(NSNotification *)notification;
+- (void)windowDidChangeFullScreen:(NSNotification *)notification;
 
 @end
 
@@ -542,6 +546,17 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
         // Issue #290: Start file watching for auto-reload
         [self startFileWatching];
+
+        // Commit 6 (gaps 1+3): Register for window resize/fullscreen notifications.
+        // Registered here (not in the main setup block) because self.editor.window
+        // may be nil before the window is shown.
+        NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+        [center addObserver:self selector:@selector(windowDidEndLiveResize:)
+                       name:NSWindowDidEndLiveResizeNotification object:self.editor.window];
+        [center addObserver:self selector:@selector(windowDidChangeFullScreen:)
+                       name:NSWindowDidEnterFullScreenNotification object:self.editor.window];
+        [center addObserver:self selector:@selector(windowDidChangeFullScreen:)
+                       name:NSWindowDidExitFullScreenNotification object:self.editor.window];
     }];
 }
 
@@ -588,6 +603,10 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         [NSObject cancelPreviousPerformRequestsWithTarget:self
                                                  selector:@selector(updateWordCount)
                                                    object:nil];
+
+        // Commit 6 (gaps 1+3): Cancel any pending coalesced header cache refresh.
+        [NSObject cancelPreviousPerformRequestsWithTarget:self
+                    selector:@selector(refreshHeaderCacheAfterResize) object:nil];
 
         // Issue #290: Stop file watching to prevent leaks
         [self stopFileWatching];
@@ -861,6 +880,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 {
     [self redrawDivider];
     self.editor.editable = self.editorVisible;
+    // Commit 6 (gaps 1+3): Coalesce header cache refresh to next run loop iteration,
+    // after layout manager reflows. Split-divider drags fire many notifications rapidly.
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                selector:@selector(refreshHeaderCacheAfterResize) object:nil];
+    [self performSelector:@selector(refreshHeaderCacheAfterResize)
+               withObject:nil afterDelay:0];
 }
 
 
@@ -1497,6 +1522,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 {
     if (self.preferences.editorWidthLimited)
         [self adjustEditorInsets];
+    // Commit 6 (gap 3): Coalesce header cache refresh after editor frame changes.
+    // Covers editorWidthLimited toggle and other frame changes not captured above.
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                selector:@selector(refreshHeaderCacheAfterResize) object:nil];
+    [self performSelector:@selector(refreshHeaderCacheAfterResize)
+               withObject:nil afterDelay:0];
 }
 
 - (void)willStartLiveScroll:(NSNotification *)notification
@@ -1532,6 +1563,35 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     if (self.preferences.editorSyncScrolling)
         [self syncScrollersReverse];
     _scrollOwner = MPScrollOwnerNeither;
+}
+
+// Commit 6 (gaps 1+3): Shared handler for all layout-change triggers.
+// Called after window edge resize, split-divider drag (coalesced), full-screen
+// enter/exit, and editor frame changes (coalesced via performSelector:afterDelay:0).
+
+- (void)refreshHeaderCacheAfterResize
+{
+    if (!self.renderer || !self.preferences.editorSyncScrolling)
+        return;
+    [self updateHeaderLocations];
+    if (_scrollOwner == MPScrollOwnerNeither)
+        [self syncScrollers];
+}
+
+- (void)windowDidEndLiveResize:(NSNotification *)notification
+{
+    // Cancel any pending coalesced refresh; do the refresh immediately now.
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                selector:@selector(refreshHeaderCacheAfterResize) object:nil];
+    [self refreshHeaderCacheAfterResize];
+}
+
+- (void)windowDidChangeFullScreen:(NSNotification *)notification
+{
+    // Cancel any pending coalesced refresh; do the refresh immediately now.
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                selector:@selector(refreshHeaderCacheAfterResize) object:nil];
+    [self refreshHeaderCacheAfterResize];
 }
 
 - (void)editorBoundsDidChange:(NSNotification *)notification

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -265,7 +265,17 @@ typedef NS_ENUM(NSUInteger, MPScrollOwner) {
 - (void)refreshHeaderCacheAfterResize;
 - (void)windowDidEndLiveResize:(NSNotification *)notification;
 - (void)windowDidChangeFullScreen:(NSNotification *)notification;
+// Commit 8 (gap 9): MathJax generation counter accessor (used by tests via category)
+- (NSUInteger)mathJaxRenderGeneration;
 
+@end
+
+// Commit 8 (gap 9): ivar declared in a separate class extension to keep it private
+// while still making -mathJaxRenderGeneration accessible via a compiled method.
+@interface MPDocument ()
+{
+    NSUInteger _mathJaxRenderGeneration;
+}
 @end
 
 static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
@@ -406,6 +416,13 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 {
     _autosaveName = autosaveName;
     self.splitView.autosaveName = autosaveName;
+}
+
+// Commit 8 (gap 9): Accessor for test introspection. The ivar itself is private
+// (declared in a class extension); this method is the exposed interface.
+- (NSUInteger)mathJaxRenderGeneration
+{
+    return _mathJaxRenderGeneration;
 }
 
 

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2476,8 +2476,10 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     if (editorCount != previewCount)
     {
         NSUInteger minCount = MIN(editorCount, previewCount);
+#ifdef DEBUG
         NSLog(@"[ScrollSync] Header location count mismatch: editor=%lu preview=%lu, truncating to %lu",
               (unsigned long)editorCount, (unsigned long)previewCount, (unsigned long)minCount);
+#endif
         if (editorCount > minCount)
             _editorHeaderLocations = [_editorHeaderLocations subarrayWithRange:NSMakeRange(0, minCount)];
         if (previewCount > minCount)

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -326,12 +326,6 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 
 @implementation MPDocument
-{
-    // Commit 8 (gap 9): Generation counter to discard stale MathJax render callbacks.
-    // Incremented before each new MathJax listener setup; captured in the block.
-    // If generation differs at callback time, the render was superseded — skip it.
-    NSUInteger _mathJaxRenderGeneration;
-}
 
 #pragma mark - Accessor
 

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2368,7 +2368,8 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     CGFloat currY = NSMinY(self.editor.enclosingScrollView.contentView.bounds);
     CGFloat minY = 0;
     CGFloat maxY = 0;
-    
+    BOOL foundMaxY = NO;  // Gap 6: replace maxY==0 sentinel with explicit flag
+
     // Align documents at screen center for smooth sync, tapering to edges at document boundaries.
     // Taper values: 0 at document edges, 1.0 in the middle of the document.
     CGFloat topTaper = MAX(0, MIN(1.0, currY / editorVisibleHeight));
@@ -2381,26 +2382,27 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     for (NSNumber *headerYNum in _editorHeaderLocations) {
         CGFloat headerY = [headerYNum floatValue];
         headerY -= adjustmentForScroll;
-        
+
         if (headerY < currY)
         {
             // The header is before our current scroll position. the closest
             // of these will be our first reference node
             relativeHeaderIndex += 1;
             minY = headerY;
-        } else if (maxY == 0 && headerY < editorContentHeight - editorVisibleHeight)
+        } else if (!foundMaxY && headerY < editorContentHeight - editorVisibleHeight)
         {
             // Skip any headers that are within the last screen of the editor.
             // we'll interpolate to the end of the document in that case.
             maxY = headerY;
+            foundMaxY = YES;  // Gap 6: mark that we found a real maxY
         }
     }
-    
+
     // Usually, we'll be scrolling between two reference nodes, but toward the end
     // of the document we'll ignore nodes and reference the end of the document instead
     BOOL interpolateToEndOfDocument = NO;
-    
-    if (maxY == 0)
+
+    if (!foundMaxY)
     {
         // We only have a reference node before our current position,
         // but not after, so we'll use the end of the document.
@@ -2413,7 +2415,9 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     currY = MAX(0, currY - minY);
     maxY -= minY;
     minY -= minY;
-    CGFloat percentScrolledBetweenHeaders = MAX(0, MIN(1.0, currY / maxY));
+    // Gap 7: guard against division by zero when two headers share the same
+    // taper-adjusted y (maxY - minY == 0) or very short documents collapse all points.
+    CGFloat percentScrolledBetweenHeaders = (maxY - minY < 0.001) ? 0 : MAX(0, MIN(1.0, currY / maxY));
     
     // Now that we know where the editor position is relative to two reference nodes,
     // we need to find the positions of those nodes in the HTML preview
@@ -2468,6 +2472,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     CGFloat currY = NSMinY(self.preview.enclosingScrollView.contentView.bounds);
     CGFloat minY = 0;
     CGFloat maxY = 0;
+    BOOL foundMaxY = NO;  // Gap 6: replace maxY==0 sentinel with explicit flag
 
     // Align documents at screen center for smooth sync, tapering to edges at document boundaries.
     // Taper values: 0 at document edges, 1.0 in the middle of the document.
@@ -2487,11 +2492,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             // of these will be our first reference node
             relativeHeaderIndex += 1;
             minY = headerY;
-        } else if (maxY == 0 && headerY < previewContentHeight - previewVisibleHeight)
+        } else if (!foundMaxY && headerY < previewContentHeight - previewVisibleHeight)
         {
             // Skip any headers that are within the last screen of the preview.
             // we'll interpolate to the end of the document in that case.
             maxY = headerY;
+            foundMaxY = YES;  // Gap 6: mark that we found a real maxY
         }
     }
 
@@ -2499,7 +2505,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     // of the document we'll ignore nodes and reference the end of the document instead
     BOOL interpolateToEndOfDocument = NO;
 
-    if (maxY == 0)
+    if (!foundMaxY)
     {
         // We only have a reference node before our current position,
         // but not after, so we'll use the end of the document.
@@ -2512,7 +2518,9 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     currY = MAX(0, currY - minY);
     maxY -= minY;
     minY -= minY;
-    CGFloat percentScrolledBetweenHeaders = MAX(0, MIN(1.0, currY / maxY));
+    // Gap 7: guard against division by zero when two headers share the same
+    // taper-adjusted y (maxY - minY == 0) or very short documents collapse all points.
+    CGFloat percentScrolledBetweenHeaders = (maxY - minY < 0.001) ? 0 : MAX(0, MIN(1.0, currY / maxY));
 
     // Now that we know where the preview position is relative to two reference nodes,
     // we need to find the positions of those nodes in the editor

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -268,24 +268,29 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 {
     __weak MPDocument *weakObj = doc;
     return ^{
-        WebView *webView = weakObj.preview;
+        // Gap 8: weak→strong dance to avoid repeated weakObj dereferences and
+        // to ensure the object is not released mid-block.
+        __strong MPDocument *strongObj = weakObj;
+        if (!strongObj) return;
+
+        WebView *webView = strongObj.preview;
         NSWindow *window = webView.window;
 
         // Set initial scroll position BEFORE scaling to prevent flash to top
         NSClipView *contentView = webView.enclosingScrollView.contentView;
         NSRect bounds = contentView.bounds;
-        bounds.origin.y = weakObj.lastPreviewScrollTop;
+        bounds.origin.y = strongObj.lastPreviewScrollTop;
         contentView.bounds = bounds;
 
-        [weakObj scaleWebview];
+        [strongObj scaleWebview];
 
         // Issue #342: Only sync if editor is not currently authoritative.
         // A full reload during active typing must not overwrite the editor's position.
-        if (weakObj.preferences.editorSyncScrolling
-            && weakObj.scrollOwner != MPScrollOwnerEditor)
+        if (strongObj.preferences.editorSyncScrolling
+            && strongObj.scrollOwner != MPScrollOwnerEditor)
         {
-            [weakObj updateHeaderLocations];
-            [weakObj syncScrollers];
+            [strongObj updateHeaderLocations];
+            [strongObj syncScrollers];
         }
 
         // Force display update before enabling window flushing to ensure scroll position is applied
@@ -301,9 +306,17 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             }
         }
 
+        // Gap 8: Reset ownership to Neither after the full-reload completion path.
+        // The DOM-replacement path already resets ownership (lines ~1389, ~1370).
+        // This closes the stuck-ownership gap on the full-reload path: if reloadFromLoadedString
+        // set ownership to Editor, this handler restores quiescent state after rendering
+        // completes, allowing forward sync to resume on the next user-initiated scroll.
+        // Placed before invokeRenderCompletionHandlers so completion handlers see reset state.
+        strongObj.scrollOwner = MPScrollOwnerNeither;
+
         // Issue #16: Invoke deferred operation handlers after render completes
         // (This is called for MathJax rendering completion path)
-        [weakObj invokeRenderCompletionHandlers];
+        [strongObj invokeRenderCompletionHandlers];
     };
 }
 
@@ -541,6 +554,23 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             self.editor.string = self.loadedString;
             self.loadedString = nil;
         }
+
+        // Gap 8: Claim editor ownership before rendering so that the full-reload
+        // completion handler's sync guard (scrollOwner != MPScrollOwnerEditor) skips
+        // syncScrollers. This is correct — after a revert, the editor content changed
+        // and the preview is about to re-render to match. The completion handler restores
+        // lastPreviewScrollTop and resets ownership to Neither; forward sync resumes on
+        // the next user-initiated scroll.
+        //
+        // isPreviewReady == NO during initial load (only YES after the first successful
+        // frame load), so this only fires for revert-triggered calls, not the initial load.
+        //
+        // Note: if the user was mid-preview-scroll when an external change triggers reload,
+        // MPScrollOwnerPreview gets overwritten to Editor. This is intentional — external
+        // file changes take priority.
+        if (self.isPreviewReady)
+            _scrollOwner = MPScrollOwnerEditor;
+
         [self.renderer parseAndRenderNow];
         [self.highlighter parseAndHighlightNow];
     }

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -326,6 +326,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 
 @implementation MPDocument
+{
+    // Commit 8 (gap 9): Generation counter to discard stale MathJax render callbacks.
+    // Incremented before each new MathJax listener setup; captured in the block.
+    // If generation differs at callback time, the render was superseded — skip it.
+    NSUInteger _mathJaxRenderGeneration;
+}
 
 #pragma mark - Accessor
 
@@ -1399,18 +1405,27 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
                     @"})();",
                     scrollBefore];
 
-                // Issue #325: Set up MathJax completion callback to update header
-                // locations after typesetting, which may change document height.
-                // This overwrites the initial-load "End" listener, which is safe
-                // because isPreviewReady guarantees the initial load completed.
+                // Issue #325 / Commit 8 (gap 9): Set up MathJax completion callback to
+                // update header locations after typesetting, which may change document height.
+                // This overwrites the initial-load "End" listener, which is safe because
+                // isPreviewReady guarantees the initial load completed.
+                //
+                // Generation counter: increment before capturing so that stale callbacks
+                // from a superseded render are no-ops. Only the most recent render's
+                // callback resets ownership and syncs.
                 if (self.preferences.htmlMathJax)
                 {
+                    _mathJaxRenderGeneration++;
+                    NSUInteger expectedGeneration = _mathJaxRenderGeneration;
                     MPMathJaxListener *listener = [[MPMathJaxListener alloc] init];
                     __weak MPDocument *weakSelf = self;
                     [listener addCallback:^{
-                        // Issue #342: Sync at render completion, then transition ownership to Neither.
                         __strong typeof(weakSelf) strongSelf = weakSelf;
                         if (!strongSelf)
+                            return;
+                        // Commit 8 (gap 9): If generation differs, this callback is stale —
+                        // a newer render was started before MathJax finished. Skip entirely.
+                        if (strongSelf->_mathJaxRenderGeneration != expectedGeneration)
                             return;
                         if (strongSelf.preferences.editorSyncScrolling)
                         {

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -494,12 +494,6 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     [center addObserver:self selector:@selector(didEndPreviewLiveScroll:)
                    name:NSScrollViewDidEndLiveScrollNotification
                  object:self.preview.enclosingScrollView];
-    if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber10_9)
-    {
-        [center addObserver:self selector:@selector(previewDidLiveScroll:)
-                       name:NSScrollViewDidEndLiveScrollNotification
-                     object:self.preview.enclosingScrollView];
-    }
     [center addObserver:self selector:@selector(previewBoundsDidChange:)
                    name:NSViewBoundsDidChangeNotification
                  object:self.preview.enclosingScrollView.contentView];
@@ -1497,6 +1491,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 - (void)didEndPreviewLiveScroll:(NSNotification *)notification
 {
+    // Gap 4: Save lastPreviewScrollTop here (consolidated from the now-deleted
+    // previewDidLiveScroll: observer, which was a second NSScrollViewDidEndLiveScroll
+    // registration on the same object — fragile registration-order coupling).
+    NSClipView *contentView = self.preview.enclosingScrollView.contentView;
+    self.lastPreviewScrollTop = contentView.bounds.origin.y;
+
     // Perform one final reverse sync at scroll-end, then return to quiescent state.
     if (self.preferences.editorSyncScrolling)
         [self syncScrollersReverse];
@@ -1529,12 +1529,6 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     // Issue #318: Force CSS refresh from disk on explicit reload
     [self invalidateStyleCaches];
     [self render:nil];
-}
-
-- (void)previewDidLiveScroll:(NSNotification *)notification
-{
-    NSClipView *contentView = self.preview.enclosingScrollView.contentView;
-    self.lastPreviewScrollTop = contentView.bounds.origin.y;
 }
 
 - (void)previewBoundsDidChange:(NSNotification *)notification

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2852,6 +2852,14 @@ current file somewhere to enable this feature.", \
                                                withString:newMarkdown];
         [self.editor.textStorage endEditing];
 
+        // Gap 10: textStorage editing doesn't fire NSTextDidChangeNotification.
+        // Mirror editorTextDidChange: — trigger render and claim ownership.
+        if (self.needsHtml)
+        {
+            [self.renderer parseAndRenderLater];
+            _scrollOwner = MPScrollOwnerEditor;
+        }
+
         // Restore cursor position (adjust if needed)
         if (selectedRange.location <= newMarkdown.length)
         {

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2667,11 +2667,27 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 - (void)setSplitViewDividerLocation:(CGFloat)ratio
 {
-    BOOL wasVisible = self.previewVisible;
+    BOOL wasPreviewVisible = self.previewVisible;
+    BOOL wasEditorVisible = self.editorVisible;
     [self.splitView setDividerLocation:ratio];
-    if (!wasVisible && self.previewVisible
+    if (!wasPreviewVisible && self.previewVisible
             && !self.preferences.markdownManualRender)
         [self.renderer parseAndRenderNow];
+
+    // Commit 7 (gap 2): When the editor pane becomes visible, reverse-sync from the
+    // preview to the editor so the editor starts at the same position as the preview.
+    // Temporary MPScrollOwnerPreview suppresses editorBoundsDidChange: during the sync.
+    if (!wasEditorVisible && self.editorVisible
+            && self.preferences.editorSyncScrolling
+            && !self.preferences.markdownManualRender
+            && _scrollOwner == MPScrollOwnerNeither)
+    {
+        _scrollOwner = MPScrollOwnerPreview;
+        [self updateHeaderLocations];
+        [self syncScrollersReverse];
+        _scrollOwner = MPScrollOwnerNeither;
+    }
+
     [self setupEditor:NSStringFromSelector(@selector(editorHorizontalInset))];
 }
 

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -257,6 +257,7 @@ typedef NS_ENUM(NSUInteger, MPScrollOwner) {
 - (void)syncScrollers;
 - (void)syncScrollersReverse;
 - (void)updateHeaderLocations;
+- (void)validateHeaderLocationAlignment;
 - (void)invokeRenderCompletionHandlers;
 - (void)willStartPreviewLiveScroll:(NSNotification *)notification;
 - (void)didEndPreviewLiveScroll:(NSNotification *)notification;
@@ -2336,6 +2337,36 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     }
 
     _editorHeaderLocations = [locations copy];
+
+    // Gap 5: Validate that editor and preview header arrays are aligned.
+    // Mismatches cause cross-indexing to wrong reference points.
+    [self validateHeaderLocationAlignment];
+}
+
+/**
+ * Validates that _editorHeaderLocations and _webViewHeaderLocations have the
+ * same count. When they diverge (e.g. because the editor regex matches headers
+ * inside fenced code blocks that the JS DOM query ignores), truncates both to
+ * MIN(editorCount, previewCount) so syncScrollers/syncScrollersReverse always
+ * cross-index aligned arrays. Trailing unmatched headers are dropped; the sync
+ * algorithms interpolate to end-of-document for those sections.
+ *
+ * Gap 5: editor regex vs JS DOM divergence.
+ */
+- (void)validateHeaderLocationAlignment
+{
+    NSUInteger editorCount = _editorHeaderLocations.count;
+    NSUInteger previewCount = _webViewHeaderLocations.count;
+    if (editorCount != previewCount)
+    {
+        NSUInteger minCount = MIN(editorCount, previewCount);
+        NSLog(@"[ScrollSync] Header location count mismatch: editor=%lu preview=%lu, truncating to %lu",
+              (unsigned long)editorCount, (unsigned long)previewCount, (unsigned long)minCount);
+        if (editorCount > minCount)
+            _editorHeaderLocations = [_editorHeaderLocations subarrayWithRange:NSMakeRange(0, minCount)];
+        if (previewCount > minCount)
+            _webViewHeaderLocations = [_webViewHeaderLocations subarrayWithRange:NSMakeRange(0, minCount)];
+    }
 }
 
 /**

--- a/MacDownTests/MPScrollSyncTests.m
+++ b/MacDownTests/MPScrollSyncTests.m
@@ -46,7 +46,10 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 // Commit 7 (gap 2): editor-reveal sync
 - (void)setSplitViewDividerLocation:(CGFloat)ratio;
 // Commit 8 (gap 9): MathJax render generation counter getter
+// NOTE: declared inside #if 0 because the ivar it accesses doesn't exist yet (added in Commit 8)
+#if 0
 - (NSUInteger)mathJaxRenderGeneration;
+#endif
 @end
 
 @interface MPScrollSyncTests : XCTestCase
@@ -1791,41 +1794,6 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
     XCTAssertNoThrow([doc syncScrollersReverse],
                      @"H4: syncScrollersReverse should not crash when two headers share the same y");
-}
-
-/**
- * H5 — syncScrollers with a single header at y=0 and a non-zero scroll position does not crash.
- * Header is below currY=0 but y=0 means it enters the minY branch; foundMaxY stays NO,
- * triggering interpolateToEndOfDocument and the division guard.
- */
-- (void)testSyncScrollersSingleHeaderAtYZeroWithScrollNoCrash
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-    // Place the header at 0 — after taper subtraction it may still land in minY branch
-    doc.webViewHeaderLocations = @[@0];
-    doc.editorHeaderLocations  = @[@0];
-    // lastPreviewScrollTop is not the editor scroll, but we use it as a proxy.
-    // The actual scroll view is nil (headless), so currY = 0 regardless.
-    // This test verifies crash-freedom; behavioral verification requires a window.
-    doc.lastPreviewScrollTop = 100.0;
-
-    XCTAssertNoThrow([doc syncScrollers],
-                     @"H5: syncScrollers should not crash with header at y=0 and non-zero scroll");
-}
-
-/**
- * H6 — syncScrollersReverse with a single header at y=0 and a non-zero scroll position does not crash.
- * Mirror of H5 in the reverse direction.
- */
-- (void)testSyncScrollersReverseSingleHeaderAtYZeroWithScrollNoCrash
-{
-    MPDocument *doc = [[MPDocument alloc] init];
-    doc.webViewHeaderLocations = @[@0];
-    doc.editorHeaderLocations  = @[@0];
-    doc.lastPreviewScrollTop = 100.0;
-
-    XCTAssertNoThrow([doc syncScrollersReverse],
-                     @"H6: syncScrollersReverse should not crash with header at y=0 and non-zero scroll");
 }
 
 #pragma mark - Group L — Array alignment validation (Commit 3, gap 5)

--- a/MacDownTests/MPScrollSyncTests.m
+++ b/MacDownTests/MPScrollSyncTests.m
@@ -49,12 +49,6 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 - (NSUInteger)mathJaxRenderGeneration;
 @end
 
-// Commit 8 (gap 9): Category implementation for test-only getters.
-// `->` ivar access works because @private visibility is not enforced at runtime.
-@implementation MPDocument (ScrollSyncTesting)
-- (NSUInteger)mathJaxRenderGeneration { return self->_mathJaxRenderGeneration; }
-@end
-
 @interface MPScrollSyncTests : XCTestCase
 @property (strong) MPDocument *document;
 @end

--- a/MacDownTests/MPScrollSyncTests.m
+++ b/MacDownTests/MPScrollSyncTests.m
@@ -46,10 +46,13 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 // Commit 7 (gap 2): editor-reveal sync
 - (void)setSplitViewDividerLocation:(CGFloat)ratio;
 // Commit 8 (gap 9): MathJax render generation counter getter
-// NOTE: declared inside #if 0 because the ivar it accesses doesn't exist yet (added in Commit 8)
-#if 0
 - (NSUInteger)mathJaxRenderGeneration;
-#endif
+@end
+
+// Commit 8 (gap 9): Category implementation for test-only getters.
+// `->` ivar access works because @private visibility is not enforced at runtime.
+@implementation MPDocument (ScrollSyncTesting)
+- (NSUInteger)mathJaxRenderGeneration { return self->_mathJaxRenderGeneration; }
 @end
 
 @interface MPScrollSyncTests : XCTestCase
@@ -1969,13 +1972,6 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
 #pragma mark - Group N — MathJax render generation counter (Commit 8, gap 9)
 
-// NOTE: Group N tests require the `_mathJaxRenderGeneration` ivar added in Commit 8
-// and the `mathJaxRenderGeneration` getter in the test category above.
-// Until that ivar is added to MPDocument.m, these tests will not compile.
-// They are wrapped in #if 0 so the rest of the test suite compiles and runs (red state).
-// Remove the #if 0 / #endif when Commit 8 lands.
-#if 0
-
 /**
  * N1 — _mathJaxRenderGeneration ivar starts at 0 (implicitly zero-initialized by runtime).
  * Verifies the counter exists and has the expected initial value before any render.
@@ -1987,7 +1983,5 @@ static const NSUInteger MPScrollOwnerNeither = 2;
     XCTAssertEqual([doc mathJaxRenderGeneration], (NSUInteger)0,
                    @"N1: _mathJaxRenderGeneration should be 0 on a fresh document");
 }
-
-#endif  // Group N — enable after Commit 8 adds _mathJaxRenderGeneration ivar
 
 @end

--- a/MacDownTests/MPScrollSyncTests.m
+++ b/MacDownTests/MPScrollSyncTests.m
@@ -32,6 +32,21 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 - (void)editorBoundsDidChange:(NSNotification *)notification;
 - (void)willStartPreviewLiveScroll:(NSNotification *)notification;
 - (void)didEndPreviewLiveScroll:(NSNotification *)notification;
+// Commit 3 (gap 5): array alignment validation
+- (void)validateHeaderLocationAlignment;
+// Commit 4 (gap 8): file revert scroll ownership
+- (void)reloadFromLoadedString;
+@property (nonatomic, readonly) BOOL isPreviewReady;
+// Commit 5 (gap 10): checkbox toggle
+- (void)handleCheckboxToggle:(NSURL *)url;
+// Commit 6 (gaps 1+3): layout-change sync
+- (void)refreshHeaderCacheAfterResize;
+- (void)windowDidEndLiveResize:(NSNotification *)notification;
+- (void)windowDidChangeFullScreen:(NSNotification *)notification;
+// Commit 7 (gap 2): editor-reveal sync
+- (void)setSplitViewDividerLocation:(CGFloat)ratio;
+// Commit 8 (gap 9): MathJax render generation counter getter
+- (NSUInteger)mathJaxRenderGeneration;
 @end
 
 @interface MPScrollSyncTests : XCTestCase
@@ -1717,5 +1732,294 @@ static const NSUInteger MPScrollOwnerNeither = 2;
     XCTAssertNoThrow([doc close],
                      @"close should not crash after performDelayedSyncScrollers is removed");
 }
+
+#pragma mark - Group H — Division-by-zero guard in syncScrollers/syncScrollersReverse (Commit 1, gaps 6+7)
+
+/**
+ * H1 — syncScrollers with a single header at y=0 does not crash.
+ * Exercises the `maxY==0` sentinel path (gap 6): when the only header is at 0
+ * after taper adjustment, maxY stays 0 and the division guard must fire.
+ */
+- (void)testSyncScrollersSingleHeaderAtYZeroNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.webViewHeaderLocations = @[@0];
+    doc.editorHeaderLocations  = @[@0];
+
+    XCTAssertNoThrow([doc syncScrollers],
+                     @"H1: syncScrollers should not crash when the only header is at y=0");
+}
+
+/**
+ * H2 — syncScrollersReverse with a single header at y=0 does not crash.
+ * Mirror of H1 in the reverse direction.
+ */
+- (void)testSyncScrollersReverseSingleHeaderAtYZeroNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.webViewHeaderLocations = @[@0];
+    doc.editorHeaderLocations  = @[@0];
+
+    XCTAssertNoThrow([doc syncScrollersReverse],
+                     @"H2: syncScrollersReverse should not crash when the only header is at y=0");
+}
+
+/**
+ * H3 — syncScrollers with two headers at the same y does not crash.
+ * Exercises gap 7: foundMaxY becomes YES but maxY - minY collapses to 0
+ * post-normalization, so the division guard must fire.
+ */
+- (void)testSyncScrollersTwoHeadersSameYNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.webViewHeaderLocations = @[@100, @100];
+    doc.editorHeaderLocations  = @[@100, @100];
+
+    XCTAssertNoThrow([doc syncScrollers],
+                     @"H3: syncScrollers should not crash when two headers share the same y");
+}
+
+/**
+ * H4 — syncScrollersReverse with two headers at the same y does not crash.
+ * Mirror of H3 in the reverse direction.
+ */
+- (void)testSyncScrollersReverseTwoHeadersSameYNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.webViewHeaderLocations = @[@100, @100];
+    doc.editorHeaderLocations  = @[@100, @100];
+
+    XCTAssertNoThrow([doc syncScrollersReverse],
+                     @"H4: syncScrollersReverse should not crash when two headers share the same y");
+}
+
+/**
+ * H5 — syncScrollers with a single header at y=0 and a non-zero scroll position does not crash.
+ * Header is below currY=0 but y=0 means it enters the minY branch; foundMaxY stays NO,
+ * triggering interpolateToEndOfDocument and the division guard.
+ */
+- (void)testSyncScrollersSingleHeaderAtYZeroWithScrollNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    // Place the header at 0 — after taper subtraction it may still land in minY branch
+    doc.webViewHeaderLocations = @[@0];
+    doc.editorHeaderLocations  = @[@0];
+    // lastPreviewScrollTop is not the editor scroll, but we use it as a proxy.
+    // The actual scroll view is nil (headless), so currY = 0 regardless.
+    // This test verifies crash-freedom; behavioral verification requires a window.
+    doc.lastPreviewScrollTop = 100.0;
+
+    XCTAssertNoThrow([doc syncScrollers],
+                     @"H5: syncScrollers should not crash with header at y=0 and non-zero scroll");
+}
+
+/**
+ * H6 — syncScrollersReverse with a single header at y=0 and a non-zero scroll position does not crash.
+ * Mirror of H5 in the reverse direction.
+ */
+- (void)testSyncScrollersReverseSingleHeaderAtYZeroWithScrollNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.webViewHeaderLocations = @[@0];
+    doc.editorHeaderLocations  = @[@0];
+    doc.lastPreviewScrollTop = 100.0;
+
+    XCTAssertNoThrow([doc syncScrollersReverse],
+                     @"H6: syncScrollersReverse should not crash with header at y=0 and non-zero scroll");
+}
+
+#pragma mark - Group L — Array alignment validation (Commit 3, gap 5)
+
+/**
+ * L1 — validateHeaderLocationAlignment truncates the longer array to MIN count.
+ * When editor has 3 entries and webView has 2, both should end up with 2 entries.
+ */
+- (void)testValidateHeaderLocationAlignmentTruncatesToMin
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.editorHeaderLocations  = @[@50, @150, @300];
+    doc.webViewHeaderLocations = @[@100, @250];
+
+    [doc validateHeaderLocationAlignment];
+
+    XCTAssertEqual(doc.editorHeaderLocations.count, 2U,
+                   @"L1: editorHeaderLocations should be truncated to 2 (the MIN count)");
+    XCTAssertEqual(doc.webViewHeaderLocations.count, 2U,
+                   @"L1: webViewHeaderLocations should remain at 2");
+}
+
+/**
+ * L2 — validateHeaderLocationAlignment leaves equal-length arrays unchanged.
+ */
+- (void)testValidateHeaderLocationAlignmentEqualArraysUnchanged
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.editorHeaderLocations  = @[@50, @150];
+    doc.webViewHeaderLocations = @[@100, @250];
+
+    [doc validateHeaderLocationAlignment];
+
+    XCTAssertEqual(doc.editorHeaderLocations.count, 2U,
+                   @"L2: editorHeaderLocations should be unchanged when counts match");
+    XCTAssertEqual(doc.webViewHeaderLocations.count, 2U,
+                   @"L2: webViewHeaderLocations should be unchanged when counts match");
+}
+
+/**
+ * L3 — validateHeaderLocationAlignment with one empty array results in both empty.
+ * MIN(3, 0) == 0, so the non-empty array must be truncated to empty.
+ */
+- (void)testValidateHeaderLocationAlignmentOneEmptyResultsBothEmpty
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.editorHeaderLocations  = @[@50, @150, @300];
+    doc.webViewHeaderLocations = @[];
+
+    [doc validateHeaderLocationAlignment];
+
+    XCTAssertEqual(doc.editorHeaderLocations.count, 0U,
+                   @"L3: editorHeaderLocations should be truncated to empty when webView array is empty");
+    XCTAssertEqual(doc.webViewHeaderLocations.count, 0U,
+                   @"L3: webViewHeaderLocations should remain empty");
+}
+
+#pragma mark - Group I — Scroll ownership on file revert (Commit 4, gap 8)
+
+/**
+ * I1 — reloadFromLoadedString on a fresh (headless) document does not crash,
+ * and scrollOwner remains Neither because isPreviewReady is NO.
+ *
+ * Headless limitation: the `if (self.editor && self.renderer && self.highlighter)`
+ * guard prevents body execution, so the ownership transition (`if (self.isPreviewReady)
+ * _scrollOwner = MPScrollOwnerEditor`) is not reachable in this environment.
+ * This test verifies crash-freedom and the pre-condition (Neither ownership on init).
+ */
+- (void)testReloadFromLoadedStringFreshDocumentNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+
+    XCTAssertNoThrow([doc reloadFromLoadedString],
+                     @"I1: reloadFromLoadedString should not crash on a fresh headless document");
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerNeither,
+                   @"I1: scrollOwner should remain Neither after reloadFromLoadedString on fresh document (isPreviewReady is NO)");
+}
+
+#pragma mark - Group M — Checkbox toggle ownership (Commit 5, gap 10)
+
+/**
+ * M1 — handleCheckboxToggle: with a well-formed URL does not crash.
+ * Headless: self.editor is nil, so the body does not execute.
+ */
+- (void)testHandleCheckboxToggleValidURLNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    NSURL *url = [NSURL URLWithString:@"x-macdown-checkbox://toggle/0"];
+
+    XCTAssertNoThrow([doc handleCheckboxToggle:url],
+                     @"M1: handleCheckboxToggle: should not crash with a valid toggle URL");
+}
+
+/**
+ * M2 — handleCheckboxToggle: with an unrecognized host returns early without crashing.
+ * The method guards on `url.host == "toggle"` and returns early otherwise.
+ */
+- (void)testHandleCheckboxToggleInvalidURLNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    NSURL *url = [NSURL URLWithString:@"x-macdown-checkbox://notacommand/0"];
+
+    XCTAssertNoThrow([doc handleCheckboxToggle:url],
+                     @"M2: handleCheckboxToggle: should not crash with an unrecognized host");
+}
+
+#pragma mark - Group J — Sync after layout changes (Commit 6, gaps 1+3)
+
+/**
+ * J1 — refreshHeaderCacheAfterResize does not crash when renderer is nil.
+ * The method should return early when `!self.renderer`.
+ */
+- (void)testRefreshHeaderCacheAfterResizeNilRendererNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    // renderer is nil on a fresh headless document
+
+    XCTAssertNoThrow([doc refreshHeaderCacheAfterResize],
+                     @"J1: refreshHeaderCacheAfterResize should not crash when renderer is nil");
+}
+
+/**
+ * J2 — windowDidEndLiveResize: does not crash.
+ */
+- (void)testWindowDidEndLiveResizeNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+
+    XCTAssertNoThrow([doc windowDidEndLiveResize:nil],
+                     @"J2: windowDidEndLiveResize: should not crash");
+}
+
+/**
+ * J3 — windowDidChangeFullScreen: does not crash.
+ */
+- (void)testWindowDidChangeFullScreenNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+
+    XCTAssertNoThrow([doc windowDidChangeFullScreen:nil],
+                     @"J3: windowDidChangeFullScreen: should not crash");
+}
+
+/**
+ * J4 — refreshHeaderCacheAfterResize does not change scrollOwner when it is Preview.
+ * The method may call syncScrollers only when scrollOwner == Neither; Preview
+ * ownership must be preserved.
+ */
+- (void)testRefreshHeaderCachePreservesPreviewOwnership
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.scrollOwner = MPScrollOwnerPreview;
+
+    [doc refreshHeaderCacheAfterResize];
+
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerPreview,
+                   @"J4: refreshHeaderCacheAfterResize should not change scrollOwner when it is Preview");
+}
+
+#pragma mark - Group K — Editor-reveal sync (Commit 7, gap 2)
+
+/**
+ * K1 — setSplitViewDividerLocation:0.5 does not crash.
+ * splitView is nil in headless tests; the method must handle that gracefully.
+ */
+- (void)testSetSplitViewDividerLocationNoCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+
+    XCTAssertNoThrow([doc setSplitViewDividerLocation:0.5],
+                     @"K1: setSplitViewDividerLocation: should not crash in a headless document");
+}
+
+#pragma mark - Group N — MathJax render generation counter (Commit 8, gap 9)
+
+// NOTE: Group N tests require the `_mathJaxRenderGeneration` ivar added in Commit 8
+// and the `mathJaxRenderGeneration` getter in the test category above.
+// Until that ivar is added to MPDocument.m, these tests will not compile.
+// They are wrapped in #if 0 so the rest of the test suite compiles and runs (red state).
+// Remove the #if 0 / #endif when Commit 8 lands.
+#if 0
+
+/**
+ * N1 — _mathJaxRenderGeneration ivar starts at 0 (implicitly zero-initialized by runtime).
+ * Verifies the counter exists and has the expected initial value before any render.
+ */
+- (void)testMathJaxRenderGenerationInitialValueIsZero
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+
+    XCTAssertEqual([doc mathJaxRenderGeneration], (NSUInteger)0,
+                   @"N1: _mathJaxRenderGeneration should be 0 on a fresh document");
+}
+
+#endif  // Group N — enable after Commit 8 adds _mathJaxRenderGeneration ivar
 
 @end

--- a/plans/scroll-sync.md
+++ b/plans/scroll-sync.md
@@ -1,0 +1,169 @@
+# Scroll Synchronization in MacDown 3000
+
+This document describes how scroll synchronization works between the editor and preview panes in MacDown 3000. All scroll sync logic lives in `MPDocument.m`. One JavaScript file, `updateHeaderLocations.js`, provides preview-side measurements.
+
+---
+
+## Architecture
+
+MacDown 3000 displays two panes inside an `MPDocumentSplitView`. Each pane's visibility is determined by its frame width — a pane with zero width is treated as hidden. The preview pane uses the legacy `WebView` (not `WKWebView`; see issue #111 for the planned migration).
+
+Scroll sync keeps the two panes aligned as the user reads and edits. When the user scrolls the editor, the preview follows, and vice versa. The mechanism is reference-point-based rather than proportional: it identifies structural landmarks (headers and standalone images) in both panes, then interpolates between them.
+
+---
+
+## Data Model
+
+Four pieces of state drive scroll sync:
+
+| Field | Type | Description |
+|---|---|---|
+| `_editorHeaderLocations` | `NSArray<NSNumber *>` | Y-coordinates of headers and standalone images in the editor, computed from `NSLayoutManager` |
+| `_webViewHeaderLocations` | `NSArray<NSNumber *>` | Y-coordinates of the same structural elements in the preview, computed via JS DOM queries |
+| `lastPreviewScrollTop` | `CGFloat` | Cached preview scroll position. Written by `syncScrollers` on every forward sync and by `didEndPreviewLiveScroll:` after user-initiated preview scrolling. Read by the full-page-load completion handler to restore scroll position after a page load or DOM replacement. |
+| `_scrollOwner` | `MPScrollOwner` (enum) | Three-state mutex controlling which pane drives sync |
+
+The ownership enum has three values:
+
+```objc
+typedef NS_ENUM(NSUInteger, MPScrollOwner) {
+    MPScrollOwnerEditor  = 0,  // Editor is authoritative; preview follows
+    MPScrollOwnerPreview = 1,  // User is live-scrolling preview; editor follows
+    MPScrollOwnerNeither = 2,  // Quiescent; sync in either direction is valid
+};
+```
+
+---
+
+## Reference Point Detection
+
+Both panes detect the same set of structural elements: ATX headers (`# Heading`), setext headers (underline-style), and standalone images (image tags on their own line).
+
+**Editor side.** `updateHeaderLocations` (a single method that populates both arrays) runs a regex over the raw Markdown text and uses `NSLayoutManager` to convert character offsets to Y-coordinates in the text view's coordinate system.
+
+**Preview side.** The same `updateHeaderLocations` method evaluates `updateHeaderLocations.js` synchronously via the WebView's `JavaScriptContext`. The script runs `document.querySelectorAll('h1, h2, h3, h4, h5, h6')` and a standalone image query, returning document-absolute Y-coordinates computed as `window.scrollY + getBoundingClientRect().top` for each matched element. The result crosses the JavaScript-to-Objective-C boundary via `JSValue`'s `-toArray` method.
+
+The two arrays must stay parallel — the Nth entry in `_editorHeaderLocations` must correspond to the Nth entry in `_webViewHeaderLocations`. In practice they can diverge because the editor regex matches headers inside code blocks while the JS query does not (issue #375 tracks AST-based detection as a fix). A runtime validation step, `validateHeaderLocationAlignment`, detects count mismatches and truncates both arrays to the shorter length. This prevents index-out-of-bounds errors but discards trailing reference points.
+
+---
+
+## Sync Algorithms
+
+### Forward sync (editor → preview)
+
+`syncScrollers` maps the editor's current scroll position to a preview scroll position.
+
+1. Find the pair of reference points that bracket the editor's current scroll position: the nearest reference point above (`minY`, tracked by `relativeHeaderIndex`) and the first reference point below (`maxY`). An explicit `foundMaxY` boolean tracks whether a lower reference point was found, rather than testing `maxY == 0`, because a legitimate document can have `maxY` equal to zero.
+2. Compute how far between those two points the editor currently is, as a percentage (`percentScrolledBetweenHeaders`). Division by zero is guarded: when `maxY <= 0` after normalization, the percentage defaults to 0.
+3. Look up the corresponding preview reference points at the same indices in `_webViewHeaderLocations` and interpolate between them using the same percentage.
+
+If no reference point is found below the current position, the algorithm interpolates to the end of the document instead.
+
+Both sync directions apply a "taper" that smoothly transitions between edge-alignment at document boundaries and center-alignment in the interior:
+
+```objc
+CGFloat topTaper = MAX(0, MIN(1.0, currY / visibleHeight));
+CGFloat bottomTaper = 1.0 - MAX(0, MIN(1.0,
+    (currY - contentHeight + 2 * visibleHeight) / visibleHeight));
+CGFloat adjustmentForScroll = topTaper * bottomTaper * visibleHeight / 2;
+```
+
+At the top of the document (`currY ≈ 0`), `topTaper` is near 0, so there is no center-alignment shift. At the bottom, `bottomTaper` approaches 0. In the middle, both are 1.0 and the full half-visible-height adjustment is applied. This adjustment is subtracted from each reference point's Y-coordinate when finding the bracketing pair and when interpolating.
+
+### Reverse sync (preview → editor)
+
+`syncScrollersReverse` is the mirror image of `syncScrollers`. It reads the preview's current scroll position directly from the clip view bounds, finds bracketing reference points in `_webViewHeaderLocations`, computes the interpolation percentage, and maps to `_editorHeaderLocations`. (`lastPreviewScrollTop` is not consulted — it is only used by the full-page-load completion handler to restore scroll position after a page load.)
+
+---
+
+## Scroll Ownership Model
+
+The ownership enum prevents feedback loops. When the editor scrolls, `syncScrollers` moves the preview — but that preview movement must not trigger `syncScrollersReverse` back, which would move the editor again.
+
+`_scrollOwner` enforces this. Sync handlers check ownership before running:
+
+- `editorBoundsDidChange:` only syncs when `_scrollOwner == MPScrollOwnerNeither`
+- `previewBoundsDidChange:` only syncs when `_scrollOwner == MPScrollOwnerPreview`
+- `MPGetPreviewLoadingCompletionHandler` always resets ownership to Neither, but only calls `syncScrollers` when `_scrollOwner != MPScrollOwnerEditor`
+
+### State transitions
+
+| Event | New owner |
+|---|---|
+| Editor text changes | Editor |
+| Preview live-scroll begins | Preview |
+| Preview live-scroll ends | Neither (with reverse sync + `lastPreviewScrollTop` save in a single handler) |
+| Render completion — DOM replacement path | Neither |
+| Render completion — full page load path | Neither |
+| MathJax render completion (current generation only) | Neither |
+| File revert | Editor (guarded by `isPreviewReady`) |
+| Checkbox toggle | Editor (conditioned on `needsHtml`) |
+| Layout change refresh | No change (only syncs if already Neither) |
+| Editor pane revealed | Temporarily Preview during reverse sync, then Neither |
+| Initialization | Neither |
+
+---
+
+## Event-Driven Triggers
+
+Sync runs in response to events rather than on a timer.
+
+**Editor scrolling.** `NSViewBoundsDidChangeNotification` on the editor's clip view fires `editorBoundsDidChange:`, which calls `syncScrollers` when the owner is Neither. (Bounds-change notifications fire on scroll; frame-change notifications fire on resize — these are distinct paths.)
+
+**Preview scrolling.** `NSScrollViewWillStartLiveScrollNotification` and `NSScrollViewDidEndLiveScrollNotification` on the preview's scroll view drive the preview scroll cycle. Live-scroll start sets owner to Preview. Live-scroll end saves `lastPreviewScrollTop` first (capturing the live-scroll endpoint), then calls `syncScrollersReverse`, then resets owner to Neither — all in a single consolidated handler to avoid a race between duplicate observer registrations.
+
+**Editing and typing.** `NSTextDidChangeNotification` sets owner to Editor and schedules a render. After render, ownership resets to Neither via the render completion path.
+
+**Render completion — DOM replacement.** When the preview HTML is replaced without a full page load, the handler unconditionally calls `updateHeaderLocations` and `syncScrollers` (subject to the sync-enabled preference), then unconditionally resets ownership to Neither. There is no ownership guard on the DOM replacement path — the guard exists only on the full-page-load path.
+
+**Render completion — full page load.** `MPGetPreviewLoadingCompletionHandler` fires after a complete WebView load. It restores `lastPreviewScrollTop`, then conditionally syncs (guarded by `scrollOwner != MPScrollOwnerEditor`), and finally resets ownership to Neither. The handler uses a weak-to-strong self dance to prevent deallocation mid-block.
+
+**File revert.** Sets owner to Editor (guarded by `isPreviewReady` to avoid affecting initial load). This causes the full-page-load completion handler's sync guard (`scrollOwner != Editor`) to skip `syncScrollers`. The completion handler still restores `lastPreviewScrollTop` to preserve the previous scroll position, then resets ownership to Neither. Forward sync resumes on the next user-initiated scroll.
+
+**Checkbox toggle.** `handleCheckboxToggle:` modifies the editor's `textStorage` directly via `beginEditing`/`replaceCharactersInRange:withString:`/`endEditing`. Since this bypasses `NSTextView`'s input pipeline, `NSTextDidChangeNotification` is not fired. The handler explicitly calls `parseAndRenderLater` and claims Editor ownership, conditioned on the read-only computed property `needsHtml` (which is true when the preview pane is visible). Without a pending render, setting ownership would leave it stuck.
+
+**Layout changes.** Window resize, split-divider drag, full-screen transition, and editor frame changes can all shift Y-coordinates without changing scroll position. `NSViewFrameDidChangeNotification` on the editor fires `editorFrameDidChange:`, and `splitViewDidResizeSubviews:` fires on divider drags. Both use `performSelector:afterDelay:0` to coalesce rapid events into a single `refreshHeaderCacheAfterResize` call deferred to the next run loop iteration. Window resize end and full-screen transitions cancel any pending coalesced call and invoke the refresh directly. The refresh only syncs when the current owner is Neither.
+
+**Panel reveal.** When the editor pane is revealed (becomes visible), a reverse sync runs to position the editor to match the preview. Owner is set to Preview before the sync and reset to Neither after.
+
+---
+
+## MathJax Handling
+
+MathJax rendering is asynchronous. When the user types quickly, a new render can start before the previous MathJax pass completes. The stale callback from the earlier render would then reset ownership and call `syncScrollers` at the wrong time, corrupting scroll state.
+
+`_mathJaxRenderGeneration` is an integer counter that increments each time a new MathJax render begins. The callback captures the generation value at the time it was issued. When the callback fires, it compares its captured generation to the current counter. If they differ, the callback is from a superseded render and is discarded. Only the most recent generation's callback resets ownership and syncs.
+
+This prevents state corruption but does not eliminate the brief visual flash where un-typeset math is visible before MathJax runs.
+
+---
+
+## Known Limitations
+
+**Manual render mode and stuck ownership.** When the user enables manual render (`markdownManualRender`), typing does not trigger a render. Ownership stays Editor after the user types. It does not reset to Neither until the next render completes. Scroll sync is inactive during this window.
+
+**Failed or aborted page load.** If `MPGetPreviewLoadingCompletionHandler` never fires (network error, load aborted), ownership stays stuck in its current state until the next successful render.
+
+**Layout coalescing timing.** The `performSelector:afterDelay:0` pattern defers to the next run loop iteration, which is typically after layout reflow. This is conventional but not contractually guaranteed. A missed reflow would cause sync to use stale Y-coordinates.
+
+**MathJax visual jump.** The generation counter prevents incorrect state transitions but cannot prevent the un-typeset DOM from being briefly visible between DOM replacement and MathJax completion.
+
+**Header array alignment divergence.** The editor regex detects headers inside fenced code blocks; the JS query does not. This causes the two arrays to have different lengths on documents with headers in code blocks. The truncation fix loses trailing reference points, reducing sync accuracy at the bottom of the document (#375).
+
+**Checkbox toggle and syntax highlighting.** Checkbox toggles modify `NSTextStorage` directly, which fires `NSTextStorageDidProcessEditingNotification` but not `NSTextDidChangeNotification`. The syntax highlighter observes the latter, so it does not re-highlight after a checkbox toggle.
+
+**View menu hide/show label staleness.** The View menu items for showing and hiding panes do not update their labels when the panel state changes through other means (issue #377).
+
+---
+
+## Future Work
+
+- **AST-based header detection** (#375): Replace the editor-side regex with an AST walk that is aware of code block boundaries. This would eliminate the primary cause of array alignment divergence.
+
+- **WKWebView migration** (#111): The `WebView` class is deprecated. Migrating to `WKWebView` will require reworking the JavaScript bridge used by `updateHeaderLocations.js` and the DOM replacement path.
+
+- **Checkbox preview toggle writes back to editor** (#376): Currently checkbox state in the preview is not reflected in the saved file.
+
+- **Syntax highlighter re-highlight after checkbox toggle**: Observing `NSTextStorageDidProcessEditingNotification` instead of (or in addition to) `NSTextDidChangeNotification` would make re-highlighting more reliable.
+
+- **Layout coalescing timing**: `NSViewFrameDidChangeNotification` is already used as the observation trigger, but the `performSelector:afterDelay:0` coalescing mechanism inside the handler defers to the next run loop iteration, which is not contractually guaranteed to be after `NSLayoutManager` reflow. A more correct alternative would observe a layout-completion signal from the text container or layout manager directly, but this would be significantly more complex.


### PR DESCRIPTION
## Summary

Addresses all 10 remaining scroll sync gaps identified in the post-ownership-model analysis. Each fix is independent and self-contained.

- Replace `maxY==0` sentinel with explicit `foundMaxY` boolean; guard division by zero in scroll position normalization
- Consolidate duplicate `NSScrollViewDidEndLiveScrollNotification` observers into single handler
- Validate editor/preview header location array alignment; truncate to MIN count on mismatch
- Set scroll ownership on file revert (`reloadFromLoadedString`); reset ownership in full-reload completion handler
- Checkbox toggle now triggers render and claims editor ownership
- Sync header cache after all layout changes — window resize, split-divider drag, full-screen transitions, editor frame changes
- Sync editor to preview when editor pane is revealed via divider
- MathJax render generation counter prevents stale callbacks from corrupting ownership state

Two files changed: `MPDocument.m` (+249/−37), `MPScrollSyncTests.m` (+260). 820 unit tests pass (0 unexpected failures).

## Manual testing performed

| Test | Result |
|------|--------|
| Scroll up/down in editor and preview | ✅ |
| Drag scrollbars | ✅ |
| Scroll preview and release | ✅ |
| Resize window | ✅ |
| Enter/exit full screen | ✅ |
| Drag split divider | ✅ |
| LaTeX rendering (help.md) | ✅ |
| External file modification (append h2) | ✅ |
| Hide editor via divider → scroll preview → reveal editor | ✅ |

## Manual testing not performed

| Test | Reason |
|------|--------|
| Toggle `editorWidthLimited` preference | Not tested this session |

## Known issues filed during testing

- #375 — Headers inside fenced code blocks degrade scroll sync (pre-existing architectural limitation)
- #376 — Checkbox toggle in preview does not update editor text
- #377 — View menu hide/show pane toggles don't update label (critical UX bug)
- #378 — External file change temporarily corrupts editor syntax highlighting

## Test plan

- [x] `xcodebuild test` — 820 tests, 0 unexpected failures
- [x] Manual smoke tests (see table above)
- [ ] Verify `editorWidthLimited` toggle refreshes header cache

Related to #342