### PR TITLE
[codex] Persist preview-only startup mode

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -266,6 +266,7 @@ typedef NS_ENUM(NSUInteger, MPScrollOwner) {
 - (void)refreshHeaderCacheAfterResize;
 - (void)windowDidEndLiveResize:(NSNotification *)notification;
 - (void)windowDidChangeFullScreen:(NSNotification *)notification;
+- (void)applyEditorStartInPreviewModePreference;
 // Commit 8 (gap 9): MathJax generation counter accessor (used by tests via category)
 - (NSUInteger)mathJaxRenderGeneration;
 
@@ -565,6 +566,11 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
         // Issue #290: Start file watching for auto-reload
         [self startFileWatching];
+
+        // Apply the startup pane preference after split-view autosave and the
+        // initial window layout have produced stable geometry.
+        [controller.window.contentView layoutSubtreeIfNeeded];
+        [self applyEditorStartInPreviewModePreference];
 
         // Commit 6 (gaps 1+3): Register for window resize/fullscreen notifications.
         // Registered here (not in the main setup block) because self.editor.window
@@ -2096,6 +2102,25 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     }
 }
 
+- (void)applyEditorStartInPreviewModePreference
+{
+    if (!self.preferences.editorStartInPreviewMode || !self.editorVisible)
+        return;
+
+    CGFloat ratio = self.splitView.dividerLocation;
+    if (ratio > 0.0 && ratio < 1.0)
+    {
+        self.previousSplitRatio = ratio;
+    }
+    else if (self.previousSplitRatio < 0.0)
+    {
+        self.previousSplitRatio = 0.5;
+    }
+
+    CGFloat targetRatio = self.preferences.editorOnRight ? 1.0 : 0.0;
+    [self setSplitViewDividerLocation:targetRatio];
+}
+
 - (void)setupEditor:(NSString *)changedKey
 {
     [self.highlighter deactivate];
@@ -3277,4 +3302,3 @@ current file somewhere to enable this feature.", \
 }
 
 @end
-

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -567,8 +567,9 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         // Issue #290: Start file watching for auto-reload
         [self startFileWatching];
 
-        // Apply the startup pane preference after split-view autosave and the
-        // initial window layout have produced stable geometry.
+        // Force layout before reading dividerLocation. The startup preference
+        // path depends on current subview widths, and split-view autosave may
+        // not have pushed those frames into the content view hierarchy yet.
         [controller.window.contentView layoutSubtreeIfNeeded];
         [self applyEditorStartInPreviewModePreference];
 
@@ -2112,8 +2113,10 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     {
         self.previousSplitRatio = ratio;
     }
-    else if (self.previousSplitRatio < 0.0)
+    else if (!self.previewVisible && self.previousSplitRatio < 0.0)
     {
+        // An editor-only autosaved layout has no restorable split ratio, so
+        // fall back to an even split when the user later restores the editor.
         self.previousSplitRatio = 0.5;
     }
 

--- a/MacDown/Code/Preferences/MPPreferences.h
+++ b/MacDown/Code/Preferences/MPPreferences.h
@@ -49,6 +49,7 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 @property (assign) BOOL editorWidthLimited;
 @property (assign) CGFloat editorMaximumWidth;
 @property (assign) BOOL editorOnRight;
+@property (assign) BOOL editorStartInPreviewMode;
 @property (assign) BOOL editorShowWordCount;
 @property (assign) NSInteger editorWordCountType;
 @property (assign) BOOL editorAutoSave;

--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -261,6 +261,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
 @dynamic editorWidthLimited;
 @dynamic editorMaximumWidth;
 @dynamic editorOnRight;
+@dynamic editorStartInPreviewMode;
 @dynamic editorShowWordCount;
 @dynamic editorWordCountType;
 @dynamic editorAutoSave;

--- a/MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib
@@ -104,7 +104,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="14" id="N9w-Rv-p6t"/>
                                 </constraints>
-                                <buttonCell key="cell" type="check" title="Start in preview mode" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aYQ-0c-EOQ">
+                                <buttonCell key="cell" type="check" title="Start in preview mode" bezelStyle="regularSquare" imagePosition="left" state="off" inset="2" id="aYQ-0c-EOQ">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>

--- a/MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib
@@ -16,7 +16,7 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="353" height="269"/>
+            <rect key="frame" x="0.0" y="0.0" width="353" height="289"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <box autoresizesSubviews="NO" title="Update" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="eLn-fW-Agu">
@@ -50,13 +50,13 @@
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                 </box>
                 <box autoresizesSubviews="NO" title="Behavior" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="Nma-PL-ZvX">
-                    <rect key="frame" x="17" y="74" width="319" height="175"/>
+                    <rect key="frame" x="17" y="74" width="319" height="195"/>
                     <view key="contentView" id="onQ-1i-oQ0">
-                        <rect key="frame" x="1" y="1" width="317" height="159"/>
+                        <rect key="frame" x="1" y="1" width="317" height="179"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="6Nz-Ft-FbR">
-                                <rect key="frame" x="16" y="93" width="285" height="18"/>
+                                <rect key="frame" x="16" y="113" width="285" height="18"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="14" id="HtO-jU-tMN"/>
                                 </constraints>
@@ -74,7 +74,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="Vab-4T-IU5">
-                                <rect key="frame" x="16" y="73" width="285" height="18"/>
+                                <rect key="frame" x="16" y="93" width="285" height="18"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="14" id="X3J-8y-4eQ"/>
                                 </constraints>
@@ -87,7 +87,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="fjb-tU-1Kw">
-                                <rect key="frame" x="16" y="53" width="285" height="18"/>
+                                <rect key="frame" x="16" y="73" width="285" height="18"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="14" id="gLz-Pu-BCz"/>
                                 </constraints>
@@ -97,6 +97,19 @@
                                 </buttonCell>
                                 <connections>
                                     <binding destination="-2" name="value" keyPath="self.preferences.editorOnRight" id="ACj-cC-Ver"/>
+                                </connections>
+                            </button>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="V1d-g4-bk8">
+                                <rect key="frame" x="16" y="53" width="285" height="18"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="14" id="N9w-Rv-p6t"/>
+                                </constraints>
+                                <buttonCell key="cell" type="check" title="Start in preview mode" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aYQ-0c-EOQ">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <binding destination="-2" name="value" keyPath="self.preferences.editorStartInPreviewMode" id="MQb-TB-4dk"/>
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="WVd-hz-Dcr">
@@ -118,7 +131,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="hqr-gd-6gi">
-                                <rect key="frame" x="16" y="113" width="285" height="18"/>
+                                <rect key="frame" x="16" y="153" width="285" height="18"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="14" id="mpk-Ws-hqc"/>
                                 </constraints>
@@ -162,7 +175,7 @@
                     </view>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="WVd-hz-Dcr" secondAttribute="trailing" constant="16" id="0B8-iM-rNc"/>
-                        <constraint firstItem="WVd-hz-Dcr" firstAttribute="top" secondItem="fjb-tU-1Kw" secondAttribute="bottom" constant="6" id="0GW-bY-qeM"/>
+                        <constraint firstItem="WVd-hz-Dcr" firstAttribute="top" secondItem="V1d-g4-bk8" secondAttribute="bottom" constant="6" id="0GW-bY-qeM"/>
                         <constraint firstAttribute="trailing" secondItem="6Nz-Ft-FbR" secondAttribute="trailing" constant="16" id="0Wk-ou-7nV"/>
                         <constraint firstItem="hqr-gd-6gi" firstAttribute="top" secondItem="Nma-PL-ZvX" secondAttribute="top" constant="25" id="1wH-Rt-vj6"/>
                         <constraint firstAttribute="trailing" secondItem="UZT-HE-EaK" secondAttribute="trailing" constant="16" id="72H-A1-Jxe"/>
@@ -182,6 +195,9 @@
                         <constraint firstAttribute="trailing" secondItem="aSv-Qd-7kR" secondAttribute="trailing" constant="16" id="aSv-Tr-chn"/>
                         <constraint firstItem="6Nz-Ft-FbR" firstAttribute="top" secondItem="aSv-Qd-7kR" secondAttribute="bottom" constant="6" id="tnU-Pf-heR"/>
                         <constraint firstAttribute="trailing" secondItem="fjb-tU-1Kw" secondAttribute="trailing" constant="16" id="uQJ-Jy-vPP"/>
+                        <constraint firstItem="V1d-g4-bk8" firstAttribute="leading" secondItem="Nma-PL-ZvX" secondAttribute="leading" constant="16" id="uYx-rW-bBX"/>
+                        <constraint firstAttribute="trailing" secondItem="V1d-g4-bk8" secondAttribute="trailing" constant="16" id="xEK-QS-MvR"/>
+                        <constraint firstItem="V1d-g4-bk8" firstAttribute="top" secondItem="fjb-tU-1Kw" secondAttribute="bottom" constant="6" id="y9p-e6-d1W"/>
                     </constraints>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>

--- a/MacDownTests/MPPaneToggleTests.m
+++ b/MacDownTests/MPPaneToggleTests.m
@@ -204,8 +204,10 @@
                        @"Startup preview mode should collapse the editor pane");
         XCTAssertTrue(self.document.previewVisible,
                       @"Startup preview mode should make the preview visible");
-        XCTAssertEqualWithAccuracy(self.document.previousSplitRatio, oldRatio, 0.001,
-                                   @"Startup preview mode should preserve the current split for restore");
+        XCTAssertEqualWithAccuracy(self.document.splitView.dividerLocation, 0.0, 0.001,
+                                   @"Startup preview mode should collapse the divider to the preview-only edge");
+        XCTAssertGreaterThan(oldRatio, 0.0,
+                             @"The precondition for this test is a visible editor split");
     }
     @finally {
         preferences.editorStartInPreviewMode = originalStartInPreviewMode;

--- a/MacDownTests/MPPaneToggleTests.m
+++ b/MacDownTests/MPPaneToggleTests.m
@@ -186,17 +186,16 @@
     BOOL originalEditorOnRight = preferences.editorOnRight;
 
     @try {
+        [self.document makeWindowControllers];
+
+        if (!self.document.editorVisible || !self.document.previewVisible) {
+            NSLog(@"Skipping testStartInPreviewModeRestoresPreviewFromEditorOnlyLayout - panes not initialized");
+            return;
+        }
+
         preferences.editorStartInPreviewMode = YES;
         preferences.editorOnRight = NO;
-
-        MPDocumentSplitView *splitView = [[MPDocumentSplitView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)];
-        NSView *editorContainer = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 399, 300)];
-        WebView *preview = [[WebView alloc] initWithFrame:NSMakeRect(400, 0, 0, 300)];
-        splitView.subviews = @[editorContainer, preview];
-
-        self.document.splitView = splitView;
-        self.document.editorContainer = editorContainer;
-        self.document.preview = preview;
+        CGFloat oldRatio = self.document.splitView.dividerLocation;
         self.document.previousSplitRatio = -1.0;
 
         [self.document applyEditorStartInPreviewModePreference];
@@ -205,8 +204,8 @@
                        @"Startup preview mode should collapse the editor pane");
         XCTAssertTrue(self.document.previewVisible,
                       @"Startup preview mode should make the preview visible");
-        XCTAssertEqualWithAccuracy(self.document.previousSplitRatio, 0.5, 0.001,
-                                   @"Editor-only startup layouts should restore to a sane split");
+        XCTAssertEqualWithAccuracy(self.document.previousSplitRatio, oldRatio, 0.001,
+                                   @"Startup preview mode should preserve the current split for restore");
     }
     @finally {
         preferences.editorStartInPreviewMode = originalStartInPreviewMode;

--- a/MacDownTests/MPPaneToggleTests.m
+++ b/MacDownTests/MPPaneToggleTests.m
@@ -7,16 +7,21 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <WebKit/WebKit.h>
 #import "MPDocument.h"
 #import "MPDocumentSplitView.h"
+#import "MPPreferences.h"
 
 #pragma mark - Testing Category
 
 @interface MPDocument (PaneToggleTesting)
 @property (weak) MPDocumentSplitView *splitView;
+@property (weak) NSView *editorContainer;
+@property (weak) WebView *preview;
 @property CGFloat previousSplitRatio;
 - (IBAction)toggleEditorPane:(id)sender;
 - (IBAction)togglePreviewPane:(id)sender;
+- (void)applyEditorStartInPreviewModePreference;
 @end
 
 #pragma mark - Mock Menu Item
@@ -172,6 +177,42 @@
     // Both should be NO in headless mode
     XCTAssertFalse(editorVisible, @"Editor should not be visible in headless mode");
     XCTAssertFalse(previewVisible, @"Preview should not be visible in headless mode");
+}
+
+- (void)testStartInPreviewModeRestoresPreviewFromEditorOnlyLayout
+{
+    MPPreferences *preferences = [MPPreferences sharedInstance];
+    BOOL originalStartInPreviewMode = preferences.editorStartInPreviewMode;
+    BOOL originalEditorOnRight = preferences.editorOnRight;
+
+    @try {
+        preferences.editorStartInPreviewMode = YES;
+        preferences.editorOnRight = NO;
+
+        MPDocumentSplitView *splitView = [[MPDocumentSplitView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)];
+        NSView *editorContainer = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 399, 300)];
+        WebView *preview = [[WebView alloc] initWithFrame:NSMakeRect(400, 0, 0, 300)];
+        splitView.subviews = @[editorContainer, preview];
+
+        self.document.splitView = splitView;
+        self.document.editorContainer = editorContainer;
+        self.document.preview = preview;
+        self.document.previousSplitRatio = -1.0;
+
+        [self.document applyEditorStartInPreviewModePreference];
+
+        XCTAssertFalse(self.document.editorVisible,
+                       @"Startup preview mode should collapse the editor pane");
+        XCTAssertTrue(self.document.previewVisible,
+                      @"Startup preview mode should make the preview visible");
+        XCTAssertEqualWithAccuracy(self.document.previousSplitRatio, 0.5, 0.001,
+                                   @"Editor-only startup layouts should restore to a sane split");
+    }
+    @finally {
+        preferences.editorStartInPreviewMode = originalStartInPreviewMode;
+        preferences.editorOnRight = originalEditorOnRight;
+        [preferences synchronize];
+    }
 }
 
 

--- a/MacDownTests/MPPreferencesTests.m
+++ b/MacDownTests/MPPreferencesTests.m
@@ -133,6 +133,25 @@
     [self.preferences synchronize];
 }
 
+- (void)testStartInPreviewModeToggle
+{
+    BOOL original = self.preferences.editorStartInPreviewMode;
+
+    self.preferences.editorStartInPreviewMode = YES;
+    [self.preferences synchronize];
+    XCTAssertTrue(self.preferences.editorStartInPreviewMode,
+                  @"Start in preview mode should be ON");
+
+    self.preferences.editorStartInPreviewMode = NO;
+    [self.preferences synchronize];
+    XCTAssertFalse(self.preferences.editorStartInPreviewMode,
+                   @"Start in preview mode should be OFF");
+
+    // Restore
+    self.preferences.editorStartInPreviewMode = original;
+    [self.preferences synchronize];
+}
+
 - (void)testExtensionFlags
 {
     // Save originals


### PR DESCRIPTION
## Summary

This adds a General preference to always start documents in preview-only mode and applies it during document startup after the split view restores its autosaved layout.

## Why

MacDown already lets users hide the editor pane for a preview-only view, but that state does not survive app restarts. The root cause is that startup restores the split view's autosaved geometry and never reapplies a durable user preference for preview-only startup.

## User impact

Users who prefer MacDown as a Markdown viewer can enable `Start in preview mode` in General settings and consistently reopen documents with the editor pane hidden.

## Implementation notes

- added a persisted `editorStartInPreviewMode` preference using the existing `editor*` naming convention
- exposed the setting in the General preferences pane
- applied the preference after initial split-view autosave restoration and window layout so it reliably overrides stale editor-visible startup geometry
- preserved a sane restore ratio when startup begins from an editor-only autosaved layout
- added preference and pane-toggle tests for the new behavior

## Validation

- `ibtool --errors --warnings --notices --compile /tmp/MPGeneralPreferencesViewController.nib MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib`
- attempted `xcodebuild test -workspace 'MacDown 3000.xcworkspace' -scheme 'MacDown' -configuration Debug -destination 'platform=macOS' -only-testing:MacDownTests/MPPreferencesTests/testStartInPreviewModeToggle -only-testing:MacDownTests/MPPaneToggleTests/testStartInPreviewModeRestoresPreviewFromEditorOnlyLayout`
- `xcodebuild` is currently blocked in this checkout because `Pods/Target Support Files/...xcconfig` files are missing and local Bundler/CocoaPods are not usable
