### PR TITLE
[codex] Harden preview script boundaries

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2959,6 +2959,24 @@ current file somewhere to enable this feature.", \
     if (![url.host isEqualToString:@"toggle"])
         return;
 
+    NSURLComponents *components =
+        [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    NSString *token = nil;
+    for (NSURLQueryItem *item in components.queryItems)
+    {
+        if ([item.name isEqualToString:@"token"])
+        {
+            token = item.value;
+            break;
+        }
+    }
+    if (!token.length
+        || ![token isEqualToString:self.renderer.checkboxBridgeToken])
+    {
+        NSLog(@"MacDown: Ignored unauthorized checkbox toggle: %@", url);
+        return;
+    }
+
     NSString *path = url.path;
     if (path.length < 2)
         return;
@@ -3277,4 +3295,3 @@ current file somewhere to enable this feature.", \
 }
 
 @end
-

--- a/MacDown/Code/Document/MPRenderer.h
+++ b/MacDown/Code/Document/MPRenderer.h
@@ -24,6 +24,7 @@ typedef NS_ENUM(NSUInteger, MPCodeBlockAccessoryType)
 @property (nonatomic) int rendererFlags;
 @property (weak) id<MPRendererDataSource> dataSource;
 @property (weak) id<MPRendererDelegate> delegate;
+@property (nonatomic, copy, readonly) NSString *checkboxBridgeToken;
 
 - (void)parseAndRenderNow;
 - (void)parseAndRenderLater;

--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -482,6 +482,8 @@ NS_INLINE NSString *MPEscapeHTMLText(NSString *value)
 
 NS_INLINE NSString *MPPreviewContentSecurityPolicy(void)
 {
+    // MathJax 2.x relies on eval/new Function during startup, and bundled
+    // preview libraries inject inline styles while rendering annotated output.
     return @"default-src 'none'; "
            @"base-uri 'none'; "
            @"form-action 'none'; "
@@ -819,7 +821,8 @@ NS_INLINE NSString *MPPreviewHeadTags(NSString *checkboxBridgeToken)
     }
 
     NSString *title = [self.dataSource rendererHTMLTitle:self];
-    self.checkboxBridgeToken = NSUUID.UUID.UUIDString;
+    if (!self.checkboxBridgeToken.length)
+        self.checkboxBridgeToken = NSUUID.UUID.UUIDString;
     NSString *headTags = MPPreviewHeadTags(self.checkboxBridgeToken);
     NSString *html = MPGetHTML(
         title, headTags, body, self.stylesheets, MPAssetFullLink,

--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -243,8 +243,8 @@ NS_INLINE NSString *MPHTMLFromMarkdown(
 }
 
 NS_INLINE NSString *MPGetHTML(
-    NSString *title, NSString *body, NSArray *styles, MPAssetOption styleopt,
-    NSArray *scripts, MPAssetOption scriptopt)
+    NSString *title, NSString *headTags, NSString *body, NSArray *styles,
+    MPAssetOption styleopt, NSArray *scripts, MPAssetOption scriptopt)
 {
     NSMutableArray *styleTags = [NSMutableArray array];
     NSMutableArray *scriptTags = [NSMutableArray array];
@@ -277,11 +277,13 @@ NS_INLINE NSString *MPGetHTML(
 
     NSString *titleTag = @"";
     if (title.length)
-        titleTag = [NSString stringWithFormat:@"<title>%@</title>", title];
+        titleTag = [NSString stringWithFormat:@"<title>%@</title>",
+                    MPEscapeHTMLText(title)];
 
     NSDictionary *context = @{
         @"title": title ? title : @"",
         @"titleTag": titleTag ? titleTag : @"",
+        @"headTags": headTags ? headTags : @"",
         @"styleTags": styleTags ? styleTags : @[],
         @"body": body ? body : @"",
         @"scriptTags": scriptTags ? scriptTags : @[],
@@ -323,6 +325,7 @@ NS_INLINE BOOL MPAreNilableStringsEqual(NSString *s1, NSString *s2)
 @property BOOL lineNumbers;
 @property BOOL manualRender;
 @property (copy) NSString *highlightingThemeName;
+@property (nonatomic, copy, readwrite) NSString *checkboxBridgeToken;
 
 // Issue #110: Cache-busting timestamps for local resources
 @property (strong) NSMutableDictionary<NSString *, NSNumber *> *resourceTimestamps;
@@ -436,6 +439,65 @@ NS_INLINE void MPFreeHTMLRenderer(hoedown_renderer *htmlRenderer)
     if (extra)
         free(extra);
     hoedown_html_renderer_free(htmlRenderer);
+}
+
+NS_INLINE NSString *MPEscapeHTMLAttribute(NSString *value)
+{
+    if (!value.length)
+        return @"";
+
+    NSMutableString *escaped = [value mutableCopy];
+    [escaped replaceOccurrencesOfString:@"&" withString:@"&amp;"
+                                options:0 range:NSMakeRange(0, escaped.length)];
+    [escaped replaceOccurrencesOfString:@"\"" withString:@"&quot;"
+                                options:0 range:NSMakeRange(0, escaped.length)];
+    [escaped replaceOccurrencesOfString:@"'" withString:@"&#39;"
+                                options:0 range:NSMakeRange(0, escaped.length)];
+    [escaped replaceOccurrencesOfString:@"<" withString:@"&lt;"
+                                options:0 range:NSMakeRange(0, escaped.length)];
+    [escaped replaceOccurrencesOfString:@">" withString:@"&gt;"
+                                options:0 range:NSMakeRange(0, escaped.length)];
+    return escaped;
+}
+
+NS_INLINE NSString *MPEscapeHTMLText(NSString *value)
+{
+    if (!value.length)
+        return @"";
+
+    NSMutableString *escaped = [value mutableCopy];
+    [escaped replaceOccurrencesOfString:@"&" withString:@"&amp;"
+                                options:0 range:NSMakeRange(0, escaped.length)];
+    [escaped replaceOccurrencesOfString:@"<" withString:@"&lt;"
+                                options:0 range:NSMakeRange(0, escaped.length)];
+    [escaped replaceOccurrencesOfString:@">" withString:@"&gt;"
+                                options:0 range:NSMakeRange(0, escaped.length)];
+    return escaped;
+}
+
+NS_INLINE NSString *MPPreviewContentSecurityPolicy(void)
+{
+    return @"default-src 'none'; "
+           @"base-uri 'none'; "
+           @"form-action 'none'; "
+           @"object-src 'none'; "
+           @"frame-src 'none'; "
+           @"img-src data: file: http: https:; "
+           @"media-src data: file: http: https:; "
+           @"style-src 'self' 'unsafe-inline' file:; "
+           @"font-src data: file:; "
+           @"connect-src http: https:; "
+           @"script-src 'self' file: https://cdnjs.cloudflare.com 'unsafe-eval'";
+}
+
+NS_INLINE NSString *MPPreviewHeadTags(NSString *checkboxBridgeToken)
+{
+    NSString *csp = MPEscapeHTMLAttribute(MPPreviewContentSecurityPolicy());
+    NSString *token = MPEscapeHTMLAttribute(checkboxBridgeToken);
+    return [NSString stringWithFormat:
+        @"<meta http-equiv=\"Content-Security-Policy\" content=\"%@\">\n"
+         "<meta name=\"macdown-checkbox-token\" content=\"%@\">",
+        csp, token];
 }
 
 
@@ -752,8 +814,10 @@ NS_INLINE void MPFreeHTMLRenderer(hoedown_renderer *htmlRenderer)
     }
 
     NSString *title = [self.dataSource rendererHTMLTitle:self];
+    self.checkboxBridgeToken = NSUUID.UUID.UUIDString;
+    NSString *headTags = MPPreviewHeadTags(self.checkboxBridgeToken);
     NSString *html = MPGetHTML(
-        title, body, self.stylesheets, MPAssetFullLink,
+        title, headTags, body, self.stylesheets, MPAssetFullLink,
         self.scripts, MPAssetFullLink);
     [delegate renderer:self didProduceHTMLOutput:html];
 
@@ -825,7 +889,8 @@ NS_INLINE void MPFreeHTMLRenderer(hoedown_renderer *htmlRenderer)
     if (!title)
         title = @"";
     NSString *html = MPGetHTML(
-        title, self.currentHtml, styles, stylesOption, scripts, scriptsOption);
+        title, nil, self.currentHtml, styles, stylesOption, scripts,
+        scriptsOption);
     return html;
 }
 

--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -242,6 +242,11 @@ NS_INLINE NSString *MPHTMLFromMarkdown(
     return result;
 }
 
+NS_INLINE NSString *MPEscapeHTMLAttribute(NSString *value);
+NS_INLINE NSString *MPEscapeHTMLText(NSString *value);
+NS_INLINE NSString *MPPreviewContentSecurityPolicy(void);
+NS_INLINE NSString *MPPreviewHeadTags(NSString *checkboxBridgeToken);
+
 NS_INLINE NSString *MPGetHTML(
     NSString *title, NSString *headTags, NSString *body, NSArray *styles,
     MPAssetOption styleopt, NSArray *scripts, MPAssetOption scriptopt)

--- a/MacDown/Resources/Extensions/tasklist.js
+++ b/MacDown/Resources/Extensions/tasklist.js
@@ -7,6 +7,8 @@
  * Related to GitHub issue #269.
  */
 (function () {
+  var tokenMeta = document.querySelector('meta[name="macdown-checkbox-token"]');
+  var checkboxToken = tokenMeta ? tokenMeta.getAttribute('content') : '';
   var taskListItems = document.getElementsByClassName('task-list-item');
   for (var i = 0; i < taskListItems.length; i++) {
     var inputs = taskListItems[i].getElementsByTagName('input');
@@ -21,7 +23,11 @@
         var index = checkbox.getAttribute('data-checkbox-index');
         if (index !== null) {
           // Navigate to custom URL scheme to trigger Objective-C handler
-          window.location = 'x-macdown-checkbox://toggle/' + index;
+          var url = 'x-macdown-checkbox://toggle/' + index;
+          if (checkboxToken) {
+            url += '?token=' + encodeURIComponent(checkboxToken);
+          }
+          window.location = url;
         }
       });
       break;

--- a/MacDown/Resources/Templates/Default.handlebars
+++ b/MacDown/Resources/Templates/Default.handlebars
@@ -6,6 +6,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 {{{ titleTag }}}
+{{{ headTags }}}
 
 {{#each styleTags }}
 {{{ this }}}

--- a/MacDownTests/MPRendererEdgeCaseTests.m
+++ b/MacDownTests/MPRendererEdgeCaseTests.m
@@ -158,7 +158,7 @@
                   @"Renderer should expose the active checkbox bridge token");
 }
 
-- (void)testPreviewRenderRotatesCheckboxBridgeToken
+- (void)testPreviewRenderKeepsCheckboxBridgeTokenStableAcrossRenders
 {
     self.renderer.rendererFlags = HOEDOWN_HTML_USE_TASK_LIST;
     self.dataSource.markdown = @"- [ ] Task";
@@ -170,8 +170,10 @@
     [self.renderer render];
     NSString *secondToken = [self.renderer.checkboxBridgeToken copy];
 
-    XCTAssertNotEqualObjects(firstToken, secondToken,
-                             @"Each preview render should mint a fresh checkbox bridge token");
+    XCTAssertEqualObjects(firstToken, secondToken,
+                          @"DOM-only preview refreshes keep the original head meta tags, so the checkbox bridge token must remain stable across renders");
+    XCTAssertTrue([self.delegate.lastHTML containsString:firstToken],
+                  @"Rendered preview HTML should continue to expose the active checkbox bridge token");
 }
 
 - (void)testHTMLExportDoesNotIncludePreviewOnlySecurityMetaTags

--- a/MacDownTests/MPRendererEdgeCaseTests.m
+++ b/MacDownTests/MPRendererEdgeCaseTests.m
@@ -13,6 +13,7 @@
 #import "MPRenderer.h"
 #import "MPRendererTestHelpers.h"
 #import "hoedown/document.h"
+#import "hoedown_html_patch.h"
 
 
 #pragma mark - Test Class
@@ -132,6 +133,60 @@
     NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
 
     XCTAssertNotNil(html, @"Should handle single newline");
+}
+
+
+#pragma mark - Preview Security Tests
+
+- (void)testPreviewRenderIncludesContentSecurityPolicyAndCheckboxToken
+{
+    self.renderer.rendererFlags = HOEDOWN_HTML_USE_TASK_LIST;
+    self.dataSource.markdown = @"- [ ] Task";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+
+    NSString *html = self.delegate.lastHTML;
+    XCTAssertNotNil(html, @"Preview render should produce HTML");
+    XCTAssertTrue([html containsString:@"Content-Security-Policy"],
+                  @"Preview HTML should include a CSP meta tag");
+    XCTAssertTrue([html containsString:@"script-src 'self' file: https://cdnjs.cloudflare.com 'unsafe-eval'"],
+                  @"CSP should whitelist only bundled scripts and the MathJax CDN");
+    XCTAssertTrue([html containsString:@"name=\"macdown-checkbox-token\""],
+                  @"Preview HTML should include a checkbox bridge token");
+    XCTAssertTrue(self.renderer.checkboxBridgeToken.length > 0,
+                  @"Renderer should expose the active checkbox bridge token");
+}
+
+- (void)testPreviewRenderRotatesCheckboxBridgeToken
+{
+    self.renderer.rendererFlags = HOEDOWN_HTML_USE_TASK_LIST;
+    self.dataSource.markdown = @"- [ ] Task";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+    NSString *firstToken = [self.renderer.checkboxBridgeToken copy];
+
+    [self.renderer render];
+    NSString *secondToken = [self.renderer.checkboxBridgeToken copy];
+
+    XCTAssertNotEqualObjects(firstToken, secondToken,
+                             @"Each preview render should mint a fresh checkbox bridge token");
+}
+
+- (void)testHTMLExportDoesNotIncludePreviewOnlySecurityMetaTags
+{
+    self.renderer.rendererFlags = HOEDOWN_HTML_USE_TASK_LIST;
+    self.dataSource.markdown = @"- [ ] Task";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
+
+    XCTAssertNotNil(html, @"Export should produce HTML");
+    XCTAssertFalse([html containsString:@"Content-Security-Policy"],
+                   @"Preview-only CSP should not be embedded into exports");
+    XCTAssertFalse([html containsString:@"macdown-checkbox-token"],
+                   @"Preview-only checkbox tokens should not leak into exports");
 }
 
 

--- a/MacDownTests/MPRendererEdgeCaseTests.m
+++ b/MacDownTests/MPRendererEdgeCaseTests.m
@@ -150,7 +150,7 @@
     XCTAssertNotNil(html, @"Preview render should produce HTML");
     XCTAssertTrue([html containsString:@"Content-Security-Policy"],
                   @"Preview HTML should include a CSP meta tag");
-    XCTAssertTrue([html containsString:@"script-src 'self' file: https://cdnjs.cloudflare.com 'unsafe-eval'"],
+    XCTAssertTrue([html containsString:@"script-src &#39;self&#39; file: https://cdnjs.cloudflare.com &#39;unsafe-eval&#39;"],
                   @"CSP should whitelist only bundled scripts and the MathJax CDN");
     XCTAssertTrue([html containsString:@"name=\"macdown-checkbox-token\""],
                   @"Preview HTML should include a checkbox bridge token");

--- a/MacDownTests/MPScrollSyncTests.m
+++ b/MacDownTests/MPScrollSyncTests.m
@@ -11,6 +11,8 @@
 #import <JavaScriptCore/JavaScriptCore.h>
 #import "MPDocument.h"
 #import "MPPreferences.h"
+#import "MPRenderer.h"
+#import "MPEditorView.h"
 
 // Issue #342: Scroll ownership enum constants (must match MPScrollOwner in MPDocument.m)
 static const NSUInteger MPScrollOwnerEditor  = 0;
@@ -23,6 +25,8 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 @property (strong) NSArray<NSNumber *> *webViewHeaderLocations;
 @property (strong) NSArray<NSNumber *> *editorHeaderLocations;
 @property (weak) WebView *preview;
+@property (strong) MPRenderer *renderer;
+@property (unsafe_unretained) MPEditorView *editor;
 @property (nonatomic) NSUInteger scrollOwner;  // Issue #342: MPScrollOwner enum
 - (void)updateHeaderLocations;
 - (void)syncScrollers;
@@ -1895,6 +1899,48 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
     XCTAssertNoThrow([doc handleCheckboxToggle:url],
                      @"M2: handleCheckboxToggle: should not crash with an unrecognized host");
+}
+
+/**
+ * M3 — handleCheckboxToggle: ignores mismatched checkbox bridge tokens.
+ */
+- (void)testHandleCheckboxToggleRejectsMismatchedToken
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    MPRenderer *renderer = [[MPRenderer alloc] init];
+    MPEditorView *editor = [[MPEditorView alloc] initWithFrame:NSZeroRect];
+    doc.renderer = renderer;
+    doc.editor = editor;
+    editor.string = @"- [ ] Task";
+    [renderer setValue:@"expected-token" forKey:@"checkboxBridgeToken"];
+
+    NSURL *url = [NSURL URLWithString:
+                  @"x-macdown-checkbox://toggle/0?token=wrong-token"];
+    [doc handleCheckboxToggle:url];
+
+    XCTAssertEqualObjects(editor.string, @"- [ ] Task",
+                          @"Checkbox toggles with a mismatched token must be ignored");
+}
+
+/**
+ * M4 — handleCheckboxToggle: applies authorized checkbox toggles.
+ */
+- (void)testHandleCheckboxToggleAcceptsMatchingToken
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    MPRenderer *renderer = [[MPRenderer alloc] init];
+    MPEditorView *editor = [[MPEditorView alloc] initWithFrame:NSZeroRect];
+    doc.renderer = renderer;
+    doc.editor = editor;
+    editor.string = @"- [ ] Task";
+    [renderer setValue:@"expected-token" forKey:@"checkboxBridgeToken"];
+
+    NSURL *url = [NSURL URLWithString:
+                  @"x-macdown-checkbox://toggle/0?token=expected-token"];
+    [doc handleCheckboxToggle:url];
+
+    XCTAssertEqualObjects(editor.string, @"- [x] Task",
+                          @"Checkbox toggles with the active bridge token should update the source document");
 }
 
 #pragma mark - Group J — Sync after layout changes (Commit 6, gaps 1+3)


### PR DESCRIPTION
## What changed

This PR hardens the main app preview against document-supplied script execution.

- adds a preview-only Content Security Policy to the rendered HTML template
- mints a per-document token for the `x-macdown-checkbox` bridge and keeps it stable across DOM-only preview refreshes
- requires that token before applying checkbox toggles back into the source document
- keeps preview-only security metadata out of HTML exports
- adds focused renderer and document-level tests for the CSP and checkbox bridge token behavior

## Why it changed

The preview currently renders Markdown into a live WebView and injects body content directly into the DOM. That makes the preview an active execution surface for attacker-controlled HTML/JS. The checkbox bridge was also callable by any preview script because it trusted every `x-macdown-checkbox://toggle/...` navigation.

This patch contains the first hardening slice by constraining which scripts can execute in the preview and by making the checkbox bridge non-forgeable from static document content.

Related to #security-review

## Impact

- untrusted inline script and event handlers in preview content are blocked by CSP
- bundled preview features continue to work through explicitly allowed script sources
- checkbox toggles now require the active bridge token minted during preview rendering
- DOM-only preview refreshes keep checkbox toggles working because the token remains stable for the document
- HTML export output is unchanged by the preview-only protections

## Validation

- added renderer tests covering preview CSP emission, stable token behavior, and export behavior
- added document-level tests covering accepted and rejected checkbox bridge tokens
- ran `xcodebuild test -workspace "MacDown 3000.xcworkspace" -scheme MacDown -destination 'platform=macOS'`
- result: `854` tests passed, `0` failures
