### PR TITLE
[codex] Harden Quick Look preview sandbox

### DIFF
--- a/MacDownCore/MPQuickLookRenderer.m
+++ b/MacDownCore/MPQuickLookRenderer.m
@@ -163,6 +163,21 @@ NS_INLINE NSString *MPPreprocessMarkdown(NSString *text)
     return result;
 }
 
+NS_INLINE NSString *MPQuickLookContentSecurityPolicy(void)
+{
+    return @"default-src 'none'; "
+           @"base-uri 'none'; "
+           @"form-action 'none'; "
+           @"object-src 'none'; "
+           @"frame-src 'none'; "
+           @"connect-src 'none'; "
+           @"img-src data: file:; "
+           @"media-src data: file:; "
+           @"font-src data: file:; "
+           @"style-src 'unsafe-inline'; "
+           @"script-src 'none'";
+}
+
 
 #pragma mark - Hoedown Renderer Callbacks
 
@@ -354,6 +369,8 @@ static void mp_quicklook_render_blockcode(
     [html appendString:@"<html>\n<head>\n"];
     [html appendString:@"<meta charset=\"utf-8\">\n"];
     [html appendString:@"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"];
+    [html appendFormat:@"<meta http-equiv=\"Content-Security-Policy\" content=\"%@\">\n",
+                       MPQuickLookContentSecurityPolicy()];
 
     // Embed CSS styles
     [html appendString:[self embeddedStyles]];
@@ -362,11 +379,6 @@ static void mp_quicklook_render_blockcode(
 
     // Body content
     [html appendString:body ?: @""];
-
-    // Embed scripts (Prism for syntax highlighting)
-    if ([self.preferences syntaxHighlightingEnabled] && self.detectedLanguages.count > 0) {
-        [html appendString:[self embeddedScripts]];
-    }
 
     [html appendString:@"\n</body>\n</html>"];
 

--- a/MacDownCore/MPQuickLookRenderer.m
+++ b/MacDownCore/MPQuickLookRenderer.m
@@ -16,7 +16,6 @@
 NSString * const MPQuickLookRendererErrorDomain = @"MPQuickLookRendererErrorDomain";
 
 // Constants
-static NSString * const kMPPrismScriptDirectory = @"Prism/components";
 static NSString * const kMPPrismThemeDirectory = @"Prism/themes";
 static size_t kMPRendererNestingLevel = SIZE_MAX;
 
@@ -181,14 +180,8 @@ NS_INLINE NSString *MPQuickLookContentSecurityPolicy(void)
 
 #pragma mark - Hoedown Renderer Callbacks
 
-// Extra state for language tracking
-typedef struct {
-    void *owner;
-    NSMutableArray *languages;
-} MPQuickLookRendererState;
-
 /**
- * Custom blockcode renderer that tracks languages for Prism.
+ * Custom blockcode renderer that adds Prism language classes without scripts.
  */
 static void mp_quicklook_render_blockcode(
     hoedown_buffer *ob,
@@ -196,9 +189,6 @@ static void mp_quicklook_render_blockcode(
     const hoedown_buffer *lang,
     const hoedown_renderer_data *data)
 {
-    hoedown_html_renderer_state *state = data->opaque;
-    MPQuickLookRendererState *extra = state->opaque;
-
     if (ob->size) hoedown_buffer_putc(ob, '\n');
 
     HOEDOWN_BUFPUTSL(ob, "<pre><code");
@@ -207,13 +197,6 @@ static void mp_quicklook_render_blockcode(
         NSString *language = [[NSString alloc] initWithBytes:lang->data
                                                       length:lang->size
                                                     encoding:NSUTF8StringEncoding];
-
-        // Track language for Prism script inclusion
-        if (extra && extra->languages && language.length > 0) {
-            if (![extra->languages containsObject:language]) {
-                [extra->languages addObject:language];
-            }
-        }
 
         // Add language class for Prism
         HOEDOWN_BUFPUTSL(ob, " class=\"language-");
@@ -233,7 +216,6 @@ static void mp_quicklook_render_blockcode(
 
 @interface MPQuickLookRenderer ()
 @property (nonatomic, strong) MPQuickLookPreferences *preferences;
-@property (nonatomic, strong) NSMutableArray *detectedLanguages;
 @end
 
 
@@ -244,7 +226,6 @@ static void mp_quicklook_render_blockcode(
     self = [super init];
     if (self) {
         _preferences = [MPQuickLookPreferences sharedPreferences];
-        _detectedLanguages = [NSMutableArray array];
     }
     return self;
 }
@@ -260,9 +241,6 @@ static void mp_quicklook_render_blockcode(
     if (markdown.length == 0) {
         return [self wrapBodyInHTML:@""];
     }
-
-    // Clear detected languages
-    [self.detectedLanguages removeAllObjects];
 
     // Preprocess markdown
     NSString *preprocessed = MPPreprocessMarkdown(markdown);
@@ -327,14 +305,8 @@ static void mp_quicklook_render_blockcode(
     // Create HTML renderer
     hoedown_renderer *renderer = hoedown_html_renderer_new(flags, 0);
 
-    // Set up custom blockcode handler for language tracking
+    // Preserve Prism language classes, but Quick Look never executes Prism JS.
     renderer->blockcode = mp_quicklook_render_blockcode;
-
-    // Set up extra state for language tracking
-    MPQuickLookRendererState extra;
-    extra.owner = (__bridge void *)self;
-    extra.languages = self.detectedLanguages;
-    ((hoedown_html_renderer_state *)renderer->opaque)->opaque = &extra;
 
     // Create document
     hoedown_document *document = hoedown_document_new(
@@ -415,51 +387,4 @@ static void mp_quicklook_render_blockcode(
 
     return styles;
 }
-
-- (NSString *)embeddedScripts
-{
-    NSMutableString *scripts = [NSMutableString string];
-    NSBundle *bundle = MPQuickLookBundle();
-
-    // Prism core
-    NSURL *coreURL = [bundle URLForResource:@"prism-core.min"
-                              withExtension:@"js"
-                               subdirectory:kMPPrismScriptDirectory];
-    if (!coreURL) {
-        coreURL = [bundle URLForResource:@"prism-core"
-                           withExtension:@"js"
-                            subdirectory:kMPPrismScriptDirectory];
-    }
-
-    NSString *coreContent = MPReadFileContents(coreURL.path);
-    if (coreContent.length > 0) {
-        [scripts appendString:@"<script type=\"text/javascript\">\n"];
-        [scripts appendString:coreContent];
-        [scripts appendString:@"\n</script>\n"];
-    }
-
-    // Language-specific Prism components
-    for (NSString *language in self.detectedLanguages) {
-        NSString *langFile = [NSString stringWithFormat:@"prism-%@.min", [language lowercaseString]];
-        NSURL *langURL = [bundle URLForResource:langFile
-                                  withExtension:@"js"
-                                   subdirectory:kMPPrismScriptDirectory];
-        if (!langURL) {
-            langFile = [NSString stringWithFormat:@"prism-%@", [language lowercaseString]];
-            langURL = [bundle URLForResource:langFile
-                               withExtension:@"js"
-                                subdirectory:kMPPrismScriptDirectory];
-        }
-
-        NSString *langContent = MPReadFileContents(langURL.path);
-        if (langContent.length > 0) {
-            [scripts appendString:@"<script type=\"text/javascript\">\n"];
-            [scripts appendString:langContent];
-            [scripts appendString:@"\n</script>\n"];
-        }
-    }
-
-    return scripts;
-}
-
 @end

--- a/MacDownQuickLook/MacDownQuickLook.entitlements
+++ b/MacDownQuickLook/MacDownQuickLook.entitlements
@@ -6,7 +6,5 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
-    <key>com.apple.security.network.client</key>
-    <true/>
 </dict>
 </plist>

--- a/MacDownQuickLook/PreviewViewController.m
+++ b/MacDownQuickLook/PreviewViewController.m
@@ -32,10 +32,11 @@
 {
     // Create web view configuration
     WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
-    config.preferences.javaScriptEnabled = NO;
     config.preferences.javaScriptCanOpenWindowsAutomatically = NO;
     if (@available(macOS 11.0, *)) {
         config.defaultWebpagePreferences.allowsContentJavaScript = NO;
+    } else {
+        config.preferences.javaScriptEnabled = NO;
     }
 
     // Create web view with a meaningful initial size
@@ -133,6 +134,8 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
     NSURL *url = navigationAction.request.URL;
     NSString *scheme = url.scheme.lowercaseString;
 
+    // `loadHTMLString:` may produce `about:` or `data:` navigations for the rendered
+    // document and embedded data URI assets. The CSP still blocks script execution.
     if ([scheme isEqualToString:@"about"] || [scheme isEqualToString:@"data"]) {
         decisionHandler(WKNavigationActionPolicyAllow);
         return;

--- a/MacDownQuickLook/PreviewViewController.m
+++ b/MacDownQuickLook/PreviewViewController.m
@@ -32,6 +32,11 @@
 {
     // Create web view configuration
     WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+    config.preferences.javaScriptEnabled = NO;
+    config.preferences.javaScriptCanOpenWindowsAutomatically = NO;
+    if (@available(macOS 11.0, *)) {
+        config.defaultWebpagePreferences.allowsContentJavaScript = NO;
+    }
 
     // Create web view with a meaningful initial size
     NSRect frame = NSMakeRect(0, 0, 800, 600);
@@ -119,6 +124,21 @@
         self.pendingHandler = nil;
         h(error);
     }
+}
+
+- (void)webView:(WKWebView *)webView
+decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction
+decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
+{
+    NSURL *url = navigationAction.request.URL;
+    NSString *scheme = url.scheme.lowercaseString;
+
+    if ([scheme isEqualToString:@"about"] || [scheme isEqualToString:@"data"]) {
+        decisionHandler(WKNavigationActionPolicyAllow);
+        return;
+    }
+
+    decisionHandler(WKNavigationActionPolicyCancel);
 }
 
 @end

--- a/MacDownTests/MPQuickLookRendererTests.m
+++ b/MacDownTests/MPQuickLookRendererTests.m
@@ -148,6 +148,19 @@
                   @"Should include closing </html> tag");
 }
 
+- (void)testRenderIncludesContentSecurityPolicy
+{
+    NSString *markdown = @"# Test";
+    NSString *html = [self.renderer renderMarkdown:markdown];
+
+    XCTAssertTrue([html containsString:@"Content-Security-Policy"],
+                  @"Quick Look HTML should include a CSP meta tag");
+    XCTAssertTrue([html containsString:@"script-src 'none'"],
+                  @"Quick Look CSP should block all script execution");
+    XCTAssertTrue([html containsString:@"connect-src 'none'"],
+                  @"Quick Look CSP should block outbound network connections");
+}
+
 - (void)testRenderIncludesCSSStyles
 {
     NSString *markdown = @"# Test";
@@ -245,15 +258,15 @@
                   @"Should add language-python class for Prism");
 }
 
-- (void)testPrismScriptsIncluded
+- (void)testQuickLookDoesNotEmbedPrismScripts
 {
     NSString *markdown = @"```javascript\nconsole.log('test');\n```";
     NSString *html = [self.renderer renderMarkdown:markdown];
 
-    // Prism scripts are only included when the bundle has the Prism resource files.
-    // In the test bundle they may be absent, so check for language class instead.
     XCTAssertTrue([html containsString:@"language-javascript"],
                   @"Should tag code blocks with Prism language class");
+    XCTAssertFalse([html containsString:@"<script type=\"text/javascript\">"],
+                   @"Quick Look should not embed executable Prism scripts");
 }
 
 - (void)testLanguageAliasesMapped


### PR DESCRIPTION
## Summary

- disable content JavaScript in the Quick Look WKWebView and cancel non-local navigations
- add a restrictive Content Security Policy to Quick Look HTML output
- stop embedding Prism scripts in Quick Look and remove the extension network-client entitlement
- add renderer tests covering the CSP and the absence of embedded Quick Look scripts

## Why

Quick Look was rendering attacker-controlled Markdown into a live WKWebView with script execution paths and outbound network capability. A malicious file previewed in Finder could execute JavaScript and exfiltrate document content without opening the main app.

## Root cause

The Quick Look path reused the normal rendered HTML body, appended executable Prism scripts, left WebKit JavaScript enabled, and shipped a sandbox entitlement for outbound network access.

## Validation

- `xcodebuild test -workspace "MacDown 3000.xcworkspace" -scheme MacDown -destination "platform=macOS"`
- 257 tests passed, 0 failures
