### PR TITLE
[codex] Restrict auto-created link targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Security
+
+- Restrict auto-created link targets to the current document's folder to prevent unauthorized file creation (#386)
+
 ## [3000.0.6] - 2026-04-18
 
 This release rebuilds scroll sync around an ownership model that eliminates timing-based race conditions, and fixes several user-reported bugs with preview rendering, Quick Look, and diagram support. The deep dive into the long history of the editor / preview panel scroll synchronization took about a day of persistent work. Hopefully it was worth it!

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2866,6 +2866,22 @@ the current file is not saved anywhere yet. Save the \
 current file somewhere to enable this feature.", \
 @"preview navigation error information")
 
+#define AUTO_CREATE_SCOPE_FAIL_ALERT_INFORMATIVE NSLocalizedString( \
+@"MacDown only auto-creates missing file links inside the current \
+document folder. Save or create the target manually if you want \
+to link outside that scope.", \
+@"preview navigation error information")
+
+
+- (BOOL)canAutomaticallyCreateLinkedFileAtURL:(NSURL *)url
+{
+    if (!url.isFileURL || !self.fileURL.isFileURL)
+        return NO;
+
+    NSURL *baseURL = self.currentBaseUrl ?: self.fileURL;
+    return [MPURLSecurityPolicy url:url isWithinScopeOfBaseURL:baseURL];
+}
+
 
 - (void)openOrCreateFileForUrl:(NSURL *)url
 {
@@ -2932,6 +2948,19 @@ current file somewhere to enable this feature.", \
                              url.lastPathComponent];
         alert.informativeText = AUTO_CREATE_FAIL_ALERT_INFORMATIVE;
         [alert runModal];
+        return;
+    }
+
+    if (![self canAutomaticallyCreateLinkedFileAtURL:url])
+    {
+        NSAlert *alert = [[NSAlert alloc] init];
+        NSString *template = NSLocalizedString(
+            @"Blocked file creation:\n%@",
+            @"preview navigation error message");
+        alert.messageText = [NSString stringWithFormat:template, url.path];
+        alert.informativeText = AUTO_CREATE_SCOPE_FAIL_ALERT_INFORMATIVE;
+        [alert runModal];
+        return;
     }
 
     // Try to created the file.

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2878,6 +2878,7 @@ to link outside that scope.", \
     if (!url.isFileURL || !self.fileURL.isFileURL)
         return NO;
 
+    // Fall back to the document file URL if a rendering base URL isn't set.
     NSURL *baseURL = self.currentBaseUrl ?: self.fileURL;
     return [MPURLSecurityPolicy url:url isWithinScopeOfBaseURL:baseURL];
 }
@@ -2954,6 +2955,7 @@ to link outside that scope.", \
     if (![self canAutomaticallyCreateLinkedFileAtURL:url])
     {
         NSAlert *alert = [[NSAlert alloc] init];
+        alert.alertStyle = NSAlertStyleWarning;
         NSString *template = NSLocalizedString(
             @"Blocked file creation:\n%@",
             @"preview navigation error message");

--- a/MacDownTests/MPDocumentIOTests.m
+++ b/MacDownTests/MPDocumentIOTests.m
@@ -10,6 +10,11 @@
 #import "MPPreferences.h"
 #import <sys/stat.h>
 
+@interface MPDocument (LinkTargetTesting)
+@property (strong) NSURL *currentBaseUrl;
+- (BOOL)canAutomaticallyCreateLinkedFileAtURL:(NSURL *)url;
+@end
+
 @interface MPDocumentIOTests : XCTestCase
 @property (strong) MPDocument *document;
 @property (strong) NSURL *testFileURL;
@@ -421,6 +426,91 @@
 
     XCTAssertNil(doc, @"Should not create document from nonexistent file");
     XCTAssertNotNil(error, @"Should return error for nonexistent file");
+}
+
+#pragma mark - Link Target Auto-Creation Security Tests
+
+- (void)testCanAutomaticallyCreateLinkedFileInSameDirectory
+{
+    NSURL *targetURL = [NSURL fileURLWithPath:
+        [self.testDirectory stringByAppendingPathComponent:@"notes.md"]];
+
+    self.document.fileURL = self.testFileURL;
+
+    XCTAssertTrue([self.document canAutomaticallyCreateLinkedFileAtURL:targetURL],
+                  @"Missing file links in the same directory should be auto-creatable");
+}
+
+- (void)testCanAutomaticallyCreateLinkedFileInSubdirectory
+{
+    NSString *subdirectory = [self.testDirectory stringByAppendingPathComponent:@"assets"];
+    [self.fileManager createDirectoryAtPath:subdirectory
+                withIntermediateDirectories:YES
+                                 attributes:nil
+                                      error:nil];
+    NSURL *targetURL = [NSURL fileURLWithPath:
+        [subdirectory stringByAppendingPathComponent:@"diagram.md"]];
+
+    self.document.fileURL = self.testFileURL;
+
+    XCTAssertTrue([self.document canAutomaticallyCreateLinkedFileAtURL:targetURL],
+                  @"Missing file links in a subdirectory should remain auto-creatable");
+}
+
+- (void)testCanAutomaticallyCreateLinkedFileRejectsUnsavedDocument
+{
+    NSURL *targetURL = [NSURL fileURLWithPath:
+        [self.testDirectory stringByAppendingPathComponent:@"notes.md"]];
+
+    XCTAssertFalse([self.document canAutomaticallyCreateLinkedFileAtURL:targetURL],
+                   @"Untitled documents should not auto-create link targets");
+}
+
+- (void)testCanAutomaticallyCreateLinkedFileRejectsOutOfScopeTarget
+{
+    NSString *outsideDirectory = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+    [self.fileManager createDirectoryAtPath:outsideDirectory
+                withIntermediateDirectories:YES
+                                 attributes:nil
+                                      error:nil];
+    [self addTeardownBlock:^{
+        [self.fileManager removeItemAtPath:outsideDirectory error:nil];
+    }];
+
+    NSURL *targetURL = [NSURL fileURLWithPath:
+        [outsideDirectory stringByAppendingPathComponent:@"outside.md"]];
+    self.document.fileURL = self.testFileURL;
+
+    XCTAssertFalse([self.document canAutomaticallyCreateLinkedFileAtURL:targetURL],
+                   @"Auto-created link targets must stay within the current document scope");
+}
+
+- (void)testCanAutomaticallyCreateLinkedFileRejectsSymlinkEscape
+{
+    NSString *docsDirectory = [self.testDirectory stringByAppendingPathComponent:@"docs"];
+    NSString *outsideDirectory = [self.testDirectory stringByAppendingPathComponent:@"outside"];
+    [self.fileManager createDirectoryAtPath:docsDirectory
+                withIntermediateDirectories:YES
+                                 attributes:nil
+                                      error:nil];
+    [self.fileManager createDirectoryAtPath:outsideDirectory
+                withIntermediateDirectories:YES
+                                 attributes:nil
+                                      error:nil];
+
+    NSString *symlinkPath = [docsDirectory stringByAppendingPathComponent:@"escape"];
+    [self.fileManager createSymbolicLinkAtPath:symlinkPath
+                           withDestinationPath:outsideDirectory
+                                         error:nil];
+
+    self.document.fileURL = [NSURL fileURLWithPath:
+        [docsDirectory stringByAppendingPathComponent:@"source.md"]];
+    NSURL *targetURL = [NSURL fileURLWithPath:
+        [symlinkPath stringByAppendingPathComponent:@"payload.md"]];
+
+    XCTAssertFalse([self.document canAutomaticallyCreateLinkedFileAtURL:targetURL],
+                   @"Symlink escapes must not be auto-created");
 }
 
 @end


### PR DESCRIPTION
## Summary

- block automatic creation of missing file-link targets that resolve outside the current document scope
- stop the auto-create path immediately for unsaved documents instead of falling through after the alert
- add document-level regression tests covering saved, unsaved, in-scope, out-of-scope, and symlink-escape link targets

## Why

When `createFileForLinkTarget` was enabled, clicking a missing Markdown file link could create an empty file anywhere the user could write, not just beside the current document. A crafted link could therefore create arbitrary files outside the document tree.

## Root cause

The preview link handler validated executable targets when opening existing files, but the auto-create branch passed unresolved file URLs straight to `createNewEmptyDocumentForURL:` without checking whether the target stayed within the current document scope.

## Validation

- `xcodebuild test -workspace "MacDown 3000.xcworkspace" -scheme MacDown -destination "platform=macOS"`
- 862 tests passed, 0 failures
