### PR TITLE
Fix flaky testCompletionHandlerIsEventuallyCalledAfterNavigation

### DIFF
--- a/MacDownQuickLook/PreviewViewController.m
+++ b/MacDownQuickLook/PreviewViewController.m
@@ -15,7 +15,7 @@
 @property (nonatomic, strong) MPQuickLookRenderer *renderer;
 @property (nonatomic, copy) void (^pendingHandler)(NSError * _Nullable);
 // Allows tests to substitute a synchronous WKWebView without starting the XPC web content process.
-@property (nonatomic, copy) WKWebView *(^webViewFactory)(WKWebViewConfiguration *config);
+@property (nonatomic, copy) WKWebView *(^webViewFactory)(WKWebViewConfiguration *config, NSRect frame);
 @end
 
 
@@ -44,7 +44,7 @@
     // Create web view with a meaningful initial size
     NSRect frame = NSMakeRect(0, 0, 800, 600);
     self.webView = self.webViewFactory
-        ? self.webViewFactory(config)
+        ? self.webViewFactory(config, frame)
         : [[WKWebView alloc] initWithFrame:frame configuration:config];
     self.webView.navigationDelegate = self;
     self.webView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;

--- a/MacDownQuickLook/PreviewViewController.m
+++ b/MacDownQuickLook/PreviewViewController.m
@@ -14,6 +14,8 @@
 @property (nonatomic, strong) WKWebView *webView;
 @property (nonatomic, strong) MPQuickLookRenderer *renderer;
 @property (nonatomic, copy) void (^pendingHandler)(NSError * _Nullable);
+// Allows tests to substitute a synchronous WKWebView without starting the XPC web content process.
+@property (nonatomic, copy) WKWebView *(^webViewFactory)(WKWebViewConfiguration *config);
 @end
 
 
@@ -41,7 +43,9 @@
 
     // Create web view with a meaningful initial size
     NSRect frame = NSMakeRect(0, 0, 800, 600);
-    self.webView = [[WKWebView alloc] initWithFrame:frame configuration:config];
+    self.webView = self.webViewFactory
+        ? self.webViewFactory(config)
+        : [[WKWebView alloc] initWithFrame:frame configuration:config];
     self.webView.navigationDelegate = self;
     self.webView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 

--- a/MacDownQuickLook/PreviewViewController.m
+++ b/MacDownQuickLook/PreviewViewController.m
@@ -43,8 +43,9 @@
 
     // Create web view with a meaningful initial size
     NSRect frame = NSMakeRect(0, 0, 800, 600);
-    self.webView = self.webViewFactory
-        ? self.webViewFactory(config, frame)
+    WKWebView *(^factory)(WKWebViewConfiguration *, NSRect) = self.webViewFactory;
+    self.webView = factory
+        ? factory(config, frame)
         : [[WKWebView alloc] initWithFrame:frame configuration:config];
     self.webView.navigationDelegate = self;
     self.webView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;

--- a/MacDownTests/MPPreviewViewControllerTests.m
+++ b/MacDownTests/MPPreviewViewControllerTests.m
@@ -22,7 +22,7 @@
 
 // Expose the test-only factory property without touching the public header.
 @interface PreviewViewController (Testing)
-@property (nonatomic, copy) WKWebView *(^webViewFactory)(WKWebViewConfiguration *config);
+@property (nonatomic, copy) WKWebView *(^webViewFactory)(WKWebViewConfiguration *config, NSRect frame);
 @end
 
 
@@ -38,10 +38,9 @@
     // Skip [super ...] — that would launch the XPC web content process.
     // Fire the navigation callback on the next run-loop turn, preserving the
     // async contract the real WKWebView provides.
-    id<WKNavigationDelegate> delegate = self.navigationDelegate;
     dispatch_async(dispatch_get_main_queue(), ^{
-        if ([delegate respondsToSelector:@selector(webView:didFinishNavigation:)])
-            [delegate webView:self didFinishNavigation:nil];
+        if ([self.navigationDelegate respondsToSelector:@selector(webView:didFinishNavigation:)])
+            [self.navigationDelegate webView:self didFinishNavigation:nil];
     });
     return nil;
 }
@@ -57,9 +56,8 @@
 - (PreviewViewController *)makeViewController
 {
     PreviewViewController *vc = [[PreviewViewController alloc] init];
-    vc.webViewFactory = ^WKWebView *(WKWebViewConfiguration *config) {
-        return [[MPTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)
-                                        configuration:config];
+    vc.webViewFactory = ^WKWebView *(WKWebViewConfiguration *config, NSRect frame) {
+        return [[MPTestWKWebView alloc] initWithFrame:frame configuration:config];
     };
     return vc;
 }

--- a/MacDownTests/MPPreviewViewControllerTests.m
+++ b/MacDownTests/MPPreviewViewControllerTests.m
@@ -20,10 +20,49 @@
 #import "PreviewViewController.h"
 
 
+// Expose the test-only factory property without touching the public header.
+@interface PreviewViewController (Testing)
+@property (nonatomic, copy) WKWebView *(^webViewFactory)(WKWebViewConfiguration *config);
+@end
+
+
+// Synchronous stand-in for WKWebView: fires didFinishNavigation: on the next
+// run-loop turn without starting the XPC web content process.
+@interface MPTestWKWebView : WKWebView
+@end
+
+@implementation MPTestWKWebView
+
+- (WKNavigation *)loadHTMLString:(NSString *)string baseURL:(nullable NSURL *)baseURL
+{
+    // Skip [super ...] — that would launch the XPC web content process.
+    // Fire the navigation callback on the next run-loop turn, preserving the
+    // async contract the real WKWebView provides.
+    id<WKNavigationDelegate> delegate = self.navigationDelegate;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([delegate respondsToSelector:@selector(webView:didFinishNavigation:)])
+            [delegate webView:self didFinishNavigation:nil];
+    });
+    return nil;
+}
+
+@end
+
+
 @interface MPPreviewViewControllerTests : XCTestCase
 @end
 
 @implementation MPPreviewViewControllerTests
+
+- (PreviewViewController *)makeViewController
+{
+    PreviewViewController *vc = [[PreviewViewController alloc] init];
+    vc.webViewFactory = ^WKWebView *(WKWebViewConfiguration *config) {
+        return [[MPTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)
+                                        configuration:config];
+    };
+    return vc;
+}
 
 
 #pragma mark - WKNavigationDelegate Conformance Tests (Bug 1, Bug 4)
@@ -88,7 +127,7 @@
                                      encoding:NSUTF8StringEncoding
                                         error:nil];
 
-    PreviewViewController *vc = [[PreviewViewController alloc] init];
+    PreviewViewController *vc = [self makeViewController];
     [vc loadView];
 
     __block BOOL handlerCalled = NO;
@@ -108,6 +147,9 @@
 {
     // Verify the handler IS called, just not synchronously.
     // This confirms the deferred path (WKWebView navigation + delegate callback) works end-to-end.
+    //
+    // MPTestWKWebView fires didFinishNavigation: via dispatch_async, so this completes
+    // in one run-loop turn without requiring the XPC web content process.
 
     NSString *tempDir = NSTemporaryDirectory();
     NSString *tempFile = [tempDir stringByAppendingPathComponent:@"test_ql_async.md"];
@@ -119,7 +161,7 @@
                                       encoding:NSUTF8StringEncoding
                                          error:nil];
 
-    PreviewViewController *vc = [[PreviewViewController alloc] init];
+    PreviewViewController *vc = [self makeViewController];
     [vc loadView];
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"QL completion handler called"];
@@ -129,12 +171,7 @@
         [expectation fulfill];
     }];
 
-    // Allow up to 10 seconds for WKWebView to load the HTML and fire the delegate callback.
-    [self waitForExpectationsWithTimeout:10.0 handler:^(NSError * _Nullable error) {
-        if (error) {
-            XCTFail(@"Completion handler was never called within 10 seconds: %@", error);
-        }
-    }];
+    [self waitForExpectations:@[expectation] timeout:2.0];
 }
 
 
@@ -148,7 +185,7 @@
     // FAILS on current code: navigationDelegate is nil (not set in loadView).
     // PASSES after fix: self.webView.navigationDelegate = self.
 
-    PreviewViewController *vc = [[PreviewViewController alloc] init];
+    PreviewViewController *vc = [self makeViewController];
     [vc loadView];
 
     XCTAssertTrue([vc.view isKindOfClass:[WKWebView class]],
@@ -167,7 +204,7 @@
     // FAILS on current code: preferredContentSize is CGSizeZero (NSZeroRect frame used).
     // PASSES after fix: preferredContentSize is set to 800×600.
 
-    PreviewViewController *vc = [[PreviewViewController alloc] init];
+    PreviewViewController *vc = [self makeViewController];
     [vc loadView];
 
     NSSize size = vc.preferredContentSize;


### PR DESCRIPTION
## Summary

`testCompletionHandlerIsEventuallyCalledAfterNavigation` timed out intermittently on CI because it depended on the XPC web content process firing `webView:didFinishNavigation:` in a headless unit-test environment — a timing-sensitive out-of-process operation that stalls on loaded or pre-release runners.

- Add a private `webViewFactory` block property to `PreviewViewController` (exposed to tests via a testing category) so tests can substitute a synchronous `WKWebView` without starting the XPC machinery
- Add `MPTestWKWebView` (test-only `WKWebView` subclass) that overrides `loadHTMLString:baseURL:` to fire `webView:didFinishNavigation:` via `dispatch_async` in one run-loop turn, without calling `super`
- Apply the factory via a shared `makeViewController` helper across all handler-deferral and view-setup tests
- Lower the `waitForExpectations` timeout from 10 s to 2 s since the test double completes immediately
- Production behaviour is unchanged — `webViewFactory` defaults to `nil` and `loadView` falls back to the standard `WKWebView` setup

## Related Issue

Related to #390

## Manual Testing Plan

N/A — this is a test infrastructure change. Verify by running:

```
xcodebuild test -workspace "MacDown 3000.xcworkspace" -scheme MacDown \
  -destination "platform=macOS" \
  -only-testing:MacDownTests/MPPreviewViewControllerTests
```

All five tests should pass consistently across repeated runs.