### PR TITLE
Fix EXC_BAD_ACCESS when clicking grouped toolbar buttons

### DIFF
--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -109,16 +109,26 @@ static CGFloat itemWidth = 37;
 - (void)selectedToolbarItemGroupItem:(NSSegmentedControl *)sender
 {
     NSInteger selectedIndex = sender.selectedSegment;
-    
+
     NSToolbarItemGroup *selectedGroup = self->toolbarItemIdentifierObjectDictionary[sender.identifier];
     NSToolbarItem *selectedItem = selectedGroup.subitems[selectedIndex];
-    
-    // Invoke the toolbar item's action
-    // Must convert to IMP to let the compiler know about the method definition
+
+    // Invoke the toolbar item's action on the document. Use performSelector:
+    // (rather than a raw IMP cast) so the ObjC ABI correctly sets up self,
+    // _cmd, and the sender argument. The previous IMP cast to `void (*)(id)`
+    // left _cmd and sender as uninitialized register values, which produced
+    // garbage senders like 0x400000000000bad0 and random EXC_BAD_ACCESS
+    // crashes when the invoked action (or its responder-chain validation)
+    // touched sender.
     MPDocument *document = self.document;
-    IMP imp = [document methodForSelector:selectedItem.action];
-    void (*impFunc)(id) = (void *)imp;
-    impFunc(document);
+    SEL action = selectedItem.action;
+    if (document && action && [document respondsToSelector:action])
+    {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [document performSelector:action withObject:selectedItem];
+        #pragma clang diagnostic pop
+    }
 }
 
 


### PR DESCRIPTION
## Problem

Clicking any grouped toolbar button (Shift Left/Right, Bold/Italic/Underline, H1/H2/H3, Lists) could crash the app with `EXC_BAD_ACCESS`. Debugging showed the invoked IBAction was entered with a nonsense `sender` such as `0x400000000000bad0`.

## Root cause

`-[MPToolbarController selectedToolbarItemGroupItem:]` invoked the selected toolbar item's action via a raw IMP cast:

```objc
IMP imp = [document methodForSelector:selectedItem.action];
void (*impFunc)(id) = (void *)imp;
impFunc(document);
```

Objective-C methods actually have the ABI signature `(id self, SEL _cmd, id sender, ...)`. The cast to `void (*)(id)` only passes `self`, so on ARM64 the `_cmd` (`x1`) and `sender` (`x2`) registers were left holding whatever garbage the caller's frame happened to contain. That garbage surfaced as bogus sender pointers (e.g. `0x400000000000bad0`) and intermittent `EXC_BAD_ACCESS` once the invoked action (or its responder-chain / menu validation) touched `sender`.

## Fix

Replace the raw IMP call with `performSelector:withObject:`, which goes through `objc_msgSend` and correctly sets up `self`, `_cmd`, and the `sender` argument. The `NSToolbarItem` is passed as the sender, matching the semantics of a normal toolbar click.

## Testing

Manual: clicked every grouped toolbar item (Bold, Italic, Underline, H1/H2/H3, Ordered/Unordered List, Shift Left/Right) — no more crashes; all actions take effect on the document.