### PR TITLE
Guard nil-group and out-of-bounds index in selectedToolbarItemGroupItem:

### DIFF
--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -111,6 +111,19 @@ static CGFloat itemWidth = 37;
     NSInteger selectedIndex = sender.selectedSegment;
 
     NSToolbarItemGroup *selectedGroup = self->toolbarItemIdentifierObjectDictionary[sender.identifier];
+    NSAssert(selectedGroup != nil,
+             @"selectedToolbarItemGroupItem: sender identifier '%@' is not registered "
+             @"in toolbarItemIdentifierObjectDictionary",
+             sender.identifier);
+    if (!selectedGroup) { return; }
+
+    NSAssert(selectedIndex >= 0 && (NSUInteger)selectedIndex < selectedGroup.subitems.count,
+             @"selectedToolbarItemGroupItem: selectedSegment %ld is out of bounds "
+             @"for group '%@' with %lu subitems",
+             (long)selectedIndex, sender.identifier,
+             (unsigned long)selectedGroup.subitems.count);
+    if (selectedIndex < 0 || (NSUInteger)selectedIndex >= selectedGroup.subitems.count) { return; }
+
     NSToolbarItem *selectedItem = selectedGroup.subitems[selectedIndex];
 
     // Invoke the toolbar item's action on the document. Use performSelector:

--- a/MacDownTests/MPToolbarControllerTests.m
+++ b/MacDownTests/MPToolbarControllerTests.m
@@ -11,6 +11,12 @@
 #import <XCTest/XCTest.h>
 #import "MPToolbarController.h"
 
+// Expose the segmented-control action method to the test target; it is not
+// part of the public header but is callable via dynamic dispatch.
+@interface MPToolbarController (MPToolbarControllerTests)
+- (void)selectedToolbarItemGroupItem:(NSSegmentedControl *)sender;
+@end
+
 @interface MPToolbarControllerTests : XCTestCase
 @property (strong) MPToolbarController *controller;
 @end
@@ -674,11 +680,11 @@
 
 - (void)testSelectedToolbarItemGroupItemOutOfBoundsIndexAsserts
 {
-    // indent-group has 2 subitems (shift-left, shift-right).
+    // indent-group has 2 subitems; segment 2 is one past the end.
     NSSegmentedControl *sender = [[NSSegmentedControl alloc] init];
     sender.identifier = @"indent-group";
-    sender.segmentCount = 99;
-    sender.selectedSegment = 50;
+    sender.segmentCount = 3;
+    sender.selectedSegment = 2;
 
     XCTAssertThrowsSpecificNamed([self.controller selectedToolbarItemGroupItem:sender],
                                  NSException, NSInternalInconsistencyException,
@@ -692,6 +698,12 @@
     sender.identifier = @"indent-group";
     sender.segmentCount = 2;
     sender.selectedSegment = -1;    // momentary tracking can theoretically produce -1
+
+    // Confirm AppKit didn't clamp the assignment. If this precondition fails
+    // on a given macOS version we'll need a different way to reach the
+    // negative-index branch.
+    XCTAssertEqual(sender.selectedSegment, (NSInteger)-1,
+                   @"NSSegmentedControl should accept a -1 selectedSegment for this test");
 
     XCTAssertThrowsSpecificNamed([self.controller selectedToolbarItemGroupItem:sender],
                                  NSException, NSInternalInconsistencyException,

--- a/MacDownTests/MPToolbarControllerTests.m
+++ b/MacDownTests/MPToolbarControllerTests.m
@@ -652,4 +652,67 @@
 }
 
 
+#pragma mark - selectedToolbarItemGroupItem: Tests (Issue #394)
+
+// CI runs tests in Debug with ENABLE_NS_ASSERTIONS enabled, so the nil- and
+// bounds-guards' NSAsserts raise NSInternalInconsistencyException. In Release
+// the asserts compile away and the trailing `if ... return;` keeps users out
+// of the crash path; that branch is not directly testable from XCTest.
+
+- (void)testSelectedToolbarItemGroupItemUnknownIdentifierAsserts
+{
+    NSSegmentedControl *sender = [[NSSegmentedControl alloc] init];
+    sender.identifier = @"nonexistent-group";
+    sender.segmentCount = 1;
+    sender.selectedSegment = 0;
+
+    XCTAssertThrowsSpecificNamed([self.controller selectedToolbarItemGroupItem:sender],
+                                 NSException, NSInternalInconsistencyException,
+                                 @"selectedToolbarItemGroupItem: must assert in Debug "
+                                 @"when sender.identifier is not registered in the dictionary");
+}
+
+- (void)testSelectedToolbarItemGroupItemOutOfBoundsIndexAsserts
+{
+    // indent-group has 2 subitems (shift-left, shift-right).
+    NSSegmentedControl *sender = [[NSSegmentedControl alloc] init];
+    sender.identifier = @"indent-group";
+    sender.segmentCount = 99;
+    sender.selectedSegment = 50;
+
+    XCTAssertThrowsSpecificNamed([self.controller selectedToolbarItemGroupItem:sender],
+                                 NSException, NSInternalInconsistencyException,
+                                 @"selectedToolbarItemGroupItem: must assert in Debug "
+                                 @"when selectedSegment is out of bounds for the group's subitems");
+}
+
+- (void)testSelectedToolbarItemGroupItemNegativeIndexAsserts
+{
+    NSSegmentedControl *sender = [[NSSegmentedControl alloc] init];
+    sender.identifier = @"indent-group";
+    sender.segmentCount = 2;
+    sender.selectedSegment = -1;    // momentary tracking can theoretically produce -1
+
+    XCTAssertThrowsSpecificNamed([self.controller selectedToolbarItemGroupItem:sender],
+                                 NSException, NSInternalInconsistencyException,
+                                 @"selectedToolbarItemGroupItem: must assert in Debug "
+                                 @"when selectedSegment is negative");
+}
+
+- (void)testSelectedToolbarItemGroupItemValidCallDoesNotCrash
+{
+    // Valid identifier and valid index. With no document connected the
+    // internal performSelector: block is skipped, so this should complete
+    // without throwing.
+    NSSegmentedControl *sender = [[NSSegmentedControl alloc] init];
+    sender.identifier = @"indent-group";
+    sender.segmentCount = 2;
+    sender.selectedSegment = 0;
+
+    XCTAssertNoThrow([self.controller selectedToolbarItemGroupItem:sender],
+                     @"selectedToolbarItemGroupItem: must not throw for a valid "
+                     @"group identifier and in-bounds selected segment");
+}
+
+
 @end

--- a/plans/test_coverage_improvement_plan.md
+++ b/plans/test_coverage_improvement_plan.md
@@ -64,7 +64,7 @@ MacDown currently has minimal test coverage (~7% test-to-code ratio) focused pri
 - Security policy (MPURLSecurityPolicy.m) - 16 tests covering executable/bundle detection and directory scope enforcement for CVE-2019-12138 and CVE-2019-12173 (Issue #351)
 - Editor text substitution settings (MPEditorView.m) - NSUserDefaults-backed getter overrides with 30 TDD tests (Issue #263)
 - Word count updates (MPDocument.m) - Tests for debounced word count updates during DOM replacement (Issue #294)
-- Toolbar controller (MPToolbarController.m) - 37 tests for NSToolbarDelegate methods, flexible space/separator support, item groups (Issue #313)
+- Toolbar controller (MPToolbarController.m) - 41 tests for NSToolbarDelegate methods, flexible space/separator support, item groups, nil-group and out-of-bounds crash guards on `selectedToolbarItemGroupItem:` (Issue #313, Issue #394)
 
 **Test Infrastructure:**
 - ✅ XCTest framework configured
@@ -449,7 +449,7 @@ MacDownTests/
 │   ├── MPAssetTests.m
 │   ├── MPEditorViewSubstitutionTests.m (✅ implemented - Issue #263 - text substitution preferences)
 │   ├── MPFileIOTests.m (new - planned)
-│   ├── MPToolbarControllerTests.m (✅ implemented - Issue #313 - toolbar item identifiers, groups, delegate methods)
+│   ├── MPToolbarControllerTests.m (✅ implemented - Issue #313, Issue #394 - toolbar item identifiers, groups, delegate methods, nil/bounds crash guards)
 │   └── MPURLSecurityPolicyTests.m (✅ implemented - Issue #351 - CVE-2019-12138, CVE-2019-12173: executable/bundle detection, scope checks)
 ├── Integration/ (planned)
 │   ├── MPRendererIntegrationTests.m

--- a/plans/test_coverage_improvement_plan.md
+++ b/plans/test_coverage_improvement_plan.md
@@ -39,7 +39,7 @@ MacDown currently has minimal test coverage (~7% test-to-code ratio) focused pri
 | MPSmartQuoteTests.m | Smart quote substitution behavior | Good | (Issue #285) |
 | MPEditorViewSubstitutionTests.m | Text substitution preference getters, NSUserDefaults integration | Good | (Issue #263) |
 | MPWordCountUpdateTests.m | Word count update debouncing, queue cancellation | Good | (Issue #294) |
-| MPToolbarControllerTests.m | Toolbar delegate methods, item identifiers, group testing | Good | (Issue #313) |
+| MPToolbarControllerTests.m | Toolbar delegate methods, item identifiers, group testing, nil/bounds guards on `selectedToolbarItemGroupItem:` | Good | (Issue #313, Issue #394) |
 | MPMermaidRenderingTests.m | Mermaid diagram rendering, MutationObserver re-rendering, SVG sizing | Good | (Issue #331) |
 | MPGraphvizRenderingTests.m | Graphviz diagram rendering, MutationObserver re-rendering, script inclusion | Good | (Issue #332) |
 | MPURLSecurityPolicyTests.m | URL security policy: executable/bundle detection, directory scope checking | Good | (Issue #351) |

--- a/plans/xcuitest.md
+++ b/plans/xcuitest.md
@@ -74,7 +74,7 @@ This document analyzes the gaps and proposes technical approaches to fill them t
 
 **5. User Interactions**
 - Zero tests for: menu actions, keyboard shortcuts, preferences UI
-- ✅ Toolbar tests added (Issue #313) - 37 unit tests for MPToolbarController covering delegate methods and item identifiers
+- ✅ Toolbar tests added (Issue #313, Issue #394) - 41 unit tests for MPToolbarController covering delegate methods, item identifiers, and nil/bounds crash guards on `selectedToolbarItemGroupItem:`
 - Missing: interactive task lists, link clicks in preview
 
 **6. Error Handling**


### PR DESCRIPTION
## Summary

Adds nil-group and out-of-bounds guards to `selectedToolbarItemGroupItem:` in `MPToolbarController.m`.

The method previously did `selectedGroup.subitems[selectedIndex]` with no protection against:
- `sender.identifier` not being present in `toolbarItemIdentifierObjectDictionary` (`selectedGroup` becomes nil)
- `selectedIndex` being negative or `>= selectedGroup.subitems.count` (NSRangeException from `objectAtIndexedSubscript:`)

The bounds case is a latent `NSRangeException` crash. The nil case is benign today thanks to ObjC nil-messaging semantics, but is a correctness hazard if the downstream guards ever change.

Both paths now use `NSAssert` + an early `return`:
- In Debug (CI default, `ENABLE_NS_ASSERTIONS = YES`) the asserts fire loudly with a message that names the offending identifier and the actual vs expected subitem count, so misconfigurations are diagnosed immediately.
- In Release (`ENABLE_NS_ASSERTIONS = NO`) the asserts compile away and the `if (…) return;` keeps users out of the crash path.

## Test coverage

Four new tests in `MPToolbarControllerTests.m`:
- `testSelectedToolbarItemGroupItemUnknownIdentifierAsserts`
- `testSelectedToolbarItemGroupItemOutOfBoundsIndexAsserts`
- `testSelectedToolbarItemGroupItemNegativeIndexAsserts` (with a precondition check that `NSSegmentedControl` actually stores `-1`)
- `testSelectedToolbarItemGroupItemValidCallDoesNotCrash` (regression guard for the happy path)

The three guard tests use `XCTAssertThrowsSpecificNamed(…, NSInternalInconsistencyException)` because the test target is built in Debug. A private category declaration exposes `selectedToolbarItemGroupItem:` to the test target so the call compiles without `-Wundeclared-selector`.

The Release-mode `if … return;` branches are defense-in-depth and not directly reachable under Debug; this is noted in a short comment above the new test section.

## Related Issue

Related to #394

## Manual Testing Plan

N/A — the XCTest suite covers the testable surface, and the guards only fire on a misconfigured toolbar that can't be produced through the normal UI (segmented controls are constructed in `toolbarItemGroupWithIdentifier:` with matching identifier and `segmentCount == items.count`, so the fault conditions are structurally impossible from user interaction).

