### PR TITLE
Address issue #382: Normalize CRLF line endings on file load

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -742,6 +742,9 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     if (!content)
         return NO;
 
+    // Normalize Windows CRLF to LF (Issue #382)
+    content = [content stringByReplacingOccurrencesOfString:@"\r\n" withString:@"\n"];
+
     self.loadedString = content;
     [self reloadFromLoadedString];
     return YES;

--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -111,6 +111,10 @@ NS_INLINE NSString *MPPreprocessMarkdown(NSString *text)
     if (!text.length)
         return text;
 
+    // Normalize Windows CRLF to LF (Issue #382). Handles content arriving via
+    // paste or programmatic assignment that bypasses readFromData:ofType:error:.
+    text = [text stringByReplacingOccurrencesOfString:@"\r\n" withString:@"\n"];
+
     // Lists after paragraphs (Issue #254)
     static NSRegularExpression *listRegex = nil;
     static dispatch_once_t listToken;

--- a/MacDownCore/MPQuickLookRenderer.m
+++ b/MacDownCore/MPQuickLookRenderer.m
@@ -292,6 +292,9 @@ static void mp_quicklook_render_blockcode(
         return nil;
     }
 
+    // Normalize Windows CRLF to LF (Issue #382)
+    markdown = [markdown stringByReplacingOccurrencesOfString:@"\r\n" withString:@"\n"];
+
     return [self renderMarkdown:markdown];
 }
 

--- a/MacDownTests/MPDocumentIOTests.m
+++ b/MacDownTests/MPDocumentIOTests.m
@@ -103,6 +103,23 @@
     // it simply returns NO when [[NSString alloc] initWithData:encoding:] returns nil
 }
 
+- (void)testReadFromDataWithCRLFLineEndings
+{
+    // Windows-created files use CRLF (\r\n). This is valid UTF-8, so the load
+    // must succeed. On load, \r\n should be normalized to \n so downstream
+    // rendering and preprocessing see only LF line endings (Issue #382).
+    NSString *crlfMarkdown = @"# Heading\r\n\r\nParagraph text.\r\n";
+    NSData *crlfData = [crlfMarkdown dataUsingEncoding:NSUTF8StringEncoding];
+
+    NSError *error = nil;
+    BOOL success = [self.document readFromData:crlfData
+                                        ofType:@"net.daringfireball.markdown"
+                                         error:&error];
+
+    XCTAssertTrue(success, @"readFromData:ofType:error: should succeed with CRLF data");
+    XCTAssertNil(error, @"No error should occur loading CRLF-terminated content");
+}
+
 - (void)testWritableTypes
 {
     // Call [MPDocument writableTypes] (class method)

--- a/MacDownTests/MPMarkdownRenderingTests.m
+++ b/MacDownTests/MPMarkdownRenderingTests.m
@@ -666,4 +666,91 @@
                   @"Large document should render in reasonable time (<%f seconds)", elapsed);
 }
 
+
+#pragma mark - CRLF Line Ending Tests (Issue #382)
+
+/**
+ * Basic heading and paragraph with Windows CRLF line endings should render
+ * identically to the same content with Unix LF endings.
+ */
+- (void)testHeadingAndParagraphWithCRLFLineEndings
+{
+    int extFlags = 0;
+    int rendFlags = 0;
+
+    NSString *lfMarkdown   = @"# Heading\n\nParagraph text.\n";
+    NSString *crlfMarkdown = @"# Heading\r\n\r\nParagraph text.\r\n";
+
+    NSString *lfHtml   = [self renderMarkdown:lfMarkdown
+                               withExtensions:extFlags
+                                rendererFlags:rendFlags];
+    NSString *crlfHtml = [self renderMarkdown:crlfMarkdown
+                               withExtensions:extFlags
+                                rendererFlags:rendFlags];
+
+    XCTAssertNotNil(crlfHtml, @"CRLF content should produce non-nil HTML");
+    XCTAssertTrue([crlfHtml containsString:@"<h1>"],
+                  @"CRLF heading should render as <h1>");
+    XCTAssertTrue([crlfHtml containsString:@"Heading"],
+                  @"CRLF heading text should appear in output");
+    XCTAssertTrue([crlfHtml containsString:@"<p>"],
+                  @"CRLF paragraph should render as <p>");
+    XCTAssertEqualObjects(lfHtml, crlfHtml,
+                          @"CRLF and LF content should produce identical HTML");
+}
+
+/**
+ * MPPreprocessMarkdown Issue #254 workaround: list immediately after paragraph.
+ * The regex that inserts a blank line uses \n, so it must also work with CRLF.
+ */
+- (void)testListAfterParagraphWithCRLFLineEndings
+{
+    int extFlags = 0;
+    int rendFlags = 0;
+
+    NSString *lfMarkdown   = @"Paragraph\n- List item\n";
+    NSString *crlfMarkdown = @"Paragraph\r\n- List item\r\n";
+
+    NSString *lfHtml   = [self renderMarkdown:lfMarkdown
+                               withExtensions:extFlags
+                                rendererFlags:rendFlags];
+    NSString *crlfHtml = [self renderMarkdown:crlfMarkdown
+                               withExtensions:extFlags
+                                rendererFlags:rendFlags];
+
+    XCTAssertTrue([crlfHtml containsString:@"<ul>"],
+                  @"CRLF list after paragraph should render as <ul>");
+    XCTAssertTrue([crlfHtml containsString:@"List item"],
+                  @"CRLF list item text should appear in output");
+    XCTAssertEqualObjects(lfHtml, crlfHtml,
+                          @"CRLF and LF list-after-paragraph should produce identical HTML");
+}
+
+/**
+ * MPPreprocessMarkdown Issue #36 workaround: fenced code block immediately after text.
+ * The fence regex must also work when lines are terminated with CRLF.
+ */
+- (void)testFencedCodeAfterTextWithCRLFLineEndings
+{
+    int extFlags = HOEDOWN_EXT_FENCED_CODE;
+    int rendFlags = 0;
+
+    NSString *lfMarkdown   = @"Text\n```\ncode\n```\n";
+    NSString *crlfMarkdown = @"Text\r\n```\r\ncode\r\n```\r\n";
+
+    NSString *lfHtml   = [self renderMarkdown:lfMarkdown
+                               withExtensions:extFlags
+                                rendererFlags:rendFlags];
+    NSString *crlfHtml = [self renderMarkdown:crlfMarkdown
+                               withExtensions:extFlags
+                                rendererFlags:rendFlags];
+
+    XCTAssertTrue([crlfHtml containsString:@"<code"],
+                  @"CRLF fenced code block should render as <code>");
+    XCTAssertTrue([crlfHtml containsString:@"code"],
+                  @"CRLF fenced code content should appear in output");
+    XCTAssertEqualObjects(lfHtml, crlfHtml,
+                          @"CRLF and LF fenced-code-after-text should produce identical HTML");
+}
+
 @end

--- a/MacDownTests/MPQuickLookRendererTests.m
+++ b/MacDownTests/MPQuickLookRendererTests.m
@@ -616,6 +616,39 @@
 }
 
 
+#pragma mark - CRLF Line Ending Tests (Issue #382)
+
+- (void)testRenderMarkdownFromURLWithCRLFLineEndings
+{
+    // Write a temp file using Windows CRLF line endings and verify it renders
+    // correctly — the same HTML that LF content produces (Issue #382).
+    NSString *tempFile = [NSTemporaryDirectory()
+                          stringByAppendingPathComponent:
+                          [NSString stringWithFormat:@"ql-crlf-%@.md",
+                           [[NSUUID UUID] UUIDString]]];
+    [self addTeardownBlock:^{
+        [[NSFileManager defaultManager] removeItemAtPath:tempFile error:nil];
+    }];
+
+    NSString *crlfMarkdown = @"# Heading\r\n\r\nParagraph text.\r\n";
+    NSData *crlfData = [crlfMarkdown dataUsingEncoding:NSUTF8StringEncoding];
+    [crlfData writeToFile:tempFile atomically:YES];
+
+    NSError *error = nil;
+    NSString *html = [self.renderer renderMarkdownFromURL:[NSURL fileURLWithPath:tempFile]
+                                                    error:&error];
+
+    XCTAssertNil(error, @"Should render CRLF file without error");
+    XCTAssertNotNil(html, @"Should produce HTML from CRLF file");
+    XCTAssertTrue([html containsString:@"<h1>"],
+                  @"CRLF heading should render as <h1>");
+    XCTAssertTrue([html containsString:@"Heading"],
+                  @"Heading text should appear in output");
+    XCTAssertTrue([html containsString:@"<p>"],
+                  @"CRLF paragraph should render as <p>");
+}
+
+
 #pragma mark - Error Handling Tests
 
 - (void)testRenderMarkdownFromURLWithNonexistentFile

--- a/plans/quick-look-manual-testing.md
+++ b/plans/quick-look-manual-testing.md
@@ -221,7 +221,7 @@ Test that syntax highlighting applies correctly for:
 - [ ] Unicode characters (emoji, CJK, etc.) render correctly
 - [ ] Special HTML entities (`&amp;`, `&lt;`, `&gt;`) render correctly
 - [ ] Markdown with HTML inline tags renders appropriately
-- [ ] File with Windows line endings (CRLF) renders correctly
+- [ ] File with Windows line endings (CRLF) is normalized to LF and renders correctly
 - [ ] File with classic Mac line endings (CR) renders correctly
 
 ### 7.4 File Path Edge Cases


### PR DESCRIPTION
## Summary

- Markdown files created on Windows use CRLF (`\r\n`) line endings. Hoedown's line-based parser expects LF (`\n`) and fails to render block elements (headings, paragraphs, lists, code blocks) when it encounters `\r\n`, producing a blank preview.
- Added CRLF→LF normalization at three levels of defense: on file load (`MPDocument.m`), in the Quick Look renderer (`MPQuickLookRenderer.m`), and as a safety net in `MPPreprocessMarkdown` (`MPRenderer.m`) for content arriving via paste or programmatic assignment.
- The existing `MPPreprocessMarkdown` regexes that fix Issues #254 and #36 also match `\n` only, so normalizing before those patterns is required for CRLF files to benefit from those workarounds.
- Saving a Windows file from MacDown will write it back with LF endings — standard macOS editor behavior.

## Related Issue

Related to #382

## Manual Testing Plan

Since a Windows machine is not available, create CRLF test files on macOS using Python:

```bash
python3 << 'EOF'
import os
test_dir = os.path.expanduser("~/Desktop/MacDown_CRLF_Tests")
os.makedirs(test_dir, exist_ok=True)

# Basic heading + paragraph
open(f"{test_dir}/basic.md", "wb").write(b"# Heading\r\n\r\nParagraph.\r\n")
# List after paragraph (Issue #254 regression check)
open(f"{test_dir}/list.md", "wb").write(b"Paragraph\r\n- Item 1\r\n- Item 2\r\n")
# Fenced code after text (Issue #36 regression check)
open(f"{test_dir}/code.md", "wb").write(b"Text\r\n```python\r\nprint('hi')\r\n```\r\n")
print("Files created in:", test_dir)
EOF
```

**Scenarios:**

- [ ] `basic.md` opens in MacDown and shows rendered `<h1>` and `<p>` (not a blank preview)
- [ ] `list.md` shows paragraph and `<ul>` as separate blocks (Issue #254 workaround still works)
- [ ] `code.md` shows a rendered code block (Issue #36 workaround still works)
- [ ] Space-bar Quick Look preview of any CRLF file in Finder shows rendered HTML
- [ ] Pasting CRLF content into a new document renders correctly
- [ ] A normal LF file still renders identically to before (regression check)

## Review Notes

- `reloadFromDisk` requires no change — it calls through to `readFromData:ofType:error:` and inherits the fix automatically.
- `NSString+Lookup.m` front matter CRLF handling is left unchanged; the defensive `[\r\n]+` patterns are harmless and provide a useful backstop.
- Bare `\r` (legacy Mac OS 9 line endings, obsolete since 2001) is not handled; the risk was judged negligible.