### PR TITLE
Address issue #376: Re-initialize task list handlers after DOM replacement

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1437,6 +1437,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
                     @"  var body = document.body;"
                     @"  body.innerHTML = html;"
                     @"  if(window.Prism){Prism.highlightAll();}"
+                    @"  if(typeof window.macdownInitTaskList==='function'){window.macdownInitTaskList();}"
                     @"  if(window.MathJax&&MathJax.Hub){"
                     @"    MathJax.Hub.Queue(['Typeset',MathJax.Hub]);"
                     @"    MathJax.Hub.Queue(function(){"

--- a/MacDown/Resources/Extensions/tasklist.js
+++ b/MacDown/Resources/Extensions/tasklist.js
@@ -6,7 +6,11 @@
  *
  * Related to GitHub issue #269.
  */
-(function () {
+
+// Exposed as a named global so the DOM-replacement path in MPDocument can
+// call it again after body.innerHTML is updated (innerHTML does not re-execute
+// script tags, so this must be invoked explicitly — same pattern as Prism).
+window.macdownInitTaskList = function () {
   var tokenMeta = document.querySelector('meta[name="macdown-checkbox-token"]');
   var checkboxToken = tokenMeta ? tokenMeta.getAttribute('content') : '';
   var taskListItems = document.getElementsByClassName('task-list-item');
@@ -30,7 +34,14 @@
           window.location = url;
         }
       });
+      // Break after the first input in this task-list-item. Each item owns
+      // exactly one checkbox; getElementsByTagName also returns inputs from
+      // nested sub-items, and those are handled when the outer loop reaches
+      // their own task-list-item element. Breaking here prevents attaching
+      // duplicate handlers to nested checkboxes.
       break;
     }
   }
-})();
+};
+
+window.macdownInitTaskList();


### PR DESCRIPTION
## Summary

- Checkbox click handlers set up by `tasklist.js` were lost whenever the preview re-rendered via DOM replacement (`body.innerHTML = …`), because browsers do not re-execute `<script>` tags injected through `innerHTML`
- Expose the initialization logic as `window.macdownInitTaskList` so it can be called explicitly after each DOM replacement, matching the existing pattern used for Prism (`Prism.highlightAll()`)
- Add an explanatory comment to the `break` statement in the inner loop, which intentionally prevents duplicate handlers from being attached to nested checkboxes

## Related Issue

Related to #376

## Manual Testing Plan

1. Open a document containing `- [ ] task` and `- [x] done`
2. Confirm checkboxes appear in the preview
3. Type a character in the editor to trigger a DOM-replacement re-render
4. Click an unchecked checkbox in the preview — the editor text should change to `[x]`
5. Click a checked checkbox in the preview — the editor text should change to `[ ]`
6. Repeat steps 3–5 several times to confirm handlers survive repeated re-renders
7. Test with nested checkboxes (e.g. `- [ ] parent\n  - [ ] child`) and confirm depth-first index ordering works correctly

## Review Notes

The root cause and fix are analogous to the Prism syntax highlighting re-initialization already present in the same DOM-replacement script. No new unit tests were added; the toggle logic and security token validation are covered by existing tests in `MPCheckboxToggleTests.m` and `MPScrollSyncTests.m`.