### PR TITLE
Fix Xcode runtime warnings

### DIFF
--- a/MacDown/Code/Application/MPMainController.m
+++ b/MacDown/Code/Application/MPMainController.m
@@ -243,6 +243,11 @@ NS_INLINE void treat()
     return !self.preferences.supressesUntitledDocumentOnLaunch;
 }
 
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app
+{
+    return YES;
+}
+
 - (void)applicationDidBecomeActive:(NSNotification *)notification
 {
     [self openPendingPipedContent];

--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -262,7 +262,6 @@ static CGFloat itemWidth = 37;
         segmentIndex++;
     }
     
-    itemGroup.maxSize = NSMakeSize(itemGroupWidth, 25);
     itemGroup.view = segmentedControl;
     
     [self->toolbarItemIdentifierObjectDictionary setObject:itemGroup forKey:itemIdentifier];

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1208,8 +1208,13 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             if (url.isFileURL)
             {
                 NSURL *baseURL = self.currentBaseUrl ?: self.fileURL;
-                if (!baseURL || !baseURL.isFileURL
-                    || ![MPURLSecurityPolicy url:url isWithinScopeOfBaseURL:baseURL]
+                if (!baseURL || !baseURL.isFileURL)
+                {
+                    // Untitled documents have no base URL; silently ignore.
+                    [listener ignore];
+                    return;
+                }
+                if (![MPURLSecurityPolicy url:url isWithinScopeOfBaseURL:baseURL]
                     || [MPURLSecurityPolicy isExecutableOrAppBundleAtURL:url])
                 {
                     NSLog(@"MacDown: Blocked file:// navigation for security: %@", url);

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -25,8 +25,7 @@
                                     <action selector="orderFrontStandardAboutPanel:" target="-1" id="Exp-CZ-Vem"/>
                                 </connections>
                             </menuItem>
-                            <!-- Temporarily disabled - will upgrade Sparkle to 2.8.1 later -->
-                            <menuItem enabled="NO" title="Check for Updates… (unavailable)" id="8xL-1V-VPX">
+                            <menuItem title="Check for Updates… (unavailable)" enabled="NO" id="8xL-1V-VPX">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
@@ -619,15 +618,9 @@ DQ
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="139" y="154"/>
         </menu>
         <customObject id="eq0-c4-vgQ" customClass="MPMainController"/>
-        <!-- Temporarily disabled - will upgrade Sparkle to 2.8.1 later
-        <customObject id="Zfp-OK-9bN" customClass="SUUpdater">
-            <connections>
-                <outlet property="delegate" destination="eq0-c4-vgQ" id="UJV-6a-eCL"/>
-            </connections>
-        </customObject>
-        -->
         <customObject id="LEY-zf-22t" customClass="NSDocumentController"/>
         <userDefaultsController representsSharedInstance="YES" id="ow1-Qr-nTV"/>
     </objects>


### PR DESCRIPTION
Removes deprecated NSToolbarItem.maxSize, adds secure restorable state opt-in, and silences misleading file:// navigation security log for untitled documents.