### PR TITLE
Hide toolbar when editor pane is hidden

### DIFF
--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -47,10 +47,6 @@ static CGFloat itemWidth = 37;
 
 - (void)setupToolbarItems
 {
-    // Set up layout drop down alternatives. title will be set in validateUserInterfaceItem:
-    NSMenuItem *toggleEditorMenuItem = [[NSMenuItem alloc] initWithTitle:@"" action:@selector(toggleEditorPane:) keyEquivalent:@"e"];
-    NSMenuItem *togglePreviewMenuItem = [[NSMenuItem alloc] initWithTitle:@"" action:@selector(togglePreviewPane:) keyEquivalent:@"p"];
-    
     // Set up all available toolbar items
     self->toolbarItems = @[
         [self toolbarItemGroupWithIdentifier:@"indent-group" separated:YES label:NSLocalizedString(@"Shift Left/Right", @"") items:@[
@@ -79,15 +75,9 @@ static CGFloat itemWidth = 37;
         [self toolbarItemWithIdentifier:@"code" label:NSLocalizedString(@"Inline Code", @"Inline code toolbar button") icon:@"ToolbarIconInlineCode" action:@selector(toggleInlineCode:)],
         [self toolbarItemWithIdentifier:@"link" label:NSLocalizedString(@"Link", @"Link toolbar button") icon:@"ToolbarIconLink" action:@selector(toggleLink:)],
         [self toolbarItemWithIdentifier:@"image" label:NSLocalizedString(@"Image", @"Image toolbar button") icon:@"ToolbarIconImage" action:@selector(toggleImage:)],
-        [self toolbarItemWithIdentifier:@"copy-html" label:NSLocalizedString(@"Copy HTML", @"Copy HTML toolbar button") icon:@"ToolbarIconCopyHTML" action:@selector(copyHtml:)],
         [self toolbarItemWithIdentifier:@"comment" label:NSLocalizedString(@"Comment", @"Comment toolbar button") icon:@"ToolbarIconComment" action:@selector(toggleComment:)],
         [self toolbarItemWithIdentifier:@"highlight" label:NSLocalizedString(@"Highlight", @"Highlight toolbar button") icon:@"ToolbarIconHighlight" action:@selector(toggleHighlight:)],
-        [self toolbarItemWithIdentifier:@"strikethrough" label:NSLocalizedString(@"Strikethrough", @"Strikethrough toolbar button") icon:@"ToolbarIconStrikethrough" action:@selector(toggleStrikethrough:)],
-        [self toolbarItemDropDownWithIdentifier:@"layout" label:NSLocalizedString(@"Layout", @"Layout toolbar button") icon:@"ToolbarIconEditorAndPreview" menuItems:
-            @[
-              toggleEditorMenuItem, togglePreviewMenuItem
-            ]
-        ]
+        [self toolbarItemWithIdentifier:@"strikethrough" label:NSLocalizedString(@"Strikethrough", @"Strikethrough toolbar button") icon:@"ToolbarIconStrikethrough" action:@selector(toggleStrikethrough:)]
     ];
     
     self->toolbarItemIdentifiers = [self toolbarItemIdentifiersFromItemsArray:self->toolbarItems];
@@ -157,7 +147,7 @@ static CGFloat itemWidth = 37;
     
     // Add space after the specified toolbar item indices
     int spaceAfterIndices[] = {}; // No space in the default set
-    int flexibleSpaceAfterIndices[] = {2, 3, 5, 7, 11};
+    int flexibleSpaceAfterIndices[] = {2, 3, 5, 7, 10};
 
     // Bounds checking to prevent buffer overflow when accessing C arrays
     // Empty spaceAfterIndices array must not be accessed (count = 0)
@@ -296,41 +286,5 @@ static CGFloat itemWidth = 37;
     
     return toolbarItem;
 }
-
-/**
- * Factory method for creating and configuring a NSToolbarItem object with a NSPopupButton holding menu options as passed in the menuItems parameter.
- */
-- (NSToolbarItem *)toolbarItemDropDownWithIdentifier:(NSString *)itemIdentifier label:(NSString *)label icon:(NSString *)iconImageName menuItems:(NSArray <NSMenuItem *>*)menuItems {
-    NSToolbarItem *toolbarItem = [[NSToolbarItem alloc] initWithItemIdentifier:itemIdentifier];
-    toolbarItem.label = label;
-    toolbarItem.paletteLabel = label;
-    toolbarItem.toolTip = label;
-    
-    NSImage *itemImage = [NSImage imageNamed:iconImageName];
-    [itemImage setTemplate:YES];
-    [itemImage setSize:CGSizeMake(19, 19)];
-    
-    NSPopUpButton *popupButton = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 42, 27) pullsDown:YES];
-    popupButton.bezelStyle = NSBezelStyleTexturedRounded;
-    popupButton.focusRingType = NSFocusRingTypeDefault;
-    //popupButton.imageScaling = NSImageScaleProportionallyDown;
-    
-    // First item's image is displayed as button image, therefor we need a dummy with the icon
-    [popupButton addItemWithTitle:@""];
-    [[popupButton lastItem] setImage:itemImage];
-    
-    for (NSMenuItem *menuItem in menuItems) {
-        [popupButton addItemWithTitle:menuItem.title];
-        [[popupButton lastItem] setTarget:self.document];
-        [[popupButton lastItem] setAction:menuItem.action];
-    }
-    
-    toolbarItem.view = popupButton;
-    
-    [self->toolbarItemIdentifierObjectDictionary setObject:toolbarItem forKey:itemIdentifier];
-    
-    return toolbarItem;
-}
-
 
 @end

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -909,6 +909,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 {
     [self redrawDivider];
     self.editor.editable = self.editorVisible;
+    [self updateToolbarVisibility];
     // Issue #377: Track divider-drag collapses. When the ratio transitions from
     // a non-collapsed value to 0 or 1, save the pre-collapse ratio to
     // previousSplitRatio so the menu item remains visible (not hidden).
@@ -2107,6 +2108,15 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     }
 }
 
+- (void)updateToolbarVisibility
+{
+    BOOL shouldShowToolbar = self.editorVisible;
+    if (self.windowForSheet.toolbar.visible != shouldShowToolbar)
+    {
+        [self.windowForSheet toggleToolbarShown:nil];
+    }
+}
+
 - (void)applyEditorStartInPreviewModePreference
 {
     if (!self.preferences.editorStartInPreviewMode || !self.editorVisible)
@@ -2772,6 +2782,8 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         [self syncScrollersReverse];
         _scrollOwner = MPScrollOwnerNeither;
     }
+
+    [self updateToolbarVisibility];
 
     [self setupEditor:NSStringFromSelector(@selector(editorHorizontalInset))];
 }

--- a/MacDownTests/MPPaneToggleTests.m
+++ b/MacDownTests/MPPaneToggleTests.m
@@ -19,9 +19,11 @@
 @property (weak) NSView *editorContainer;
 @property (weak) WebView *preview;
 @property CGFloat previousSplitRatio;
+@property (readonly) BOOL toolbarVisible;
 - (IBAction)toggleEditorPane:(id)sender;
 - (IBAction)togglePreviewPane:(id)sender;
 - (void)applyEditorStartInPreviewModePreference;
+- (void)updateToolbarVisibility;
 @end
 
 #pragma mark - Mock Menu Item
@@ -208,6 +210,48 @@
                                    @"Startup preview mode should collapse the divider to the preview-only edge");
         XCTAssertGreaterThan(oldRatio, 0.0,
                              @"The precondition for this test is a visible editor split");
+    }
+    @finally {
+        preferences.editorStartInPreviewMode = originalStartInPreviewMode;
+        preferences.editorOnRight = originalEditorOnRight;
+        [preferences synchronize];
+    }
+}
+
+- (void)testStartInPreviewModeHidesToolbar
+{
+    MPPreferences *preferences = [MPPreferences sharedInstance];
+    BOOL originalStartInPreviewMode = preferences.editorStartInPreviewMode;
+    BOOL originalEditorOnRight = preferences.editorOnRight;
+
+    @try {
+        [self.document makeWindowControllers];
+
+        if (!self.document.editorVisible || !self.document.previewVisible) {
+            NSLog(@"Skipping testStartInPreviewModeHidesToolbar - panes not initialized");
+            return;
+        }
+
+        preferences.editorStartInPreviewMode = YES;
+        preferences.editorOnRight = NO;
+        self.document.previousSplitRatio = -1.0;
+
+        [self.document applyEditorStartInPreviewModePreference];
+        [self.document updateToolbarVisibility];
+
+        XCTAssertFalse(self.document.editorVisible,
+                       @"Startup preview mode should collapse the editor pane");
+        XCTAssertFalse(self.document.toolbarVisible,
+                       @"Toolbar should be hidden when editor is hidden in preview mode");
+
+        // Restore editor pane and verify toolbar is shown
+        [self.document toggleEditorPane:nil];
+        [self.document updateToolbarVisibility];
+
+        XCTAssertTrue(self.document.editorVisible,
+                      @"Restoring editor pane should make editor visible");
+        XCTAssertTrue(self.document.toolbarVisible,
+                      @"Toolbar should be shown when editor pane is restored");
     }
     @finally {
         preferences.editorStartInPreviewMode = originalStartInPreviewMode;


### PR DESCRIPTION
When the 'Start in preview mode' setting is enabled, the toolbar should be hidden because it only contains editing controls. This PR also strips non-editing controls (Copy HTML, Layout toggle) from the toolbar so it is purely editing-focused.\n\n- Add `updateToolbarVisibility` to MPDocument that hides/shows toolbar based on editor visibility\n- Call `updateToolbarVisibility` from `splitViewDidResizeSubviews:` and `setSplitViewDividerLocation:`\n- Remove Copy HTML and Layout (pane toggle) items from toolbar to keep it purely editing controls\n- Add `testStartInPreviewModeHidesToolbar` to verify toolbar state in preview mode