### PR TITLE
Address issue #387: strip grey background from printed output

### DIFF
--- a/MacDown/Resources/Extensions/print.css
+++ b/MacDown/Resources/Extensions/print.css
@@ -70,4 +70,19 @@
     body {
         padding: 0;
     }
+
+    /* Issue #387: themes set an explicit body background-color (e.g.
+     * GitHub.css uses #F8F8F8) and also declare
+     * `* { -webkit-print-color-adjust: exact; }`, which forces WebKit to
+     * preserve that background in printed output and exported PDFs.
+     * Force a white page and dark body text so every theme prints
+     * legibly on paper. pre/code/table/blockquote/heading/link rules are
+     * intentionally left alone - they either set their own color or have
+     * their own background designed for readability. */
+    html, body {
+        background: #ffffff !important;
+    }
+    body {
+        color: #000000 !important;
+    }
 }


### PR DESCRIPTION
## Summary

Printed output and exported PDFs had a grey page behind the text because every bundled theme CSS sets a body `background-color` (e.g. `GitHub.css` uses `#F8F8F8`) and also declares `* { -webkit-print-color-adjust: exact; }`, which forces WebKit to preserve that background in print output instead of stripping it in its default "economy" mode.

Fix this by adding `@media print` rules to `MacDown/Resources/Extensions/print.css` that force the page background to white and body text to black. `print.css` is already loaded after all theme CSS (see `MPRenderer.m` 534-670), so the `!important` rules cascade-override every theme.

Code block, table, blockquote, heading, and link rules are intentionally left alone — themes set their own `color` directly on those elements, so the body-level override doesn't leak via inheritance. Syntax highlighting and visual distinction survive in print.

## Related Issue

Related to #387

## Manual Testing Plan

1. Build MacDown 3000 in Xcode.
2. Open a markdown document containing H1-H3 headings, paragraphs, a blockquote, a fenced code block with syntax highlighting, inline code, a table, and a link. (The issue reporter's attached `Test Document-Macdown 3000.md` is a good candidate.)
3. For each of the 8 bundled themes (cycle via View > Style):
   - `File > Export > PDF...` and open the result. Verify:
     - Page background is white (no grey/cream/dark fill)
     - Body paragraph text is dark/legible
     - Fenced code blocks retain their theme-specific `pre` background
     - Inline `code` retains its theme-specific background
     - Headings, links, and tables retain their theme colors
   - `File > Print...` — confirm print preview matches the PDF above.
4. Regression check for PR #329: set custom margins via `File > Page Setup...`, export PDF, confirm margins are still honored.

### Specific edge cases
- Dark themes (Clearness Dark, GitHub Tomorrow, Github2 (dark), Solarized (Dark), GitHub-2020): body text was previously light → now black on white, legible.
- Solarized themes' `html body { ... }` and `html * { ... }` selectors: body background is overridden by `!important`; `html *` color stays on headings/code/links (by direct application), which is the desired behaviour.

## Review Notes

- Architectural review (Plan agent) confirmed the cascade: all 8 themes use specificity 0-0-1 without `!important` on body background and color, so a plain `!important` in `@media print` defeats every one. Solarized's `html body` (0-0-2) also loses to `!important`. No theme sets a background on `html` or uses image/gradient backgrounds, but `html, body` is covered defensively.
- Code review found no blocking issues and verified no element in any theme sets a dark opaque background while relying on inherited body text color (which would have become unreadable after forcing body `color: #000`).
- No plans in `plans/` describe print/PDF behaviour that this change contradicts, so no doc updates needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xx3ZGpqGBWDjeutReRNQVP)_