### PR TITLE
Sort editor theme and rendering CSS preference menus

### DIFF
--- a/MacDown/Code/Preferences/MPEditorPreferencesViewController.m
+++ b/MacDown/Code/Preferences/MPEditorPreferencesViewController.m
@@ -71,6 +71,7 @@ NSString * const MPDidRequestEditorSetupNotificationKeyName =
         kMPThemesDirectoryName,
         MPFileNameHasExtensionProcessor(kMPThemeFileExtension)
     );
+    itemTitles = [itemTitles sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
 
     [self.themeSelect addItemWithTitle:@""];
     [self.themeSelect addItemsWithTitles:itemTitles];

--- a/MacDown/Code/Preferences/MPHtmlPreferencesViewController.m
+++ b/MacDown/Code/Preferences/MPHtmlPreferencesViewController.m
@@ -148,6 +148,7 @@ NS_INLINE NSString *MPPrismDefaultThemeName()
         kMPStylesDirectoryName,
         MPFileNameHasExtensionProcessor(kMPStyleFileExtension)
     );
+    itemTitles = [itemTitles sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
 
     [self.stylesheetSelect addItemWithTitle:@""];
     [self.stylesheetSelect addItemsWithTitles:itemTitles];


### PR DESCRIPTION
## Summary
- Sort the **Theme (Editor)** and **CSS (Rendering)** popup lists in Preferences alphabetically using `localizedStandardCompare:` so entries are easier to discover.

Ported from upstream [macdownapp/macdown#1371](https://github.com/macdownapp/macdown/pull/1371) by @lexblagus.

## Test plan
- [ ] Open Preferences → Editor and confirm the Theme dropdown is sorted alphabetically (locale-aware).
- [ ] Open Preferences → Rendering and confirm the CSS dropdown is sorted alphabetically.
- [ ] CI build passes on macOS.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBDNAGZUjHci19onMUMYEP)_