### PR TITLE
Support uppercase task list checkboxes

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -3097,11 +3097,10 @@ to link outside that scope.", \
     if (!markdown || markdown.length == 0)
         return markdown;
 
-    // Regex pattern to match checkbox syntax: - [ ], - [x], * [ ], * [x], + [ ], + [x], 1. [ ], etc.
-    // Note: Only lowercase [x] is recognized by hoedown, so we only match that.
+    // Regex pattern to match checkbox syntax: - [ ], - [x], - [X], * [ ], etc.
     NSError *error = nil;
     NSRegularExpression *regex = [NSRegularExpression
-        regularExpressionWithPattern:@"^([ \\t]*)[-*+][ \\t]+\\[([ x])\\]|^([ \\t]*)\\d+\\.[ \\t]+\\[([ x])\\]"
+        regularExpressionWithPattern:@"^([ \\t]*)[-*+][ \\t]+\\[([ xX])\\]|^([ \\t]*)\\d+\\.[ \\t]+\\[([ xX])\\]"
                              options:NSRegularExpressionAnchorsMatchLines
                                error:&error];
 

--- a/MacDown/Code/Extension/hoedown_html_patch.c
+++ b/MacDown/Code/Extension/hoedown_html_patch.c
@@ -118,7 +118,7 @@ void hoedown_patch_render_listitem(
         if (flags & HOEDOWN_LI_BLOCK)
             offset = 3;
 
-        // Do task list checkbox ([x] or [ ]).
+        // Do task list checkbox ([x], [X], or [ ]).
         if (USE_TASK_LIST(state) && text->size >= 3)
         {
             if (strncmp((char *)(text->data + offset), "[ ]", 3) == 0)
@@ -131,7 +131,8 @@ void hoedown_patch_render_listitem(
                     g_checkbox_index++);
 				offset += 3;
             }
-            else if (strncmp((char *)(text->data + offset), "[x]", 3) == 0)
+            else if (strncmp((char *)(text->data + offset), "[x]", 3) == 0 ||
+                     strncmp((char *)(text->data + offset), "[X]", 3) == 0)
             {
                 HOEDOWN_BUFPUTSL(ob, "<li class=\"task-list-item\">");
                 hoedown_buffer_put(ob, text->data, offset);

--- a/MacDownTests/Fixtures/task-lists.html
+++ b/MacDownTests/Fixtures/task-lists.html
@@ -9,24 +9,25 @@
 </li>
 <li class="task-list-item"><input type="checkbox" data-checkbox-index="2"> Another unchecked task
 </li>
-<li>[X] Checked with capital X</li>
+<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="3"> Checked with capital X
+</li>
 </ul>
 
 <h2>Nested Task Lists</h2>
 
 <ul>
-<li class="task-list-item"><input type="checkbox" data-checkbox-index="6"> Parent task
+<li class="task-list-item"><input type="checkbox" data-checkbox-index="7"> Parent task
 
 <ul>
-<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="3"> Completed subtask
+<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="4"> Completed subtask
 </li>
-<li class="task-list-item"><input type="checkbox" data-checkbox-index="4"> Incomplete subtask
+<li class="task-list-item"><input type="checkbox" data-checkbox-index="5"> Incomplete subtask
 </li>
-<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="5"> Another completed subtask
+<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="6"> Another completed subtask
 </li>
 </ul>
 </li>
-<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="7"> Completed parent
+<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="8"> Completed parent
 </li>
 </ul>
 
@@ -34,10 +35,10 @@
 
 <ul>
 <li>Regular list item</li>
-<li class="task-list-item"><input type="checkbox" data-checkbox-index="8"> Task item
+<li class="task-list-item"><input type="checkbox" data-checkbox-index="9"> Task item
 </li>
 <li>Another regular item</li>
-<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="9"> Completed task
+<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="10"> Completed task
 </li>
 <li>Final regular item</li>
 </ul>
@@ -45,24 +46,24 @@
 <h2>Tasks with Inline Formatting</h2>
 
 <ul>
-<li class="task-list-item"><input type="checkbox" data-checkbox-index="10"> Task with <strong>bold text</strong>
+<li class="task-list-item"><input type="checkbox" data-checkbox-index="11"> Task with <strong>bold text</strong>
 </li>
-<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="11"> Task with <em>italic text</em>
+<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="12"> Task with <em>italic text</em>
 </li>
-<li class="task-list-item"><input type="checkbox" data-checkbox-index="12"> Task with <code>code</code>
+<li class="task-list-item"><input type="checkbox" data-checkbox-index="13"> Task with <code>code</code>
 </li>
-<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="13"> Task with <a href="https://example.com">link</a>
+<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="14"> Task with <a href="https://example.com">link</a>
 </li>
 </ul>
 
 <h2>Numbered Task Lists</h2>
 
 <ol>
-<li class="task-list-item"><input type="checkbox" data-checkbox-index="14"> First task
+<li class="task-list-item"><input type="checkbox" data-checkbox-index="15"> First task
 </li>
-<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="15"> Second task (completed)
+<li class="task-list-item"><input type="checkbox" checked data-checkbox-index="16"> Second task (completed)
 </li>
-<li class="task-list-item"><input type="checkbox" data-checkbox-index="16"> Third task
+<li class="task-list-item"><input type="checkbox" data-checkbox-index="17"> Third task
 </li>
 </ol>
 
@@ -70,7 +71,7 @@
 
 <ul>
 <li>[] Invalid (no space)</li>
-<li class="task-list-item"><p><input type="checkbox" data-checkbox-index="17"> Valid unchecked
+<li class="task-list-item"><p><input type="checkbox" data-checkbox-index="18"> Valid unchecked
 -[ ] Invalid (no space after dash)</p>
 </li>
 <li><p>[x ] Invalid (space before X)</p></li>

--- a/MacDownTests/MPCheckboxToggleTests.m
+++ b/MacDownTests/MPCheckboxToggleTests.m
@@ -273,6 +273,17 @@
                           @"Asterisk marker checkbox should toggle correctly");
 }
 
+- (void)testToggleUppercaseCheckedCheckbox
+{
+    NSString *markdown = @"- [X] Done";
+    NSString *expected = @"- [ ] Done";
+
+    NSString *result = [MPDocument toggleCheckboxAtIndex:0 inMarkdown:markdown];
+
+    XCTAssertEqualObjects(result, expected,
+                          @"Uppercase checked checkbox should toggle to unchecked");
+}
+
 /**
  * Test checkbox with plus marker.
  */

--- a/MacDownTests/MPMarkdownRenderingTests.m
+++ b/MacDownTests/MPMarkdownRenderingTests.m
@@ -300,6 +300,19 @@
                   @"Second checkbox should have index 1");
 }
 
+- (void)testUppercaseCheckedCheckboxHasDataIndex
+{
+    self.delegate.extensions = 0;
+    self.renderer.rendererFlags = HOEDOWN_HTML_USE_TASK_LIST;
+    self.dataSource.markdown = @"- [X] Done";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    XCTAssertTrue([html containsString:@"<input type=\"checkbox\" checked data-checkbox-index=\"0\">"],
+                  @"Uppercase checked task-list markers should render as checked checkboxes");
+}
+
 /**
  * Test that multiple checkboxes get sequential indices.
  * Related to GitHub issue #269.


### PR DESCRIPTION
## Summary
- Render `[X]` task-list markers as checked checkboxes, matching `[x]`
- Allow preview checkbox toggles to find and clear uppercase checked markers
- Update the task-list golden fixture and add targeted regression tests

## Root cause
The patched Hoedown list-item renderer and source-toggle regex only recognized lowercase `[x]`, so uppercase checked task-list markers stayed literal text and were skipped by toggle handling.

## Validation
- `bundle exec pod install`
- `xcodebuild test -workspace 'MacDown 3000.xcworkspace' -scheme MacDown -destination 'platform=macOS' -only-testing:MacDownTests/MPMarkdownRenderingTests/testUppercaseCheckedCheckboxHasDataIndex -only-testing:MacDownTests/MPCheckboxToggleTests/testToggleUppercaseCheckedCheckbox`

Related to #369
