### PR TITLE
Add File menu autosave toggle

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -899,6 +899,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             return NO;
         }
     }
+    else if (action == @selector(toggleAutoSave:))
+    {
+        if ([(id)item isKindOfClass:[NSMenuItem class]])
+            ((NSMenuItem *)item).state = self.preferences.editorAutoSave ?
+                NSControlStateValueOn : NSControlStateValueOff;
+    }
     return result;
 }
 
@@ -1993,6 +1999,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 - (IBAction)toggleEditorPane:(id)sender
 {
     [self toggleSplitterCollapsingEditorPane:YES];
+}
+
+- (IBAction)toggleAutoSave:(id)sender
+{
+    self.preferences.editorAutoSave = !self.preferences.editorAutoSave;
+    [self.preferences synchronize];
 }
 
 - (IBAction)render:(id)sender

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -115,6 +115,12 @@
                                     <action selector="revertDocumentToSaved:" target="-1" id="iJ3-Pv-kwq"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Auto Save" id="aSv-FL-tgl">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleAutoSave:" target="-1" id="aSv-FL-act"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="oOV-6A-wGe"/>
                             <menuItem title="Export" id="5mp-ev-1el">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/MacDownTests/MPDocumentIOTests.m
+++ b/MacDownTests/MPDocumentIOTests.m
@@ -13,6 +13,7 @@
 @interface MPDocument (LinkTargetTesting)
 @property (strong) NSURL *currentBaseUrl;
 - (BOOL)canAutomaticallyCreateLinkedFileAtURL:(NSURL *)url;
+- (IBAction)toggleAutoSave:(id)sender;
 @end
 
 @interface MPDocumentIOTests : XCTestCase
@@ -202,6 +203,44 @@
                    @"MPDocument should not autosave when editorAutoSave is NO");
 
     // Restore
+    prefs.editorAutoSave = original;
+}
+
+- (void)testToggleAutoSaveActionUpdatesPreference
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    BOOL original = prefs.editorAutoSave;
+
+    prefs.editorAutoSave = YES;
+    [self.document toggleAutoSave:nil];
+    XCTAssertFalse(prefs.editorAutoSave,
+                   @"File menu auto-save toggle should disable autosave");
+
+    [self.document toggleAutoSave:nil];
+    XCTAssertTrue(prefs.editorAutoSave,
+                  @"File menu auto-save toggle should re-enable autosave");
+
+    prefs.editorAutoSave = original;
+}
+
+- (void)testToggleAutoSaveMenuValidationReflectsPreference
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    BOOL original = prefs.editorAutoSave;
+    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@"Auto Save"
+                                                  action:@selector(toggleAutoSave:)
+                                           keyEquivalent:@""];
+
+    prefs.editorAutoSave = YES;
+    [self.document validateUserInterfaceItem:item];
+    XCTAssertEqual(item.state, NSControlStateValueOn,
+                   @"Auto-save menu item should be checked when autosave is enabled");
+
+    prefs.editorAutoSave = NO;
+    [self.document validateUserInterfaceItem:item];
+    XCTAssertEqual(item.state, NSControlStateValueOff,
+                   @"Auto-save menu item should be unchecked when autosave is disabled");
+
     prefs.editorAutoSave = original;
 }
 


### PR DESCRIPTION
## Summary
- Add an Auto Save toggle to the File menu
- Wire the toggle to the existing `editorAutoSave` preference used by `MPDocument.autosavesInPlace`
- Keep the menu item checked/unchecked through standard menu validation

## Root cause
Autosave could already be disabled through preferences, but there was no fast document-menu control for users who want prompt-on-close behavior after disabling autosave.

## Validation
- `ibtool --warnings --errors --notices MacDown/Localization/Base.lproj/MainMenu.xib`
- `xcodebuild test -workspace 'MacDown 3000.xcworkspace' -scheme MacDown -destination 'platform=macOS' -only-testing:MacDownTests/MPDocumentIOTests/testAutosavesInPlaceRespectsPreference -only-testing:MacDownTests/MPDocumentIOTests/testToggleAutoSaveActionUpdatesPreference -only-testing:MacDownTests/MPDocumentIOTests/testToggleAutoSaveMenuValidationReflectsPreference`

Related to #301
