### PR TITLE
Hide unparsable YAML front matter

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2789,7 +2789,11 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     NSString *title = nil;
     NSString *string = self.editor.string;
     if (self.preferences.htmlDetectFrontMatter)
-        title = [[[string frontMatter:NULL] objectForKey:@"title"] description];
+    {
+        id frontMatter = [string frontMatter:NULL];
+        if ([frontMatter respondsToSelector:@selector(objectForKey:)])
+            title = [[frontMatter objectForKey:@"title"] description];
+    }
     if (title)
         return title;
 

--- a/MacDown/Code/Extension/NSString+Lookup.m
+++ b/MacDown/Code/Extension/NSString+Lookup.m
@@ -70,17 +70,6 @@
         return nil;
     }
 
-    NSString *frontMatter = [self substringWithRange:[result rangeAtIndex:1]];
-    NSArray *objects =
-        [YAMLSerialization objectsWithYAMLString:frontMatter
-                                         options:kYAMLReadOptionStringScalars
-                                           error:NULL];
-    if (!objects.count)
-    {
-        if (contentOffset)
-            *contentOffset = 0;
-        return nil;
-    }
     if (contentOffset)
     {
         NSUInteger offset = NSMaxRange([result rangeAtIndex:0]);
@@ -95,6 +84,13 @@
         }
         *contentOffset = offset;
     }
+    NSString *frontMatter = [self substringWithRange:[result rangeAtIndex:1]];
+    NSArray *objects =
+        [YAMLSerialization objectsWithYAMLString:frontMatter
+                                         options:kYAMLReadOptionStringScalars
+                                           error:NULL];
+    if (!objects.count)
+        return nil;
     return objects[0];
 }
 

--- a/MacDownTests/MPRendererEdgeCaseTests.m
+++ b/MacDownTests/MPRendererEdgeCaseTests.m
@@ -701,6 +701,35 @@
                    @"Should not contain front matter table");
 }
 
+- (void)testRendererWithInvalidFrontMatterStillHidesFromPreview
+{
+    self.delegate.detectFrontMatter = YES;
+    self.dataSource.markdown = @"---\ninvalid: yaml: content:\n---\n\n# Content";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    XCTAssertFalse([html containsString:@"invalid"],
+                   @"Invalid front matter should not appear in preview");
+    XCTAssertTrue([html containsString:@"Content"],
+                  @"Content after invalid front matter should render");
+}
+
+- (void)testRendererWithHTMLTitleInFrontMatterStillRendersBody
+{
+    self.delegate.detectFrontMatter = YES;
+    self.dataSource.markdown =
+        @"---\ntitle: <title>Hidden</title>\n---\n\n# Visible Body";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    XCTAssertFalse([html containsString:@"Hidden"],
+                   @"Front matter HTML values should not appear in preview");
+    XCTAssertTrue([html containsString:@"Visible Body"],
+                  @"Body should render after front matter containing HTML tags");
+}
+
 
 #pragma mark - Issue #254: Lists After Paragraphs
 

--- a/MacDownTests/MPStringLookupTests.m
+++ b/MacDownTests/MPStringLookupTests.m
@@ -246,4 +246,15 @@
                           @"Should consume single trailing newline after closing delimiter");
 }
 
+- (void)testFrontMatterContentOffsetWithInvalidYAML
+{
+    NSString *input = @"---\ninvalid: yaml: content:\n---\n\n# Content";
+    NSUInteger offset = 0;
+    id result = [input frontMatter:&offset];
+    NSString *remaining = [input substringFromIndex:offset];
+    XCTAssertNil(result, @"Invalid YAML should not return parsed front matter");
+    XCTAssertEqualObjects(remaining, @"# Content",
+                          @"Syntactic front matter should still be skipped");
+}
+
 @end


### PR DESCRIPTION
## Summary
- advance the preview content offset after syntactic YAML front matter even when YAML parsing fails
- keep front-matter title extraction from assuming the parsed object is always a dictionary
- add regressions for invalid YAML and `<title>` values inside front matter

Related to #307.

## Validation
- xcodebuild test -workspace 'MacDown 3000.xcworkspace' -scheme MacDown -destination 'platform=macOS' -only-testing:MacDownTests/MPStringLookupTests/testFrontMatterContentOffsetWithInvalidYAML -only-testing:MacDownTests/MPRendererEdgeCaseTests/testRendererWithInvalidFrontMatterStillHidesFromPreview -only-testing:MacDownTests/MPRendererEdgeCaseTests/testRendererWithHTMLTitleInFrontMatterStillRendersBody