### PR TITLE
Mirror drag-collapse ratio on pane swap

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2269,6 +2269,9 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             [self.splitView swapViews];
             if (!self.previewVisible && self.previousSplitRatio >= 0.0)
                 self.previousSplitRatio = 1.0 - self.previousSplitRatio;
+            if (self.lastNonCollapsedRatio > 0.0
+                    && self.lastNonCollapsedRatio < 1.0)
+                self.lastNonCollapsedRatio = 1.0 - self.lastNonCollapsedRatio;
 
             // Need to queue this or the views won't be initialised correctly.
             // Don't really know why, but this works.

--- a/MacDownTests/MPPaneToggleTests.m
+++ b/MacDownTests/MPPaneToggleTests.m
@@ -19,9 +19,11 @@
 @property (weak) NSView *editorContainer;
 @property (weak) WebView *preview;
 @property CGFloat previousSplitRatio;
+@property CGFloat lastNonCollapsedRatio;
 - (IBAction)toggleEditorPane:(id)sender;
 - (IBAction)togglePreviewPane:(id)sender;
 - (void)applyEditorStartInPreviewModePreference;
+- (void)setupEditor:(NSString *)changedKey;
 @end
 
 #pragma mark - Mock Menu Item
@@ -899,6 +901,39 @@
 
     XCTAssertFalse(item.hidden,
                    @"Issue #377: Editor menu item should NOT be hidden after divider-drag collapse");
+}
+
+- (void)testEditorOnRightMirrorsLastNonCollapsedRatio
+{
+    MPPreferences *preferences = [MPPreferences sharedInstance];
+    BOOL originalEditorOnRight = preferences.editorOnRight;
+
+    @try {
+        MPDocumentSplitView *splitView =
+            [[MPDocumentSplitView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)];
+        NSView *preview = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 50, 100)];
+        NSView *editor = [[NSView alloc] initWithFrame:NSMakeRect(50, 0, 50, 100)];
+        [splitView addSubview:preview];
+        [splitView addSubview:editor];
+        self.document.splitView = splitView;
+        self.document.preview = (WebView *)preview;
+
+        preferences.editorOnRight = NO;
+        [self.document setupEditor:@"editorOnRight"];
+        self.document.previousSplitRatio = -1.0;
+        self.document.lastNonCollapsedRatio = 0.3;
+
+        preferences.editorOnRight = YES;
+        [self.document setupEditor:@"editorOnRight"];
+
+        XCTAssertEqualWithAccuracy(self.document.lastNonCollapsedRatio, 0.7, 0.001,
+                                   @"Issue #380: drag-collapse restore ratio should mirror "
+                                   @"when editorOnRight swaps panes");
+    }
+    @finally {
+        preferences.editorOnRight = originalEditorOnRight;
+        [preferences synchronize];
+    }
 }
 
 @end


### PR DESCRIPTION
## Summary
- mirror `lastNonCollapsedRatio` when `editorOnRight` swaps the editor and preview panes
- add a deterministic regression for the pane-swap restore ratio path

Related to #380.

## Validation
- xcodebuild test -workspace 'MacDown 3000.xcworkspace' -scheme MacDown -destination 'platform=macOS' -only-testing:MacDownTests/MPPaneToggleTests/testEditorOnRightMirrorsLastNonCollapsedRatio