### PR TITLE
Clear editor highlighting on reload

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -594,6 +594,8 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         {
             self.editor.string = self.loadedString;
             self.loadedString = nil;
+            [self.highlighter clearHighlighting];
+            [self.highlighter readClearTextStylesFromTextView];
         }
 
         // Gap 8: Claim editor ownership before rendering so that the full-reload

--- a/MacDownTests/MPDocumentLifecycleTests.m
+++ b/MacDownTests/MPDocumentLifecycleTests.m
@@ -48,12 +48,20 @@
 // Spy highlighter: records whether parseAndHighlightNow was called.
 @interface MPSpyHighlighter : HGMarkdownHighlighter
 @property (nonatomic) BOOL parseAndHighlightNowCalled;
+@property (nonatomic) BOOL clearHighlightingCalled;
+@property (nonatomic) BOOL readClearTextStylesFromTextViewCalled;
 @end
 
 @implementation MPSpyHighlighter
 - (void)parseAndHighlightNow {
     self.parseAndHighlightNowCalled = YES;
     // Do not call super — avoids actual text-view work in tests.
+}
+- (void)clearHighlighting {
+    self.clearHighlightingCalled = YES;
+}
+- (void)readClearTextStylesFromTextView {
+    self.readClearTextStylesFromTextViewCalled = YES;
 }
 @end
 
@@ -656,6 +664,29 @@
 
     XCTAssertTrue(highlighter.parseAndHighlightNowCalled,
                   @"parseAndHighlightNow must fire for new documents (issue #358)");
+}
+
+- (void)testExistingDocumentClearsHighlightingBeforeReloadHighlight
+{
+    MPSpyHighlighter *highlighter = nil;
+    MPEditorView *editor = nil;
+    [self wireDocument:self.document
+           intoRenderer:nil
+            highlighter:&highlighter
+                 editor:&editor];
+
+    self.document.loadedString = @"# Reloaded\n\nBody";
+    highlighter.clearHighlightingCalled = NO;
+    highlighter.readClearTextStylesFromTextViewCalled = NO;
+
+    [self.document reloadFromLoadedString];
+
+    XCTAssertTrue(highlighter.clearHighlightingCalled,
+                  @"Issue #378: external reload should clear stale editor attributes "
+                  @"before the async highlight pass");
+    XCTAssertTrue(highlighter.readClearTextStylesFromTextViewCalled,
+                  @"Issue #378: highlighter should refresh clear-text attributes "
+                  @"after replacing editor text");
 }
 
 // Regression: existing-document path must still trigger a render after the fix.


### PR DESCRIPTION
## Summary
- clear existing editor highlighting after replacing text during reload from disk
- refresh clear-text attributes before scheduling the new highlight pass
- add a lifecycle regression for the external reload path

Related to #378.

## Validation
- xcodebuild test -workspace 'MacDown 3000.xcworkspace' -scheme MacDown -destination 'platform=macOS' -only-testing:MacDownTests/MPDocumentLifecycleTests/testExistingDocumentClearsHighlightingBeforeReloadHighlight -only-testing:MacDownTests/MPDocumentLifecycleTests/testExistingDocumentTriggersRenderOnReload -only-testing:MacDownTests/MPDocumentLifecycleTests/testExistingDocumentTriggersHighlightOnReload

Note: the last only-testing selector is not present on main, so Xcode ran the two matching lifecycle tests.