### PR TITLE
Preserve custom Prism theme filename case

### DIFF
--- a/MacDown/Code/Utility/MPUtilities.m
+++ b/MacDown/Code/Utility/MPUtilities.m
@@ -234,34 +234,51 @@ static NSString *MPPrismThemeDisplayName(NSString *fileName)
     return [name capitalizedString];
 }
 
+static NSURL *MPPrismThemeURLInRoot(NSString *root, NSString *fileName)
+{
+    if (!root || !fileName)
+        return nil;
+
+    NSString *themeDir = [NSString pathWithComponents:@[
+        root, kMPPrismThemesDirectoryName]];
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSArray *files = [manager contentsOfDirectoryAtPath:themeDir error:nil];
+    for (NSString *file in files)
+    {
+        if ([file caseInsensitiveCompare:fileName] == NSOrderedSame)
+        {
+            NSString *path = [themeDir stringByAppendingPathComponent:file];
+            return [NSURL fileURLWithPath:path];
+        }
+    }
+
+    NSString *path = [themeDir stringByAppendingPathComponent:fileName];
+    if ([manager fileExistsAtPath:path])
+        return [NSURL fileURLWithPath:path];
+    return nil;
+}
+
 NSURL *MPHighlightingThemeURLForNameInPaths(
     NSString *name, NSString *userDataRoot, NSString *bundleResourceRoot)
 {
     NSString *fileName = MPPrismThemeFileName(name);
-    NSFileManager *manager = [NSFileManager defaultManager];
 
     // Check user Application Support directory first
-    if (userDataRoot)
-    {
-        NSString *userPath = [NSString pathWithComponents:@[
-            userDataRoot, kMPPrismThemesDirectoryName, fileName]];
-        if ([manager fileExistsAtPath:userPath])
-            return [NSURL fileURLWithPath:userPath];
-    }
+    NSURL *url = MPPrismThemeURLInRoot(userDataRoot, fileName);
+    if (url)
+        return url;
 
     // Fall back to bundle resources
     if (bundleResourceRoot)
     {
-        NSString *bundlePath = [NSString pathWithComponents:@[
-            bundleResourceRoot, kMPPrismThemesDirectoryName, fileName]];
-        if ([manager fileExistsAtPath:bundlePath])
-            return [NSURL fileURLWithPath:bundlePath];
+        url = MPPrismThemeURLInRoot(bundleResourceRoot, fileName);
+        if (url)
+            return url;
 
         // Safety net: fall back to default theme (prism.css)
-        NSString *defaultPath = [NSString pathWithComponents:@[
-            bundleResourceRoot, kMPPrismThemesDirectoryName, @"prism.css"]];
-        if ([manager fileExistsAtPath:defaultPath])
-            return [NSURL fileURLWithPath:defaultPath];
+        url = MPPrismThemeURLInRoot(bundleResourceRoot, @"prism.css");
+        if (url)
+            return url;
     }
 
     return nil;
@@ -317,4 +334,3 @@ NSArray *MPListHighlightingThemesInPaths(
 
     return [[names array] sortedArrayUsingSelector:@selector(compare:)];
 }
-

--- a/MacDownTests/MPUtilityTests.m
+++ b/MacDownTests/MPUtilityTests.m
@@ -76,6 +76,28 @@
                   @"Should return user theme path, got: %@", result.path);
 }
 
+- (void)testHighlightingThemeURLPreservesUserThemeFilenameCase
+{
+    NSString *userThemeDir = [self.tempDir
+        stringByAppendingPathComponent:@"Prism/themes"];
+    [[NSFileManager defaultManager] createDirectoryAtPath:userThemeDir
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+    [@"/* custom theme */" writeToFile:[userThemeDir
+        stringByAppendingPathComponent:@"prism-Embark6.css"]
+                            atomically:YES
+                              encoding:NSUTF8StringEncoding
+                                 error:nil];
+
+    NSURL *result = MPHighlightingThemeURLForNameInPaths(@"Embark6",
+                                                         self.tempDir,
+                                                         nil);
+    XCTAssertNotNil(result, @"Should find mixed-case user theme");
+    XCTAssertEqualObjects(result.lastPathComponent, @"prism-Embark6.css",
+                          @"Should return the actual theme filename");
+}
+
 - (void)testHighlightingThemeURLReturnsBundleURLWhenNoUserTheme
 {
     // Create a fake bundle theme directory


### PR DESCRIPTION
Related to #315

## Summary
- Resolve Prism themes by scanning the actual user and bundle theme directories case-insensitively
- Return the real CSS filename path so mixed-case custom themes load on open
- Add a regression test for mixed-case user theme filenames

## Tests
- xcodebuild test -workspace 'MacDown 3000.xcworkspace' -scheme MacDown -destination 'platform=macOS' -only-testing:MacDownTests/MPUtilityTests/testHighlightingThemeURLPreservesUserThemeFilenameCase -only-testing:MacDownTests/MPUtilityTests/testHighlightingThemeURLReturnsUserThemeWhenPresent