### PR TITLE
Render GitHub alert blockquotes

### DIFF
--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -192,6 +192,59 @@ NS_INLINE NSString *MPPreprocessMarkdown(NSString *text)
     return mut;
 }
 
+NS_INLINE NSString *MPHTMLWithGitHubAlertBlocks(NSString *html)
+{
+    if (!html.length)
+        return html;
+
+    static NSRegularExpression *alertRegex = nil;
+    static NSDictionary<NSString *, NSString *> *titles = nil;
+    static dispatch_once_t alertToken;
+    dispatch_once(&alertToken, ^{
+        NSString *pattern =
+            @"<blockquote>\\s*<p>\\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\]"
+             "(?:\\s*<br\\s*/?>)?\\s*([\\s\\S]*?)</p>([\\s\\S]*?)</blockquote>";
+        alertRegex = [[NSRegularExpression alloc] initWithPattern:pattern
+                                                          options:NSRegularExpressionCaseInsensitive
+                                                            error:NULL];
+        titles = @{
+            @"note": @"Note",
+            @"tip": @"Tip",
+            @"important": @"Important",
+            @"warning": @"Warning",
+            @"caution": @"Caution"
+        };
+    });
+
+    NSMutableString *result = [html mutableCopy];
+    NSArray<NSTextCheckingResult *> *matches =
+        [alertRegex matchesInString:result options:0
+                              range:NSMakeRange(0, result.length)];
+    NSCharacterSet *whitespaceAndNewline =
+        [NSCharacterSet whitespaceAndNewlineCharacterSet];
+    for (NSTextCheckingResult *match in [matches reverseObjectEnumerator])
+    {
+        NSString *kind = [[result substringWithRange:[match rangeAtIndex:1]]
+            lowercaseString];
+        NSString *firstParagraph = [[result substringWithRange:[match rangeAtIndex:2]]
+            stringByTrimmingCharactersInSet:whitespaceAndNewline];
+        NSString *remainingHTML = [result substringWithRange:[match rangeAtIndex:3]];
+
+        NSMutableString *body = [NSMutableString string];
+        if (firstParagraph.length)
+            [body appendFormat:@"<p>%@</p>\n", firstParagraph];
+        [body appendString:remainingHTML];
+
+        NSString *replacement = [NSString stringWithFormat:
+            @"<div class=\"markdown-alert markdown-alert-%@\">\n"
+             "<p class=\"markdown-alert-title\">%@</p>\n"
+             "%@</div>",
+            kind, titles[kind], body];
+        [result replaceCharactersInRange:match.range withString:replacement];
+    }
+    return result;
+}
+
 NS_INLINE NSString *MPHTMLFromMarkdown(
     NSString *text, int flags, BOOL smartypants, NSString *frontMatter,
     hoedown_renderer *htmlRenderer, hoedown_renderer *tocRenderer)
@@ -242,6 +295,7 @@ NS_INLINE NSString *MPHTMLFromMarkdown(
     }
     if (frontMatter)
         result = [NSString stringWithFormat:@"%@\n%@", frontMatter, result];
+    result = MPHTMLWithGitHubAlertBlocks(result);
     
     return result;
 }
@@ -662,6 +716,9 @@ NS_INLINE NSString *MPPreviewHeadTags(NSString *checkboxBridgeToken)
     NSURL *printURL = MPExtensionURL(@"print", @"css");
     [stylesheets addObject:[MPStyleSheet CSSWithURL:printURL]];
 
+    NSURL *alertsURL = MPExtensionURL(@"github-alerts", @"css");
+    [stylesheets addObject:[MPStyleSheet CSSWithURL:alertsURL]];
+
     // Load export.css last for paragraph text wrapping in HTML exports and preview
     NSURL *exportURL = MPExtensionURL(@"export", @"css");
     [stylesheets addObject:[MPStyleSheet CSSWithURL:exportURL]];
@@ -893,6 +950,9 @@ NS_INLINE NSString *MPPreviewHeadTags(NSString *checkboxBridgeToken)
     // Must be after all other stylesheets to ensure proper cascade order
     if (withStyles)
     {
+        NSURL *alertsURL = MPExtensionURL(@"github-alerts", @"css");
+        [styles addObject:[MPStyleSheet CSSWithURL:alertsURL]];
+
         NSURL *exportURL = MPExtensionURL(@"export", @"css");
         [styles addObject:[MPStyleSheet CSSWithURL:exportURL]];
     }

--- a/MacDown/Resources/Extensions/github-alerts.css
+++ b/MacDown/Resources/Extensions/github-alerts.css
@@ -1,0 +1,58 @@
+.markdown-alert {
+    margin: 1em 0;
+    padding: .5em 1em;
+    border-left: .25em solid #57606a;
+}
+
+.markdown-alert > :first-child {
+    margin-top: 0;
+}
+
+.markdown-alert > :last-child {
+    margin-bottom: 0;
+}
+
+.markdown-alert-title {
+    margin-bottom: .5em;
+    font-weight: 600;
+}
+
+.markdown-alert-note {
+    border-left-color: #0969da;
+}
+
+.markdown-alert-note .markdown-alert-title {
+    color: #0969da;
+}
+
+.markdown-alert-tip {
+    border-left-color: #1a7f37;
+}
+
+.markdown-alert-tip .markdown-alert-title {
+    color: #1a7f37;
+}
+
+.markdown-alert-important {
+    border-left-color: #8250df;
+}
+
+.markdown-alert-important .markdown-alert-title {
+    color: #8250df;
+}
+
+.markdown-alert-warning {
+    border-left-color: #9a6700;
+}
+
+.markdown-alert-warning .markdown-alert-title {
+    color: #9a6700;
+}
+
+.markdown-alert-caution {
+    border-left-color: #d1242f;
+}
+
+.markdown-alert-caution .markdown-alert-title {
+    color: #d1242f;
+}

--- a/MacDownTests/MPRendererEdgeCaseTests.m
+++ b/MacDownTests/MPRendererEdgeCaseTests.m
@@ -135,6 +135,36 @@
     XCTAssertNotNil(html, @"Should handle single newline");
 }
 
+- (void)testRendererFormatsGitHubAlertBlockquote
+{
+    self.dataSource.markdown = @"> [!WARNING]\n> Check this before release.";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = self.renderer.currentHtml;
+
+    XCTAssertTrue([html containsString:@"markdown-alert markdown-alert-warning"],
+                  @"Should render warning alert container");
+    XCTAssertTrue([html containsString:@"markdown-alert-title\">Warning"],
+                  @"Should render alert title");
+    XCTAssertTrue([html containsString:@"<p>Check this before release.</p>"],
+                  @"Should preserve alert body");
+    XCTAssertFalse([html containsString:@"[!WARNING]"],
+                   @"Should remove GitHub alert marker");
+}
+
+- (void)testRendererLeavesNormalBlockquoteAlone
+{
+    self.dataSource.markdown = @"> Ordinary quote";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = self.renderer.currentHtml;
+
+    XCTAssertTrue([html containsString:@"<blockquote>"],
+                  @"Should keep ordinary blockquotes");
+    XCTAssertFalse([html containsString:@"markdown-alert"],
+                   @"Should not convert ordinary blockquotes to alerts");
+}
+
 
 #pragma mark - Preview Security Tests
 


### PR DESCRIPTION
Related to #291

## Summary
- Convert GitHub-style blockquote alerts into semantic alert containers after Markdown rendering
- Add bundled alert CSS for preview and styled HTML export
- Add renderer tests for alert conversion and ordinary blockquotes

## Tests
- xcodebuild test -workspace 'MacDown 3000.xcworkspace' -scheme MacDown -destination 'platform=macOS' -only-testing:MacDownTests/MPRendererEdgeCaseTests/testRendererFormatsGitHubAlertBlockquote -only-testing:MacDownTests/MPRendererEdgeCaseTests/testRendererLeavesNormalBlockquoteAlone -only-testing:MacDownTests/MPRendererEdgeCaseTests/testPreviewRenderIncludesContentSecurityPolicyAndCheckboxToken