### PR TITLE
Add insert table toolbar action

### DIFF
--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -79,6 +79,7 @@ static CGFloat itemWidth = 37;
         [self toolbarItemWithIdentifier:@"code" label:NSLocalizedString(@"Inline Code", @"Inline code toolbar button") icon:@"ToolbarIconInlineCode" action:@selector(toggleInlineCode:)],
         [self toolbarItemWithIdentifier:@"link" label:NSLocalizedString(@"Link", @"Link toolbar button") icon:@"ToolbarIconLink" action:@selector(toggleLink:)],
         [self toolbarItemWithIdentifier:@"image" label:NSLocalizedString(@"Image", @"Image toolbar button") icon:@"ToolbarIconImage" action:@selector(toggleImage:)],
+        [self toolbarItemWithIdentifier:@"table" label:NSLocalizedString(@"Table", @"Table toolbar button") icon:NSImageNameListViewTemplate action:@selector(insertTable:)],
         [self toolbarItemWithIdentifier:@"copy-html" label:NSLocalizedString(@"Copy HTML", @"Copy HTML toolbar button") icon:@"ToolbarIconCopyHTML" action:@selector(copyHtml:)],
         [self toolbarItemWithIdentifier:@"comment" label:NSLocalizedString(@"Comment", @"Comment toolbar button") icon:@"ToolbarIconComment" action:@selector(toggleComment:)],
         [self toolbarItemWithIdentifier:@"highlight" label:NSLocalizedString(@"Highlight", @"Highlight toolbar button") icon:@"ToolbarIconHighlight" action:@selector(toggleHighlight:)],
@@ -157,7 +158,7 @@ static CGFloat itemWidth = 37;
     
     // Add space after the specified toolbar item indices
     int spaceAfterIndices[] = {}; // No space in the default set
-    int flexibleSpaceAfterIndices[] = {2, 3, 5, 7, 11};
+    int flexibleSpaceAfterIndices[] = {2, 3, 5, 8, 12};
 
     // Bounds checking to prevent buffer overflow when accessing C arrays
     // Empty spaceAfterIndices array must not be accessed (count = 0)

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1918,6 +1918,34 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     self.editor.selectedRange = selectedRange;
 }
 
+- (IBAction)insertTable:(id)sender
+{
+    NSString *template = @"| Column 1 | Column 2 | Column 3 |\n"
+                         @"| --- | --- | --- |\n"
+                         @"|  |  |  |\n";
+    NSRange selectedRange = self.editor.selectedRange;
+    NSString *content = self.editor.string ?: @"";
+    NSMutableString *inserted = [template mutableCopy];
+    NSUInteger cursorOffset = [template rangeOfString:@"|  |"].location + 2;
+
+    if (selectedRange.location > 0 &&
+        [content characterAtIndex:selectedRange.location - 1] != '\n')
+    {
+        [inserted insertString:@"\n\n" atIndex:0];
+        cursorOffset += 2;
+    }
+
+    NSUInteger selectionEnd = NSMaxRange(selectedRange);
+    if (selectionEnd < content.length &&
+        [content characterAtIndex:selectionEnd] != '\n')
+    {
+        [inserted appendString:@"\n"];
+    }
+
+    [self.editor insertText:inserted replacementRange:selectedRange];
+    self.editor.selectedRange = NSMakeRange(selectedRange.location + cursorOffset, 0);
+}
+
 - (IBAction)toggleOrderedList:(id)sender
 {
     [self.editor toggleBlockWithPattern:@"^[0-9]+ \\S" prefix:@"1. "];

--- a/MacDownTests/MPToolbarControllerTests.m
+++ b/MacDownTests/MPToolbarControllerTests.m
@@ -91,6 +91,7 @@
         @"code",
         @"link",
         @"image",
+        @"table",
         @"copy-html",
         @"comment",
         @"highlight",
@@ -107,10 +108,10 @@
 - (void)testAllowedIdentifiersTotalCount
 {
     NSArray *allowed = [self.controller toolbarAllowedItemIdentifiers:nil];
-    // 13 custom + 3 system (flexible space, space, separator)
-    XCTAssertEqual(allowed.count, 16,
-                   @"Allowed identifiers should have 16 items: "
-                   @"13 custom + flexible space + space + separator");
+    // 14 custom + 3 system (flexible space, space, separator)
+    XCTAssertEqual(allowed.count, 17,
+                   @"Allowed identifiers should have 17 items: "
+                   @"14 custom + flexible space + space + separator");
 }
 
 - (void)testAllowedIdentifiersOrderCustomItemsFirst
@@ -126,6 +127,7 @@
         @"code",
         @"link",
         @"image",
+        @"table",
         @"copy-html",
         @"comment",
         @"highlight",
@@ -213,6 +215,7 @@
         @"code",
         @"link",
         @"image",
+        @"table",
         @"copy-html",
         @"comment",
         @"highlight",
@@ -229,8 +232,8 @@
 - (void)testSelectableIdentifiersCount
 {
     NSArray *selectable = [self.controller toolbarSelectableItemIdentifiers:nil];
-    XCTAssertEqual(selectable.count, 13,
-                   @"Selectable identifiers should have exactly 13 items (custom only, no system items)");
+    XCTAssertEqual(selectable.count, 14,
+                   @"Selectable identifiers should have exactly 14 items (custom only, no system items)");
 }
 
 - (void)testSelectableIdentifiersAcceptsNilToolbar
@@ -275,6 +278,7 @@
         @"code",
         @"link",
         @"image",
+        @"table",
         @"copy-html",
         @"layout"
     ];
@@ -303,8 +307,8 @@
 - (void)testDefaultIdentifiersTotalCount
 {
     NSArray *defaults = [self.controller toolbarDefaultItemIdentifiers:nil];
-    XCTAssertEqual(defaults.count, 15,
-                   @"Default toolbar should have 15 items: 10 custom + 5 flexible spaces");
+    XCTAssertEqual(defaults.count, 16,
+                   @"Default toolbar should have 16 items: 11 custom + 5 flexible spaces");
 }
 
 - (void)testDefaultIdentifiersDoNotContainFixedSpaces
@@ -330,6 +334,7 @@
         NSToolbarFlexibleSpaceItemIdentifier,
         @"link",
         @"image",
+        @"table",
         NSToolbarFlexibleSpaceItemIdentifier,
         @"copy-html",
         NSToolbarFlexibleSpaceItemIdentifier,
@@ -366,6 +371,7 @@
         @"code",
         @"link",
         @"image",
+        @"table",
         @"copy-html",
         @"comment",
         @"highlight",
@@ -394,6 +400,7 @@
         @"code",
         @"link",
         @"image",
+        @"table",
         @"copy-html",
         @"comment",
         @"highlight",


### PR DESCRIPTION
## Summary
- add a Table toolbar item that inserts a basic Markdown table template
- keep the cursor in the first body cell after insertion
- update toolbar identifier tests for the new item

## Tests
- xcodebuild test -workspace "MacDown 3000.xcworkspace" -scheme MacDown -only-testing:MacDownTests/MPToolbarControllerTests -destination 'platform=macOS'\n\nRelated to #278