### PR TITLE
Add editor invisible character toggle

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -76,7 +76,7 @@ NS_INLINE NSSet *MPEditorPreferencesToObserve()
             @"editorHorizontalInset", @"editorVerticalInset",
             @"editorWidthLimited", @"editorMaximumWidth", @"editorLineSpacing",
             @"editorOnRight", @"editorStyleName", @"editorShowWordCount",
-            @"editorScrollsPastEnd",
+            @"editorScrollsPastEnd", @"editorShowsInvisibleCharacters",
             @"htmlMathJax", @"htmlMathJaxInlineDollar", nil
         ];
     });
@@ -898,6 +898,13 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         {
             return NO;
         }
+    }
+    else if (action == @selector(toggleInvisibleCharacters:))
+    {
+        NSMenuItem *it = ((NSMenuItem *)item);
+        it.state = self.preferences.editorShowsInvisibleCharacters
+            ? NSControlStateValueOn : NSControlStateValueOff;
+        return self.editor != nil;
     }
     return result;
 }
@@ -1995,6 +2002,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     [self toggleSplitterCollapsingEditorPane:YES];
 }
 
+- (IBAction)toggleInvisibleCharacters:(id)sender
+{
+    self.preferences.editorShowsInvisibleCharacters =
+        !self.preferences.editorShowsInvisibleCharacters;
+}
+
 - (IBAction)render:(id)sender
 {
     [self.renderer parseAndRenderLater];
@@ -2241,6 +2254,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         if (contentRect.size.width < minSize.width)
             contentRect.size.width = minSize.width;
         self.editor.frame = contentRect;
+    }
+
+    if (!changedKey || [changedKey isEqualToString:@"editorShowsInvisibleCharacters"])
+    {
+        self.editor.layoutManager.showsInvisibleCharacters =
+            self.preferences.editorShowsInvisibleCharacters;
     }
 
     if (!changedKey)

--- a/MacDown/Code/Preferences/MPPreferences.h
+++ b/MacDown/Code/Preferences/MPPreferences.h
@@ -55,6 +55,7 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 @property (assign) BOOL editorAutoSave;
 @property (assign) BOOL editorScrollsPastEnd;
 @property (assign) BOOL editorEnsuresNewlineAtEndOfFile;
+@property (assign) BOOL editorShowsInvisibleCharacters;
 @property (assign) NSInteger editorUnorderedListMarkerType;
 
 @property (assign) BOOL previewZoomRelativeToBaseFontSize;

--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -254,6 +254,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
 @dynamic editorAutoSave;
 @dynamic editorScrollsPastEnd;
 @dynamic editorEnsuresNewlineAtEndOfFile;
+@dynamic editorShowsInvisibleCharacters;
 @dynamic editorUnorderedListMarkerType;
 
 @dynamic previewZoomRelativeToBaseFontSize;

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -367,6 +367,12 @@
                                     <binding destination="LEY-zf-22t" name="enabled" keyPath="self.currentDocument.previewVisible" id="5e7-rJ-oX2"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Show Invisible Characters" id="TQb-x5-V3x">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleInvisibleCharacters:" target="-1" id="vf0-M2-rZ7"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="onf-Mq-Pah"/>
                             <menuItem title="Left 1:3 Right" id="VW7-VH-9yl">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/MacDownTests/MPPreferencesTests.m
+++ b/MacDownTests/MPPreferencesTests.m
@@ -152,6 +152,24 @@
     [self.preferences synchronize];
 }
 
+- (void)testInvisibleCharactersToggle
+{
+    BOOL original = self.preferences.editorShowsInvisibleCharacters;
+
+    self.preferences.editorShowsInvisibleCharacters = YES;
+    [self.preferences synchronize];
+    XCTAssertTrue(self.preferences.editorShowsInvisibleCharacters,
+                  @"Invisible characters should be ON");
+
+    self.preferences.editorShowsInvisibleCharacters = NO;
+    [self.preferences synchronize];
+    XCTAssertFalse(self.preferences.editorShowsInvisibleCharacters,
+                   @"Invisible characters should be OFF");
+
+    self.preferences.editorShowsInvisibleCharacters = original;
+    [self.preferences synchronize];
+}
+
 - (void)testExtensionFlags
 {
     // Save originals


### PR DESCRIPTION
## Summary
- add a View menu toggle for showing invisible editor characters
- persist the toggle in editor preferences, defaulting off
- apply the setting through the text layout manager

## Tests
- xcodebuild test -workspace "MacDown 3000.xcworkspace" -scheme MacDown -only-testing:MacDownTests/MPPreferencesTests -destination 'platform=macOS'\n\nRelated to #43