### PR TITLE
Skip file watchers on remote volumes

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -3228,6 +3228,9 @@ to link outside that scope.", \
 
     [self stopFileWatching];
 
+    if (![MPFileWatcher canWatchPath:self.fileURL.path])
+        return;
+
     __weak MPDocument *weakSelf = self;
     self.fileWatcher = [[MPFileWatcher alloc]
         initWithPath:self.fileURL.path

--- a/MacDown/Code/Utility/MPFileWatcher.h
+++ b/MacDown/Code/Utility/MPFileWatcher.h
@@ -16,6 +16,9 @@
 /// YES if currently watching.
 @property (nonatomic, readonly, getter=isWatching) BOOL watching;
 
+/// YES if the path is on a local volume that should receive vnode watchers.
++ (BOOL)canWatchPath:(NSString *)path;
+
 /// Create a watcher for the given path. Calls handler on the main queue
 /// when the file is written to. Calls cancelHandler when the file is
 /// deleted, renamed, or stopWatching is called.

--- a/MacDown/Code/Utility/MPFileWatcher.m
+++ b/MacDown/Code/Utility/MPFileWatcher.m
@@ -16,6 +16,22 @@
 
 @implementation MPFileWatcher
 
++ (BOOL)canWatchPath:(NSString *)path
+{
+    if (!path.length)
+        return NO;
+
+    NSURL *url = [NSURL fileURLWithPath:path];
+    NSNumber *isLocal = nil;
+    if (![url getResourceValue:&isLocal
+                        forKey:NSURLVolumeIsLocalKey error:NULL])
+    {
+        return NO;
+    }
+
+    return isLocal.boolValue;
+}
+
 - (instancetype)initWithPath:(NSString *)path
                      handler:(void (^)(NSString *path))handler
                cancelHandler:(void (^)(NSString *path))cancelHandler
@@ -24,7 +40,7 @@
     if (!self)
         return nil;
 
-    if (!path)
+    if (![MPFileWatcher canWatchPath:path])
         return self;
 
     int fd = open(path.fileSystemRepresentation, O_EVTONLY);

--- a/MacDownTests/MPFileWatcherTests.m
+++ b/MacDownTests/MPFileWatcherTests.m
@@ -75,6 +75,18 @@
     XCTAssertNil(watcher.path);
 }
 
+- (void)testCanWatchLocalPath
+{
+    NSString *path = [self createTestFileWithName:@"local.txt" content:@"hello"];
+
+    XCTAssertTrue([MPFileWatcher canWatchPath:path]);
+}
+
+- (void)testCannotWatchNilPath
+{
+    XCTAssertFalse([MPFileWatcher canWatchPath:nil]);
+}
+
 #pragma mark - Event Handling
 
 - (void)testHandlerCalledOnFileWrite


### PR DESCRIPTION
## Summary
- skip vnode file watching when a path is not on a local volume
- avoid creating document/resource watchers for remote/network files
- cover local and nil watchability checks

## Tests
- xcodebuild test -workspace "MacDown 3000.xcworkspace" -scheme MacDown -only-testing:MacDownTests/MPFileWatcherTests -only-testing:MacDownTests/MPResourceWatcherSetTests -destination 'platform=macOS'

Related to #371