### PR TITLE
Add automatic appearance theme pairs

### DIFF
--- a/MacDown/Code/Application/MPMainController.m
+++ b/MacDown/Code/Application/MPMainController.m
@@ -24,6 +24,9 @@
 
 
 static NSString * const kMPTreatLastSeenStampKey = @"treatLastSeenStamp";
+static NSString * const kMPViewMenuTitle = @"View";
+static NSString * const kMPFollowSystemAppearanceMenuItemTitle =
+    @"Follow System Appearance";
 
 
 NS_INLINE void MPOpenBundledFile(NSString *resource, NSString *extension)
@@ -97,7 +100,7 @@ NS_INLINE void treat()
 }
 
 
-@interface MPMainController ()
+@interface MPMainController () <NSMenuItemValidation>
 @property (readonly) NSWindowController *preferencesWindowController;
 @end
 
@@ -112,6 +115,7 @@ NS_INLINE void treat()
         setEventHandler:self
             andSelector:@selector(openUrlSchemeAppleEvent:withReplyEvent:)
           forEventClass:kInternetEventClass andEventID:kAEGetURL];
+    [self installAppearanceThemeMenuItem];
 }
 
 // Open a file from a browser with url of the form :
@@ -216,6 +220,26 @@ NS_INLINE void treat()
     [[NSWorkspace sharedWorkspace] openURL:url];
 }
 
+- (IBAction)toggleAppearanceThemesFollowSystem:(id)sender
+{
+    MPPreferences *preferences = self.preferences;
+    preferences.appearanceThemesFollowSystem =
+        !preferences.appearanceThemesFollowSystem;
+}
+
+
+#pragma mark - NSMenuItemValidation
+
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem
+{
+    if (menuItem.action == @selector(toggleAppearanceThemesFollowSystem:))
+    {
+        menuItem.state = self.preferences.appearanceThemesFollowSystem ?
+            NSControlStateValueOn : NSControlStateValueOff;
+    }
+    return YES;
+}
+
 
 #pragma mark - Override
 
@@ -305,6 +329,28 @@ NS_INLINE void treat()
                 [manager copyItemAtURL:fileSource toURL:fileTarget error:NULL];
         }
     }
+}
+
+- (void)installAppearanceThemeMenuItem
+{
+    NSMenuItem *viewItem = [NSApp.mainMenu itemWithTitle:kMPViewMenuTitle];
+    NSMenu *viewMenu = viewItem.submenu;
+    if (!viewMenu)
+        return;
+
+    SEL action = @selector(toggleAppearanceThemesFollowSystem:);
+    for (NSMenuItem *item in viewMenu.itemArray)
+    {
+        if (item.action == action)
+            return;
+    }
+
+    [viewMenu addItem:[NSMenuItem separatorItem]];
+    NSMenuItem *item =
+        [[NSMenuItem alloc] initWithTitle:kMPFollowSystemAppearanceMenuItemTitle
+                                   action:action keyEquivalent:@""];
+    item.target = self;
+    [viewMenu addItem:item];
 }
 
 - (void)openPendingFiles

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -37,6 +37,8 @@
 #import <JavaScriptCore/JavaScriptCore.h>
 
 static NSString * const kMPDefaultAutosaveName = @"Untitled";
+static NSString * const kMPAppleInterfaceThemeChangedNotification =
+    @"AppleInterfaceThemeChangedNotification";
 
 
 NS_INLINE NSString *MPEditorPreferenceKeyWithValueKey(NSString *key)
@@ -76,6 +78,8 @@ NS_INLINE NSSet *MPEditorPreferencesToObserve()
             @"editorHorizontalInset", @"editorVerticalInset",
             @"editorWidthLimited", @"editorMaximumWidth", @"editorLineSpacing",
             @"editorOnRight", @"editorStyleName", @"editorShowWordCount",
+            @"appearanceThemesFollowSystem", @"editorLightStyleName",
+            @"editorDarkStyleName",
             @"editorScrollsPastEnd",
             @"htmlMathJax", @"htmlMathJaxInlineDollar", nil
         ];
@@ -535,6 +539,9 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     [center addObserver:self selector:@selector(previewBoundsDidChange:)
                    name:NSViewBoundsDidChangeNotification
                  object:self.preview.enclosingScrollView.contentView];
+    [[NSDistributedNotificationCenter defaultCenter]
+        addObserver:self selector:@selector(applicationAppearanceDidChange:)
+               name:kMPAppleInterfaceThemeChangedNotification object:nil];
 
     self.needsToUnregister = YES;
 
@@ -654,6 +661,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         }
 
         [[NSNotificationCenter defaultCenter] removeObserver:self];
+        [[NSDistributedNotificationCenter defaultCenter] removeObserver:self];
 
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
@@ -1323,7 +1331,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 - (NSString *)rendererStyleName:(MPRenderer *)renderer
 {
-    return self.preferences.htmlStyleName;
+    return self.preferences.effectiveHtmlStyleName;
 }
 
 - (BOOL)rendererDetectsFrontMatter:(MPRenderer *)renderer
@@ -1398,7 +1406,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
     // Check if CSS style or highlighting theme has changed.
     // If either changed, we must do a full reload to update <head> with new CSS links.
-    NSString *newStyleName = self.preferences.htmlStyleName;
+    NSString *newStyleName = self.preferences.effectiveHtmlStyleName;
     NSString *newHighlightingTheme = self.preferences.htmlHighlightingThemeName;
     BOOL stylesChanged = !MPAreNilableStringsEqual(self.currentStyleName, newStyleName) ||
                          !MPAreNilableStringsEqual(self.currentHighlightingThemeName, newHighlightingTheme);
@@ -1689,6 +1697,15 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     [self render:nil];
 }
 
+- (void)applicationAppearanceDidChange:(NSNotification *)notification
+{
+    if (!self.preferences.appearanceThemesFollowSystem)
+        return;
+
+    [self setupEditor:nil];
+    [self.renderer renderIfPreferencesChanged];
+}
+
 - (void)previewBoundsDidChange:(NSNotification *)notification
 {
     // Issue #342: Only trigger reverse sync when the user is explicitly scrolling
@@ -1757,7 +1774,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
     MPExportPanelAccessoryViewController *controller =
         [[MPExportPanelAccessoryViewController alloc] init];
-    controller.stylesIncluded = (BOOL)self.preferences.htmlStyleName;
+    controller.stylesIncluded = (BOOL)self.preferences.effectiveHtmlStyleName;
     controller.highlightingIncluded = self.preferences.htmlSyntaxHighlighting;
     panel.accessoryView = controller.view;
 
@@ -2159,6 +2176,9 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
     if (!changedKey || [changedKey isEqualToString:@"editorBaseFontInfo"]
             || [changedKey isEqualToString:@"editorStyleName"]
+            || [changedKey isEqualToString:@"appearanceThemesFollowSystem"]
+            || [changedKey isEqualToString:@"editorLightStyleName"]
+            || [changedKey isEqualToString:@"editorDarkStyleName"]
             || [changedKey isEqualToString:@"editorLineSpacing"])
     {
         NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
@@ -2192,7 +2212,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         self.highlighter.styles = nil;
         [self.highlighter readClearTextStylesFromTextView];
 
-        NSString *themeName = [self.preferences.editorStyleName copy];
+        NSString *themeName = [self.preferences.effectiveEditorStyleName copy];
         if (themeName.length)
         {
             NSString *path = MPThemePathForName(themeName);
@@ -2200,7 +2220,9 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             [self.highlighter applyStylesFromStylesheet:themeString
                                        withErrorHandler:
                 ^(NSArray *errorMessages) {
-                    self.preferences.editorStyleName = nil;
+                    [self.preferences setEditorStyleName:nil
+                                       forDarkAppearance:
+                        self.preferences.usesDarkSystemAppearance];
                 }];
         }
 

--- a/MacDown/Code/Preferences/MPEditorPreferencesViewController.m
+++ b/MacDown/Code/Preferences/MPEditorPreferencesViewController.m
@@ -76,7 +76,7 @@ NSString * const MPDidRequestEditorSetupNotificationKeyName =
     [self.themeSelect addItemWithTitle:@""];
     [self.themeSelect addItemsWithTitles:itemTitles];
 
-    NSString *title = [self.preferences.editorStyleName copy];
+    NSString *title = [self.preferences.effectiveEditorStyleName copy];
     if (title.length)
         [self.themeSelect selectItemWithTitle:title];
 
@@ -123,10 +123,17 @@ NSString * const MPDidRequestEditorSetupNotificationKeyName =
     NSString *title = sender.selectedItem.title;
 
     // Special case: the first (empty) item. No stylesheets will be used.
-    if (!title.length)
-        self.preferences.editorStyleName = nil;
+    NSString *styleName = title.length ? title : nil;
+    if (self.preferences.appearanceThemesFollowSystem)
+    {
+        [self.preferences setEditorStyleName:styleName
+                           forDarkAppearance:
+            self.preferences.usesDarkSystemAppearance];
+    }
     else
-        self.preferences.editorStyleName = title;
+    {
+        self.preferences.editorStyleName = styleName;
+    }
 }
 
 - (IBAction)invokeStylesheetFunction:(NSSegmentedControl *)sender

--- a/MacDown/Code/Preferences/MPHtmlPreferencesViewController.m
+++ b/MacDown/Code/Preferences/MPHtmlPreferencesViewController.m
@@ -61,10 +61,17 @@ NS_INLINE NSString *MPPrismDefaultThemeName()
     NSString *title = sender.selectedItem.title;
 
     // Special case: the first (empty) item. No stylesheets will be used.
-    if (!title.length)
-        self.preferences.htmlStyleName = nil;
+    NSString *styleName = title.length ? title : nil;
+    if (self.preferences.appearanceThemesFollowSystem)
+    {
+        [self.preferences setHtmlStyleName:styleName
+                         forDarkAppearance:
+            self.preferences.usesDarkSystemAppearance];
+    }
     else
-        self.preferences.htmlStyleName = title;
+    {
+        self.preferences.htmlStyleName = styleName;
+    }
 }
 
 - (IBAction)changeHighlightingTheme:(NSPopUpButton *)sender
@@ -153,7 +160,7 @@ NS_INLINE NSString *MPPrismDefaultThemeName()
     [self.stylesheetSelect addItemWithTitle:@""];
     [self.stylesheetSelect addItemsWithTitles:itemTitles];
 
-    NSString *title = self.preferences.htmlStyleName;
+    NSString *title = self.preferences.effectiveHtmlStyleName;
     if (title.length)
         [self.stylesheetSelect selectItemWithTitle:title];
 

--- a/MacDown/Code/Preferences/MPPreferences.h
+++ b/MacDown/Code/Preferences/MPPreferences.h
@@ -43,6 +43,9 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 @property (assign) BOOL editorSyncScrolling;
 @property (assign) BOOL editorSmartHome;
 @property (assign) NSString *editorStyleName;
+@property (assign) BOOL appearanceThemesFollowSystem;
+@property (assign) NSString *editorLightStyleName;
+@property (assign) NSString *editorDarkStyleName;
 @property (assign) CGFloat editorHorizontalInset;
 @property (assign) CGFloat editorVerticalInset;
 @property (assign) CGFloat editorLineSpacing;
@@ -61,6 +64,8 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 
 @property (assign) NSString *htmlTemplateName;
 @property (assign) NSString *htmlStyleName;
+@property (assign) NSString *htmlLightStyleName;
+@property (assign) NSString *htmlDarkStyleName;
 @property (assign) BOOL htmlDetectFrontMatter;
 @property (assign) BOOL htmlTaskList;
 @property (assign) BOOL htmlHardWrap;
@@ -80,8 +85,17 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 @property (readonly) CGFloat editorBaseFontSize;
 @property (nonatomic, assign) NSFont *editorBaseFont;
 @property (readonly) NSString *editorUnorderedListMarker;
+@property (readonly) NSString *effectiveEditorStyleName;
+@property (readonly) NSString *effectiveHtmlStyleName;
 
 - (instancetype)init;
+- (BOOL)usesDarkSystemAppearance;
+- (NSString *)editorStyleNameForDarkAppearance:(BOOL)darkAppearance;
+- (NSString *)htmlStyleNameForDarkAppearance:(BOOL)darkAppearance;
+- (void)setEditorStyleName:(NSString *)styleName
+         forDarkAppearance:(BOOL)darkAppearance;
+- (void)setHtmlStyleName:(NSString *)styleName
+       forDarkAppearance:(BOOL)darkAppearance;
 
 // Convinience methods.
 @property (nonatomic, assign) NSArray *filesToOpen;

--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -32,7 +32,9 @@ static CGFloat    const kMPDefaultEditorVerticalInset = 30.0;
 static CGFloat    const kMPDefaultEditorLineSpacing = 3.0;
 static BOOL       const kMPDefaultEditorSyncScrolling = YES;
 static NSString * const kMPDefaultEditorThemeName = @"Tomorrow+";
+static NSString * const kMPDefaultEditorDarkThemeName = @"Mou Night+";
 static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
+static NSString * const kMPDefaultHtmlDarkStyleName = @"Github2 (dark)";
 
 
 @implementation MPPreferences
@@ -242,6 +244,9 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
 @dynamic editorSyncScrolling;
 @dynamic editorSmartHome;
 @dynamic editorStyleName;
+@dynamic appearanceThemesFollowSystem;
+@dynamic editorLightStyleName;
+@dynamic editorDarkStyleName;
 @dynamic editorHorizontalInset;
 @dynamic editorVerticalInset;
 @dynamic editorLineSpacing;
@@ -260,6 +265,8 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
 
 @dynamic htmlTemplateName;
 @dynamic htmlStyleName;
+@dynamic htmlLightStyleName;
+@dynamic htmlDarkStyleName;
 @dynamic htmlDetectFrontMatter;
 @dynamic htmlTaskList;
 @dynamic htmlHardWrap;
@@ -316,6 +323,69 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
         default:
             return @"* ";
     }
+}
+
+- (BOOL)usesDarkSystemAppearance
+{
+    NSAppearance *appearance = NSApp.effectiveAppearance;
+    if (!appearance)
+        appearance = [NSAppearance currentAppearance];
+
+    NSString *match = [appearance bestMatchFromAppearancesWithNames:
+        @[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
+    return [match isEqualToString:NSAppearanceNameDarkAqua];
+}
+
+- (NSString *)editorStyleNameForDarkAppearance:(BOOL)darkAppearance
+{
+    if (!self.appearanceThemesFollowSystem)
+        return self.editorStyleName;
+
+    NSString *styleName =
+        darkAppearance ? self.editorDarkStyleName : self.editorLightStyleName;
+    return styleName.length ? styleName : self.editorStyleName;
+}
+
+- (NSString *)htmlStyleNameForDarkAppearance:(BOOL)darkAppearance
+{
+    if (!self.appearanceThemesFollowSystem)
+        return self.htmlStyleName;
+
+    NSString *styleName =
+        darkAppearance ? self.htmlDarkStyleName : self.htmlLightStyleName;
+    return styleName.length ? styleName : self.htmlStyleName;
+}
+
+- (void)setEditorStyleName:(NSString *)styleName
+         forDarkAppearance:(BOOL)darkAppearance
+{
+    if (darkAppearance)
+        self.editorDarkStyleName = styleName;
+    else
+        self.editorLightStyleName = styleName;
+    self.editorStyleName = styleName;
+}
+
+- (void)setHtmlStyleName:(NSString *)styleName
+       forDarkAppearance:(BOOL)darkAppearance
+{
+    if (darkAppearance)
+        self.htmlDarkStyleName = styleName;
+    else
+        self.htmlLightStyleName = styleName;
+    self.htmlStyleName = styleName;
+}
+
+- (NSString *)effectiveEditorStyleName
+{
+    return [self editorStyleNameForDarkAppearance:
+        [self usesDarkSystemAppearance]];
+}
+
+- (NSString *)effectiveHtmlStyleName
+{
+    return [self htmlStyleNameForDarkAppearance:
+        [self usesDarkSystemAppearance]];
 }
 
 - (NSArray *)filesToOpen
@@ -406,7 +476,12 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
     self.editorVerticalInset = kMPDefaultEditorVerticalInset;
     self.editorLineSpacing = kMPDefaultEditorLineSpacing;
     self.editorSyncScrolling = kMPDefaultEditorSyncScrolling;
+    self.appearanceThemesFollowSystem = NO;
+    self.editorLightStyleName = kMPDefaultEditorThemeName;
+    self.editorDarkStyleName = kMPDefaultEditorDarkThemeName;
     self.htmlStyleName = kMPDefaultHtmlStyleName;
+    self.htmlLightStyleName = kMPDefaultHtmlStyleName;
+    self.htmlDarkStyleName = kMPDefaultHtmlDarkStyleName;
     self.htmlDefaultDirectoryUrl = [NSURL fileURLWithPath:NSHomeDirectory()
                                               isDirectory:YES];
 }
@@ -437,6 +512,14 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
         self.extensionStrikethough = YES;
     if (![defaults objectForKey:@"editorAutoSave"])
         self.editorAutoSave = YES;
+    if (![defaults objectForKey:@"editorLightStyleName"])
+        self.editorLightStyleName = self.editorStyleName ?: kMPDefaultEditorThemeName;
+    if (![defaults objectForKey:@"editorDarkStyleName"])
+        self.editorDarkStyleName = kMPDefaultEditorDarkThemeName;
+    if (![defaults objectForKey:@"htmlLightStyleName"])
+        self.htmlLightStyleName = self.htmlStyleName ?: kMPDefaultHtmlStyleName;
+    if (![defaults objectForKey:@"htmlDarkStyleName"])
+        self.htmlDarkStyleName = kMPDefaultHtmlDarkStyleName;
 
     // Apply preference migrations using version-based system.
     [self applyPreferencesMigrations];

--- a/MacDownTests/MPPreferencesTests.m
+++ b/MacDownTests/MPPreferencesTests.m
@@ -12,6 +12,13 @@
 @interface MPPreferencesTests : XCTestCase
 @property MPPreferences *preferences;
 @property NSDictionary *oldFontInfo;
+@property BOOL oldAppearanceThemesFollowSystem;
+@property NSString *oldEditorStyleName;
+@property NSString *oldEditorLightStyleName;
+@property NSString *oldEditorDarkStyleName;
+@property NSString *oldHtmlStyleName;
+@property NSString *oldHtmlLightStyleName;
+@property NSString *oldHtmlDarkStyleName;
 @end
 
 
@@ -22,12 +29,28 @@
     [super setUp];
     self.preferences = [MPPreferences sharedInstance];
     self.oldFontInfo = [self.preferences.editorBaseFontInfo copy];
+    self.oldAppearanceThemesFollowSystem =
+        self.preferences.appearanceThemesFollowSystem;
+    self.oldEditorStyleName = [self.preferences.editorStyleName copy];
+    self.oldEditorLightStyleName = [self.preferences.editorLightStyleName copy];
+    self.oldEditorDarkStyleName = [self.preferences.editorDarkStyleName copy];
+    self.oldHtmlStyleName = [self.preferences.htmlStyleName copy];
+    self.oldHtmlLightStyleName = [self.preferences.htmlLightStyleName copy];
+    self.oldHtmlDarkStyleName = [self.preferences.htmlDarkStyleName copy];
 }
 
 - (void)tearDown
 {
-    // Only restore font info which is what the original test modified
+    // Restore shared singleton state touched by these tests.
     self.preferences.editorBaseFontInfo = self.oldFontInfo;
+    self.preferences.appearanceThemesFollowSystem =
+        self.oldAppearanceThemesFollowSystem;
+    self.preferences.editorStyleName = self.oldEditorStyleName;
+    self.preferences.editorLightStyleName = self.oldEditorLightStyleName;
+    self.preferences.editorDarkStyleName = self.oldEditorDarkStyleName;
+    self.preferences.htmlStyleName = self.oldHtmlStyleName;
+    self.preferences.htmlLightStyleName = self.oldHtmlLightStyleName;
+    self.preferences.htmlDarkStyleName = self.oldHtmlDarkStyleName;
     [self.preferences synchronize];
     [super tearDown];
 }
@@ -213,6 +236,61 @@
     // Restore
     self.preferences.htmlHighlightingThemeName = original;
     [self.preferences synchronize];
+}
+
+- (void)testAppearanceThemePairsUseSingleThemeWhenDisabled
+{
+    self.preferences.appearanceThemesFollowSystem = NO;
+    self.preferences.editorStyleName = @"Tomorrow+";
+    self.preferences.editorLightStyleName = @"Solarized (Light)+";
+    self.preferences.editorDarkStyleName = @"Mou Night+";
+    self.preferences.htmlStyleName = @"GitHub2";
+    self.preferences.htmlLightStyleName = @"Solarized (Light)";
+    self.preferences.htmlDarkStyleName = @"Solarized (Dark)";
+
+    XCTAssertEqualObjects(
+        [self.preferences editorStyleNameForDarkAppearance:YES],
+        @"Tomorrow+");
+    XCTAssertEqualObjects(
+        [self.preferences htmlStyleNameForDarkAppearance:YES],
+        @"GitHub2");
+}
+
+- (void)testAppearanceThemePairsSelectLightAndDarkThemes
+{
+    self.preferences.appearanceThemesFollowSystem = YES;
+    self.preferences.editorStyleName = @"Tomorrow+";
+    self.preferences.editorLightStyleName = @"Solarized (Light)+";
+    self.preferences.editorDarkStyleName = @"Mou Night+";
+    self.preferences.htmlStyleName = @"GitHub2";
+    self.preferences.htmlLightStyleName = @"Solarized (Light)";
+    self.preferences.htmlDarkStyleName = @"Solarized (Dark)";
+
+    XCTAssertEqualObjects(
+        [self.preferences editorStyleNameForDarkAppearance:NO],
+        @"Solarized (Light)+");
+    XCTAssertEqualObjects(
+        [self.preferences editorStyleNameForDarkAppearance:YES],
+        @"Mou Night+");
+    XCTAssertEqualObjects(
+        [self.preferences htmlStyleNameForDarkAppearance:NO],
+        @"Solarized (Light)");
+    XCTAssertEqualObjects(
+        [self.preferences htmlStyleNameForDarkAppearance:YES],
+        @"Solarized (Dark)");
+}
+
+- (void)testAppearanceThemePairSettersUpdateCurrentFallback
+{
+    [self.preferences setEditorStyleName:@"Mou Night+"
+                       forDarkAppearance:YES];
+    [self.preferences setHtmlStyleName:@"Solarized (Dark)"
+                     forDarkAppearance:YES];
+
+    XCTAssertEqualObjects(self.preferences.editorDarkStyleName, @"Mou Night+");
+    XCTAssertEqualObjects(self.preferences.editorStyleName, @"Mou Night+");
+    XCTAssertEqualObjects(self.preferences.htmlDarkStyleName, @"Solarized (Dark)");
+    XCTAssertEqualObjects(self.preferences.htmlStyleName, @"Solarized (Dark)");
 }
 
 


### PR DESCRIPTION
## Summary
- add light/dark editor and rendering stylesheet pairs behind a View menu toggle
- use the effective paired theme for editor highlighting, preview rendering, and exports
- refresh open documents when macOS appearance changes
- cover paired theme fallback and setter behavior in preferences tests

## Tests
- xcodebuild test -workspace "MacDown 3000.xcworkspace" -scheme MacDown -only-testing:MacDownTests/MPPreferencesTests -destination 'platform=macOS'
- xcodebuild test -workspace "MacDown 3000.xcworkspace" -scheme MacDown -only-testing:MacDownTests/MPDocumentStyleUpdateTests -only-testing:MacDownTests/MPNotificationTests -destination 'platform=macOS'

Related to #292