### PR TITLE
Emit slug-based heading IDs for anchor link navigation

### DIFF
--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -423,6 +423,7 @@ NS_INLINE hoedown_renderer *MPCreateHTMLRenderer(MPRenderer *renderer, int tocLe
         flags, tocLevel);
     htmlRenderer->blockcode = hoedown_patch_render_blockcode;
     htmlRenderer->listitem = hoedown_patch_render_listitem;
+    htmlRenderer->header = hoedown_patch_render_header;
 
     hoedown_html_renderer_state_extra *extra =
         hoedown_malloc(sizeof(hoedown_html_renderer_state_extra));

--- a/MacDown/Code/Extension/hoedown_html_patch.c
+++ b/MacDown/Code/Extension/hoedown_html_patch.c
@@ -161,6 +161,85 @@ void hoedown_patch_render_listitem(
 	HOEDOWN_BUFPUTSL(ob, "</li>\n");
 }
 
+// Build a stable text-derived slug from a heading's HTML content.
+// Strips HTML tags, lowercases ASCII, converts spaces to hyphens,
+// drops ASCII punctuation, preserves UTF-8 multi-byte sequences so
+// accented characters survive (e.g. "Introducción" -> "introducción").
+static void slugify(hoedown_buffer *out, const hoedown_buffer *content)
+{
+    if (!content || !content->size)
+        return;
+
+    int in_tag = 0;
+    int last_was_dash = 1;
+
+    for (size_t i = 0; i < content->size; i++)
+    {
+        uint8_t c = content->data[i];
+
+        if (in_tag)
+        {
+            if (c == '>') in_tag = 0;
+            continue;
+        }
+        if (c == '<')
+        {
+            in_tag = 1;
+            continue;
+        }
+
+        if (c >= 0x80)
+        {
+            hoedown_buffer_putc(out, c);
+            last_was_dash = 0;
+            continue;
+        }
+
+        if (c >= 'A' && c <= 'Z')
+            c += 32;
+
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_')
+        {
+            hoedown_buffer_putc(out, c);
+            last_was_dash = 0;
+        }
+        else if (c == ' ' || c == '\t' || c == '-')
+        {
+            if (!last_was_dash)
+            {
+                hoedown_buffer_putc(out, '-');
+                last_was_dash = 1;
+            }
+        }
+    }
+
+    while (out->size > 0 && out->data[out->size - 1] == '-')
+        out->size--;
+}
+
+// rndr_header replacement that always emits a text-derived id, independent
+// of the TOC nesting level. Enables [link](#section-name) navigation.
+void hoedown_patch_render_header(
+    hoedown_buffer *ob, const hoedown_buffer *content, int level,
+    const hoedown_renderer_data *data)
+{
+    (void)data;
+    if (ob->size) hoedown_buffer_putc(ob, '\n');
+
+    hoedown_buffer *slug = hoedown_buffer_new(content ? content->size : 16);
+    slugify(slug, content);
+    if (slug->size == 0)
+        HOEDOWN_BUFPUTSL(slug, "section");
+
+    hoedown_buffer_printf(ob, "<h%d id=\"", level);
+    hoedown_buffer_put(ob, slug->data, slug->size);
+    HOEDOWN_BUFPUTSL(ob, "\">");
+    if (content) hoedown_buffer_put(ob, content->data, content->size);
+    hoedown_buffer_printf(ob, "</h%d>\n", level);
+
+    hoedown_buffer_free(slug);
+}
+
 // Adds a "toc" class to the outmost UL element to support TOC styling.
 void hoedown_patch_render_toc_header(
     hoedown_buffer *ob, const hoedown_buffer *content, int level,
@@ -195,7 +274,15 @@ void hoedown_patch_render_toc_header(
             HOEDOWN_BUFPUTSL(ob,"</li>\n<li>\n");
         }
 
-        hoedown_buffer_printf(ob, "<a href=\"#toc_%d\">", state->toc_data.header_count++);
+        hoedown_buffer *slug = hoedown_buffer_new(content ? content->size : 16);
+        slugify(slug, content);
+        if (slug->size == 0)
+            HOEDOWN_BUFPUTSL(slug, "section");
+        HOEDOWN_BUFPUTSL(ob, "<a href=\"#");
+        hoedown_buffer_put(ob, slug->data, slug->size);
+        HOEDOWN_BUFPUTSL(ob, "\">");
+        hoedown_buffer_free(slug);
+        state->toc_data.header_count++;
         if (content) hoedown_buffer_put(ob, content->data, content->size);
         HOEDOWN_BUFPUTSL(ob, "</a>\n");
     }

--- a/MacDown/Code/Extension/hoedown_html_patch.c
+++ b/MacDown/Code/Extension/hoedown_html_patch.c
@@ -162,9 +162,12 @@ void hoedown_patch_render_listitem(
 }
 
 // Build a stable text-derived slug from a heading's HTML content.
-// Strips HTML tags, lowercases ASCII, converts spaces to hyphens,
-// drops ASCII punctuation, preserves UTF-8 multi-byte sequences so
-// accented characters survive (e.g. "Introducción" -> "introducción").
+// Strips HTML tags and skips HTML entities (&amp; / &lt; / &#39; ...),
+// lowercases ASCII, converts spaces to hyphens, drops ASCII punctuation,
+// preserves UTF-8 multi-byte sequences so accented characters survive
+// (e.g. "Introducción" -> "introducción"). Anchors keep their raw UTF-8
+// bytes (no percent-encoding): browsers match the URL fragment against
+// the id literally, so encoding would break navigation.
 static void slugify(hoedown_buffer *out, const hoedown_buffer *content)
 {
     if (!content || !content->size)
@@ -185,6 +188,13 @@ static void slugify(hoedown_buffer *out, const hoedown_buffer *content)
         if (c == '<')
         {
             in_tag = 1;
+            continue;
+        }
+        if (c == '&')
+        {            // skip an HTML entity like &amp; / &lt; / &#39;
+            while (i + 1 < content->size && content->data[i + 1] != ';')
+                i++;
+            i++;                    // consume the ';'
             continue;
         }
 

--- a/MacDown/Code/Extension/hoedown_html_patch.h
+++ b/MacDown/Code/Extension/hoedown_html_patch.h
@@ -38,6 +38,10 @@ void hoedown_patch_render_listitem(
     hoedown_buffer *ob, const hoedown_buffer *text, hoedown_list_flags flags,
     const hoedown_renderer_data *data);
 
+void hoedown_patch_render_header(
+    hoedown_buffer *ob, const hoedown_buffer *content, int level,
+    const hoedown_renderer_data *data);
+
 void hoedown_patch_render_toc_header(
      hoedown_buffer *ob, const hoedown_buffer *content, int level,
      const hoedown_renderer_data *data);

--- a/MacDownCore/MPQuickLookRenderer.m
+++ b/MacDownCore/MPQuickLookRenderer.m
@@ -183,6 +183,12 @@ NS_INLINE NSString *MPQuickLookContentSecurityPolicy(void)
 // Build a stable text-derived slug from a heading's HTML content.
 // Mirrors slugify() in MacDown/Code/Extension/hoedown_html_patch.c so the
 // preview and Quick Look render identical heading ids.
+// Strips HTML tags and skips HTML entities (&amp; / &lt; / &#39; ...),
+// lowercases ASCII, converts spaces to hyphens, drops ASCII punctuation,
+// preserves UTF-8 multi-byte sequences so accented characters survive
+// (e.g. "Introducción" -> "introducción"). Anchors keep their raw UTF-8
+// bytes (no percent-encoding): browsers match the URL fragment against
+// the id literally, so encoding would break navigation.
 static void mp_quicklook_slugify(hoedown_buffer *out, const hoedown_buffer *content)
 {
     if (!content || !content->size)
@@ -203,6 +209,13 @@ static void mp_quicklook_slugify(hoedown_buffer *out, const hoedown_buffer *cont
         if (c == '<')
         {
             in_tag = 1;
+            continue;
+        }
+        if (c == '&')
+        {            // skip an HTML entity like &amp; / &lt; / &#39;
+            while (i + 1 < content->size && content->data[i + 1] != ';')
+                i++;
+            i++;                    // consume the ';'
             continue;
         }
 

--- a/MacDownCore/MPQuickLookRenderer.m
+++ b/MacDownCore/MPQuickLookRenderer.m
@@ -180,6 +180,84 @@ NS_INLINE NSString *MPQuickLookContentSecurityPolicy(void)
 
 #pragma mark - Hoedown Renderer Callbacks
 
+// Build a stable text-derived slug from a heading's HTML content.
+// Mirrors slugify() in MacDown/Code/Extension/hoedown_html_patch.c so the
+// preview and Quick Look render identical heading ids.
+static void mp_quicklook_slugify(hoedown_buffer *out, const hoedown_buffer *content)
+{
+    if (!content || !content->size)
+        return;
+
+    int in_tag = 0;
+    int last_was_dash = 1;
+
+    for (size_t i = 0; i < content->size; i++)
+    {
+        uint8_t c = content->data[i];
+
+        if (in_tag)
+        {
+            if (c == '>') in_tag = 0;
+            continue;
+        }
+        if (c == '<')
+        {
+            in_tag = 1;
+            continue;
+        }
+
+        if (c >= 0x80)
+        {
+            hoedown_buffer_putc(out, c);
+            last_was_dash = 0;
+            continue;
+        }
+
+        if (c >= 'A' && c <= 'Z')
+            c += 32;
+
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_')
+        {
+            hoedown_buffer_putc(out, c);
+            last_was_dash = 0;
+        }
+        else if (c == ' ' || c == '\t' || c == '-')
+        {
+            if (!last_was_dash)
+            {
+                hoedown_buffer_putc(out, '-');
+                last_was_dash = 1;
+            }
+        }
+    }
+
+    while (out->size > 0 && out->data[out->size - 1] == '-')
+        out->size--;
+}
+
+// Emit headings with text-derived id attributes so anchor links work in
+// Quick Look previews, matching the main MacDown preview behavior.
+static void mp_quicklook_render_header(
+    hoedown_buffer *ob, const hoedown_buffer *content, int level,
+    const hoedown_renderer_data *data)
+{
+    (void)data;
+    if (ob->size) hoedown_buffer_putc(ob, '\n');
+
+    hoedown_buffer *slug = hoedown_buffer_new(content ? content->size : 16);
+    mp_quicklook_slugify(slug, content);
+    if (slug->size == 0)
+        HOEDOWN_BUFPUTSL(slug, "section");
+
+    hoedown_buffer_printf(ob, "<h%d id=\"", level);
+    hoedown_buffer_put(ob, slug->data, slug->size);
+    HOEDOWN_BUFPUTSL(ob, "\">");
+    if (content) hoedown_buffer_put(ob, content->data, content->size);
+    hoedown_buffer_printf(ob, "</h%d>\n", level);
+
+    hoedown_buffer_free(slug);
+}
+
 /**
  * Custom blockcode renderer that adds Prism language classes without scripts.
  */
@@ -310,6 +388,7 @@ static void mp_quicklook_render_blockcode(
 
     // Preserve Prism language classes, but Quick Look never executes Prism JS.
     renderer->blockcode = mp_quicklook_render_blockcode;
+    renderer->header = mp_quicklook_render_header;
 
     // Create document
     hoedown_document *document = hoedown_document_new(

--- a/MacDownTests/Fixtures/autolinks.html
+++ b/MacDownTests/Fixtures/autolinks.html
@@ -1,6 +1,6 @@
-<h1>Autolink Tests</h1>
+<h1 id="autolink-tests">Autolink Tests</h1>
 
-<h2>URL Autolinks</h2>
+<h2 id="url-autolinks">URL Autolinks</h2>
 
 <p><a href="https://example.com">https://example.com</a></p>
 
@@ -10,7 +10,7 @@
 
 <p><a href="https://example.com/path?query=param&amp;other=value">https://example.com/path?query=param&amp;other=value</a></p>
 
-<h2>Email Autolinks</h2>
+<h2 id="email-autolinks">Email Autolinks</h2>
 
 <p><a href="mailto:user@example.com">user@example.com</a></p>
 
@@ -18,17 +18,17 @@
 
 <p><a href="mailto:contact+tag@example.com">contact+tag@example.com</a></p>
 
-<h2>Plain URLs (may or may not auto-link depending on parser)</h2>
+<h2 id="plain-urls-may-or-may-not-auto-link-depending-on-parser">Plain URLs (may or may not auto-link depending on parser)</h2>
 
 <p>Visit <a href="https://example.com">https://example.com</a> for more.</p>
 
 <p>Check out <a href="http://www.example.org">http://www.example.org</a> too.</p>
 
-<h2>Mixed Content</h2>
+<h2 id="mixed-content">Mixed Content</h2>
 
 <p>Email me at <a href="mailto:user@example.com">user@example.com</a> or visit <a href="https://example.com">https://example.com</a>.</p>
 
-<h2>Edge Cases</h2>
+<h2 id="edge-cases">Edge Cases</h2>
 
 <p>Multiple autolinks: <a href="https://first.com">https://first.com</a> and <a href="https://second.com">https://second.com</a>.</p>
 
@@ -36,7 +36,7 @@
 
 <p>End with autolink: <a href="https://end.com">https://end.com</a></p>
 
-<h2>In Lists</h2>
+<h2 id="in-lists">In Lists</h2>
 
 <ul>
 <li><a href="https://example.com">https://example.com</a></li>

--- a/MacDownTests/Fixtures/basic.html
+++ b/MacDownTests/Fixtures/basic.html
@@ -1,24 +1,24 @@
-<h1>Heading 1</h1>
+<h1 id="heading-1">Heading 1</h1>
 
 <p>This is a paragraph under heading 1. It contains some text to test basic paragraph rendering.</p>
 
-<h2>Heading 2</h2>
+<h2 id="heading-2">Heading 2</h2>
 
 <p>Another paragraph here. This one is under heading 2.</p>
 
-<h3>Heading 3</h3>
+<h3 id="heading-3">Heading 3</h3>
 
 <p>A third paragraph for heading 3.</p>
 
-<h4>Heading 4</h4>
+<h4 id="heading-4">Heading 4</h4>
 
 <p>Fourth level heading with text.</p>
 
-<h5>Heading 5</h5>
+<h5 id="heading-5">Heading 5</h5>
 
 <p>Fifth level heading.</p>
 
-<h6>Heading 6</h6>
+<h6 id="heading-6">Heading 6</h6>
 
 <p>The deepest heading level in Markdown.</p>
 

--- a/MacDownTests/Fixtures/blockquotes.html
+++ b/MacDownTests/Fixtures/blockquotes.html
@@ -1,19 +1,19 @@
-<h1>Blockquote Tests</h1>
+<h1 id="blockquote-tests">Blockquote Tests</h1>
 
-<h2>Basic Blockquote</h2>
+<h2 id="basic-blockquote">Basic Blockquote</h2>
 
 <blockquote>
 <p>This is a blockquote.
 It can span multiple lines.</p>
 </blockquote>
 
-<h2>Single Line Blockquote</h2>
+<h2 id="single-line-blockquote">Single Line Blockquote</h2>
 
 <blockquote>
 <p>Single line blockquote.</p>
 </blockquote>
 
-<h2>Nested Blockquotes</h2>
+<h2 id="nested-blockquotes">Nested Blockquotes</h2>
 
 <blockquote>
 <p>First level quote</p>
@@ -27,7 +27,7 @@ It can span multiple lines.</p>
 </blockquote>
 </blockquote>
 
-<h2>Blockquote with Multiple Paragraphs</h2>
+<h2 id="blockquote-with-multiple-paragraphs">Blockquote with Multiple Paragraphs</h2>
 
 <blockquote>
 <p>First paragraph in blockquote.</p>
@@ -35,7 +35,7 @@ It can span multiple lines.</p>
 <p>Second paragraph in blockquote.</p>
 </blockquote>
 
-<h2>Blockquote with Formatting</h2>
+<h2 id="blockquote-with-formatting">Blockquote with Formatting</h2>
 
 <blockquote>
 <p>This has <strong>bold text</strong>.</p>
@@ -45,7 +45,7 @@ It can span multiple lines.</p>
 <p>This has <code>code</code>.</p>
 </blockquote>
 
-<h2>Blockquote with Lists</h2>
+<h2 id="blockquote-with-lists">Blockquote with Lists</h2>
 
 <blockquote>
 <ul>
@@ -61,22 +61,22 @@ It can span multiple lines.</p>
 </ol>
 </blockquote>
 
-<h2>Blockquote with Headers</h2>
+<h2 id="blockquote-with-headers">Blockquote with Headers</h2>
 
 <blockquote>
-<h2>Header in Blockquote</h2>
+<h2 id="header-in-blockquote">Header in Blockquote</h2>
 
 <p>Some text under the header.</p>
 </blockquote>
 
-<h2>Lazy Blockquotes</h2>
+<h2 id="lazy-blockquotes">Lazy Blockquotes</h2>
 
 <blockquote>
 <p>This is lazy continuation
 without the &gt; character.</p>
 </blockquote>
 
-<h2>Complex Nesting</h2>
+<h2 id="complex-nesting">Complex Nesting</h2>
 
 <blockquote>
 <p>Top level</p>

--- a/MacDownTests/Fixtures/code-fenced.html
+++ b/MacDownTests/Fixtures/code-fenced.html
@@ -1,18 +1,18 @@
-<h1>Fenced Code Block Tests</h1>
+<h1 id="fenced-code-block-tests">Fenced Code Block Tests</h1>
 
-<h2>Basic Fenced Block</h2>
+<h2 id="basic-fenced-block">Basic Fenced Block</h2>
 
 <div><pre><code class="language-none">This is a basic code block.
 No language specified.
 Multiple lines.</code></pre></div>
 
-<h2>Code Block with Content</h2>
+<h2 id="code-block-with-content">Code Block with Content</h2>
 
 <div><pre><code class="language-none">function example() {
     return true;
 }</code></pre></div>
 
-<h2>Multiple Blocks</h2>
+<h2 id="multiple-blocks">Multiple Blocks</h2>
 
 <p>First block:</p>
 
@@ -22,11 +22,11 @@ Multiple lines.</code></pre></div>
 
 <div><pre><code class="language-none">Block two</code></pre></div>
 
-<h2>Empty Block</h2>
+<h2 id="empty-block">Empty Block</h2>
 
 <div><pre><code class="language-none"></code></pre></div>
 
-<h2>Block with Special Characters</h2>
+<h2 id="block-with-special-characters">Block with Special Characters</h2>
 
 <div><pre><code class="language-none">&lt;html&gt;
 **Not bold**

--- a/MacDownTests/Fixtures/code-inline.html
+++ b/MacDownTests/Fixtures/code-inline.html
@@ -1,16 +1,16 @@
-<h1>Inline Code Tests</h1>
+<h1 id="inline-code-tests">Inline Code Tests</h1>
 
-<h2>Basic Inline Code</h2>
+<h2 id="basic-inline-code">Basic Inline Code</h2>
 
 <p>Use the <code>printf()</code> function to print output.</p>
 
 <p>The variable <code>userName</code> stores the user&#39;s name.</p>
 
-<h2>Multiple Code Spans</h2>
+<h2 id="multiple-code-spans">Multiple Code Spans</h2>
 
 <p>Use <code>git add</code> and then <code>git commit</code> to save changes.</p>
 
-<h2>Code with Special Characters</h2>
+<h2 id="code-with-special-characters">Code with Special Characters</h2>
 
 <p>This is <code>code with spaces</code>.</p>
 
@@ -20,7 +20,7 @@
 
 <p>Use <code>**not bold**</code> inside code.</p>
 
-<h2>Edge Cases</h2>
+<h2 id="edge-cases">Edge Cases</h2>
 
 <p><code>Code at start</code> of line.</p>
 

--- a/MacDownTests/Fixtures/code-languages.html
+++ b/MacDownTests/Fixtures/code-languages.html
@@ -1,49 +1,49 @@
-<h1>Code Blocks with Language Tags</h1>
+<h1 id="code-blocks-with-language-tags">Code Blocks with Language Tags</h1>
 
-<h2>JavaScript</h2>
+<h2 id="javascript">JavaScript</h2>
 
 <div><pre><code class="language-javascript">function greet(name) {
     console.log(&quot;Hello, &quot; + name);
 }</code></pre></div>
 
-<h2>Python</h2>
+<h2 id="python">Python</h2>
 
 <div><pre><code class="language-python">def greet(name):
     print(f&quot;Hello, {name}&quot;)</code></pre></div>
 
-<h2>Ruby</h2>
+<h2 id="ruby">Ruby</h2>
 
 <div><pre><code class="language-ruby">def greet(name)
   puts &quot;Hello, #{name}&quot;
 end</code></pre></div>
 
-<h2>HTML</h2>
+<h2 id="html">HTML</h2>
 
 <div><pre><code class="language-markup">&lt;div class=&quot;container&quot;&gt;
     &lt;h1&gt;Hello World&lt;/h1&gt;
 &lt;/div&gt;</code></pre></div>
 
-<h2>CSS</h2>
+<h2 id="css">CSS</h2>
 
 <div><pre><code class="language-css">.container {
     max-width: 1200px;
     margin: 0 auto;
 }</code></pre></div>
 
-<h2>Objective-C</h2>
+<h2 id="objective-c">Objective-C</h2>
 
 <div><pre><code class="language-objectivec">
 - (void)greetWithName:(NSString *)name {
     NSLog(@&quot;Hello, %@&quot;, name);
 }</code></pre></div>
 
-<h2>Swift</h2>
+<h2 id="swift">Swift</h2>
 
 <div><pre><code class="language-swift">func greet(name: String) {
     print(&quot;Hello, \(name)&quot;)
 }</code></pre></div>
 
-<h2>Bash</h2>
+<h2 id="bash">Bash</h2>
 
 <div><pre><code class="language-bash">#!/bin/bash
 echo &quot;Hello, World&quot;</code></pre></div>

--- a/MacDownTests/Fixtures/edge-cases.html
+++ b/MacDownTests/Fixtures/edge-cases.html
@@ -1,12 +1,12 @@
-<h1>Edge Cases and Special Characters</h1>
+<h1 id="edge-cases-and-special-characters">Edge Cases and Special Characters</h1>
 
-<h2>Empty Lines</h2>
+<h2 id="empty-lines">Empty Lines</h2>
 
 <p>This paragraph has an empty line after it.</p>
 
 <p>This paragraph has two empty lines before it.</p>
 
-<h2>Special Characters</h2>
+<h2 id="special-characters">Special Characters</h2>
 
 <p>Ampersand: &amp; &amp;</p>
 
@@ -16,7 +16,7 @@
 
 <p>Quotes: &quot;double&quot; and &#39;single&#39;</p>
 
-<h2>Escaping</h2>
+<h2 id="escaping">Escaping</h2>
 
 <p>*Not italic*</p>
 
@@ -28,7 +28,7 @@
 
 <p>~~Not strikethrough~~</p>
 
-<h2>HTML Entities</h2>
+<h2 id="html-entities">HTML Entities</h2>
 
 <p>&copy; &reg; &trade;</p>
 
@@ -36,7 +36,7 @@
 
 <p>&nbsp; (non-breaking space)</p>
 
-<h2>Unicode</h2>
+<h2 id="unicode">Unicode</h2>
 
 <p>Emoji: 😀 🚀 ⭐</p>
 
@@ -46,15 +46,15 @@
 
 <p>Arrows: → ← ↑ ↓</p>
 
-<h2>Edge Case Headers</h2>
+<h2 id="edge-case-headers">Edge Case Headers</h2>
 
-<h1>No space after hash</h1>
+<h1 id="no-space-after-hash">No space after hash</h1>
 
-<h1>Trailing hash</h1>
+<h1 id="trailing-hash">Trailing hash</h1>
 
-<h2>Multiple##Hashes</h2>
+<h2 id="multiplehashes">Multiple##Hashes</h2>
 
-<h2>Consecutive Formatting</h2>
+<h2 id="consecutive-formatting">Consecutive Formatting</h2>
 
 <p><strong>Bold</strong><strong>More bold</strong></p>
 
@@ -62,7 +62,7 @@
 
 <p><strong><em>All together</em></strong></p>
 
-<h2>Malformed Markdown</h2>
+<h2 id="malformed-markdown">Malformed Markdown</h2>
 
 <p>[Link without URL]</p>
 
@@ -74,7 +74,7 @@
 
 <p>~~Unclosed strikethrough</p>
 
-<h2>Line Breaks</h2>
+<h2 id="line-breaks">Line Breaks</h2>
 
 <p>Line with two spaces at end
 Should create line break.</p>
@@ -82,19 +82,19 @@ Should create line break.</p>
 <p>Line without spaces
 Should not break.</p>
 
-<h2>Tabs vs Spaces</h2>
+<h2 id="tabs-vs-spaces">Tabs vs Spaces</h2>
 
 <div><pre><code class="language-none">Tab-indented text
 
 Four-space indented text</code></pre></div>
 
-<h2>Mixed Whitespace</h2>
+<h2 id="mixed-whitespace">Mixed Whitespace</h2>
 
 <p>Text with    multiple    spaces.</p>
 
 <p>Text    with    tabs.</p>
 
-<h2>URL Edge Cases</h2>
+<h2 id="url-edge-cases">URL Edge Cases</h2>
 
 <p>https://example.com/path?query=1&amp;other=2</p>
 
@@ -102,7 +102,7 @@ Four-space indented text</code></pre></div>
 
 <p>ftp://files.example.com</p>
 
-<h2>Numbers and Punctuation</h2>
+<h2 id="numbers-and-punctuation">Numbers and Punctuation</h2>
 
 <ol>
 <li>Not a list (no space).</li>
@@ -110,9 +110,9 @@ Four-space indented text</code></pre></div>
 
 <p>100.5 decimal number</p>
 
-<h1>1 hashtag number</h1>
+<h1 id="1-hashtag-number">1 hashtag number</h1>
 
-<h2>Backslashes</h2>
+<h2 id="backslashes">Backslashes</h2>
 
 <p>Backslash: \</p>
 
@@ -120,7 +120,7 @@ Four-space indented text</code></pre></div>
 
 <p>Network: \\server\share</p>
 
-<h2>Parentheses and Brackets</h2>
+<h2 id="parentheses-and-brackets">Parentheses and Brackets</h2>
 
 <p>(Text in parentheses)</p>
 
@@ -130,7 +130,7 @@ Four-space indented text</code></pre></div>
 
 <p><Text in angle brackets></p>
 
-<h2>Consecutive Punctuation</h2>
+<h2 id="consecutive-punctuation">Consecutive Punctuation</h2>
 
 <p>Multiple periods...</p>
 
@@ -140,7 +140,7 @@ Four-space indented text</code></pre></div>
 
 <p>Mixed?!?!</p>
 
-<h2>Empty Elements</h2>
+<h2 id="empty-elements">Empty Elements</h2>
 
 <p>[]</p>
 

--- a/MacDownTests/Fixtures/emphasis.html
+++ b/MacDownTests/Fixtures/emphasis.html
@@ -1,18 +1,18 @@
-<h1>Emphasis Tests</h1>
+<h1 id="emphasis-tests">Emphasis Tests</h1>
 
-<h2>Italic</h2>
+<h2 id="italic">Italic</h2>
 
 <p>This is <em>italic text with asterisks</em>.</p>
 
 <p>This is <em>italic text with underscores</em>.</p>
 
-<h2>Bold</h2>
+<h2 id="bold">Bold</h2>
 
 <p>This is <strong>bold text with asterisks</strong>.</p>
 
 <p>This is <strong>bold text with underscores</strong>.</p>
 
-<h2>Combined Emphasis</h2>
+<h2 id="combined-emphasis">Combined Emphasis</h2>
 
 <p>This is <strong><em>bold and italic with asterisks</em></strong>.</p>
 
@@ -22,7 +22,7 @@
 
 <p>This is *italic with <strong>bold inside</strong>*.</p>
 
-<h2>Edge Cases</h2>
+<h2 id="edge-cases">Edge Cases</h2>
 
 <p>Not<em>actually</em>italic because no spaces.</p>
 

--- a/MacDownTests/Fixtures/horizontal-rules.html
+++ b/MacDownTests/Fixtures/horizontal-rules.html
@@ -1,14 +1,6 @@
-<h1>Horizontal Rule Tests</h1>
+<h1 id="horizontal-rule-tests">Horizontal Rule Tests</h1>
 
-<h2>Three Hyphens</h2>
-
-<p>Text before rule.</p>
-
-<hr>
-
-<p>Text after rule.</p>
-
-<h2>Three Asterisks</h2>
+<h2 id="three-hyphens">Three Hyphens</h2>
 
 <p>Text before rule.</p>
 
@@ -16,7 +8,7 @@
 
 <p>Text after rule.</p>
 
-<h2>Three Underscores</h2>
+<h2 id="three-asterisks">Three Asterisks</h2>
 
 <p>Text before rule.</p>
 
@@ -24,7 +16,15 @@
 
 <p>Text after rule.</p>
 
-<h2>More Than Three</h2>
+<h2 id="three-underscores">Three Underscores</h2>
+
+<p>Text before rule.</p>
+
+<hr>
+
+<p>Text after rule.</p>
+
+<h2 id="more-than-three">More Than Three</h2>
 
 <hr>
 
@@ -32,7 +32,7 @@
 
 <hr>
 
-<h2>With Spaces</h2>
+<h2 id="with-spaces">With Spaces</h2>
 
 <hr>
 
@@ -40,7 +40,7 @@
 
 <hr>
 
-<h2>Multiple Rules</h2>
+<h2 id="multiple-rules">Multiple Rules</h2>
 
 <p>First section.</p>
 
@@ -56,9 +56,9 @@
 
 <p>Fourth section.</p>
 
-<h2>Rules in Context</h2>
+<h2 id="rules-in-context">Rules in Context</h2>
 
-<h1>Heading</h1>
+<h1 id="heading">Heading</h1>
 
 <p>Some text here.</p>
 

--- a/MacDownTests/Fixtures/images.html
+++ b/MacDownTests/Fixtures/images.html
@@ -1,6 +1,6 @@
-<h1>Image Tests</h1>
+<h1 id="image-tests">Image Tests</h1>
 
-<h2>Inline Images</h2>
+<h2 id="inline-images">Inline Images</h2>
 
 <p><img src="https://example.com/image.png" alt="Alt text"></p>
 
@@ -8,17 +8,17 @@
 
 <p><img src="https://example.com/no-alt.png" alt=""></p>
 
-<h2>Reference Images</h2>
+<h2 id="reference-images">Reference Images</h2>
 
 <p><img src="https://example.com/ref-image.png" alt="Reference image"></p>
 
 <p><img src="https://example.com/ref-image2.png" alt="Another reference" title="Reference Image Title"></p>
 
-<h2>Images in Links</h2>
+<h2 id="images-in-links">Images in Links</h2>
 
 <p><a href="https://example.com/link"><img src="https://example.com/image.png" alt="Linked image"></a></p>
 
-<h2>Edge Cases</h2>
+<h2 id="edge-cases">Edge Cases</h2>
 
 <p><img src="https://example.com/image.png" alt="Alt text with **bold**"></p>
 

--- a/MacDownTests/Fixtures/links.html
+++ b/MacDownTests/Fixtures/links.html
@@ -1,6 +1,6 @@
-<h1>Link Tests</h1>
+<h1 id="link-tests">Link Tests</h1>
 
-<h2>Inline Links</h2>
+<h2 id="inline-links">Inline Links</h2>
 
 <p>This is an <a href="https://example.com">inline link</a>.</p>
 
@@ -8,7 +8,7 @@
 
 <p>This is a <a href="/path/to/page">link to a path</a>.</p>
 
-<h2>Reference Links</h2>
+<h2 id="reference-links">Reference Links</h2>
 
 <p>This is a <a href="https://example.com">reference link</a>.</p>
 
@@ -16,7 +16,7 @@
 
 <p>This uses <a href="https://implicit.example.com">implicit reference</a>.</p>
 
-<h2>Edge Cases</h2>
+<h2 id="edge-cases">Edge Cases</h2>
 
 <p><a href="https://start.com">Link at start</a> of line.</p>
 

--- a/MacDownTests/Fixtures/lists-nested.html
+++ b/MacDownTests/Fixtures/lists-nested.html
@@ -1,6 +1,6 @@
-<h1>Nested List Tests</h1>
+<h1 id="nested-list-tests">Nested List Tests</h1>
 
-<h2>Nested Unordered Lists</h2>
+<h2 id="nested-unordered-lists">Nested Unordered Lists</h2>
 
 <ul>
 <li>First level
@@ -13,7 +13,7 @@
 <li>Back to first level</li>
 </ul>
 
-<h2>Nested Ordered Lists</h2>
+<h2 id="nested-ordered-lists">Nested Ordered Lists</h2>
 
 <ol>
 <li>First level
@@ -30,7 +30,7 @@
 <li>Back to first level</li>
 </ol>
 
-<h2>Mixed Nested Lists</h2>
+<h2 id="mixed-nested-lists">Mixed Nested Lists</h2>
 
 <ul>
 <li>Unordered first
@@ -48,7 +48,7 @@
 <li>Unordered first again</li>
 </ul>
 
-<h2>Nested with Content</h2>
+<h2 id="nested-with-content">Nested with Content</h2>
 
 <ol>
 <li><p>First item</p>
@@ -66,7 +66,7 @@
 <li><p>Second item</p></li>
 </ol>
 
-<h2>Deep Nesting</h2>
+<h2 id="deep-nesting">Deep Nesting</h2>
 
 <ul>
 <li>Level 1

--- a/MacDownTests/Fixtures/lists-ordered.html
+++ b/MacDownTests/Fixtures/lists-ordered.html
@@ -1,6 +1,6 @@
-<h1>Ordered List Tests</h1>
+<h1 id="ordered-list-tests">Ordered List Tests</h1>
 
-<h2>Basic Ordered List</h2>
+<h2 id="basic-ordered-list">Basic Ordered List</h2>
 
 <ol>
 <li>First item</li>
@@ -8,7 +8,7 @@
 <li>Third item</li>
 </ol>
 
-<h2>List Starting with Different Number</h2>
+<h2 id="list-starting-with-different-number">List Starting with Different Number</h2>
 
 <ol>
 <li>Fifth item</li>
@@ -16,7 +16,7 @@
 <li>Seventh item</li>
 </ol>
 
-<h2>List with All Ones</h2>
+<h2 id="list-with-all-ones">List with All Ones</h2>
 
 <ol>
 <li>First item</li>
@@ -24,7 +24,7 @@
 <li>Third item (still numbered 3)</li>
 </ol>
 
-<h2>List with Paragraphs</h2>
+<h2 id="list-with-paragraphs">List with Paragraphs</h2>
 
 <ol>
 <li><p>First item with text</p></li>
@@ -32,7 +32,7 @@
 <li><p>Third item</p></li>
 </ol>
 
-<h2>List with Inline Formatting</h2>
+<h2 id="list-with-inline-formatting">List with Inline Formatting</h2>
 
 <ol>
 <li><strong>Bold</strong> item</li>
@@ -41,7 +41,7 @@
 <li><a href="https://example.com">Link</a> item</li>
 </ol>
 
-<h2>Tight vs Loose Lists</h2>
+<h2 id="tight-vs-loose-lists">Tight vs Loose Lists</h2>
 
 <p>Tight list:</p>
 

--- a/MacDownTests/Fixtures/lists-unordered.html
+++ b/MacDownTests/Fixtures/lists-unordered.html
@@ -1,14 +1,6 @@
-<h1>Unordered List Tests</h1>
+<h1 id="unordered-list-tests">Unordered List Tests</h1>
 
-<h2>Basic List with Asterisks</h2>
-
-<ul>
-<li>First item</li>
-<li>Second item</li>
-<li>Third item</li>
-</ul>
-
-<h2>Basic List with Hyphens</h2>
+<h2 id="basic-list-with-asterisks">Basic List with Asterisks</h2>
 
 <ul>
 <li>First item</li>
@@ -16,7 +8,7 @@
 <li>Third item</li>
 </ul>
 
-<h2>Basic List with Plus</h2>
+<h2 id="basic-list-with-hyphens">Basic List with Hyphens</h2>
 
 <ul>
 <li>First item</li>
@@ -24,7 +16,15 @@
 <li>Third item</li>
 </ul>
 
-<h2>List with Paragraphs</h2>
+<h2 id="basic-list-with-plus">Basic List with Plus</h2>
+
+<ul>
+<li>First item</li>
+<li>Second item</li>
+<li>Third item</li>
+</ul>
+
+<h2 id="list-with-paragraphs">List with Paragraphs</h2>
 
 <ul>
 <li><p>First item with text</p></li>
@@ -32,7 +32,7 @@
 <li><p>Third item</p></li>
 </ul>
 
-<h2>List with Inline Formatting</h2>
+<h2 id="list-with-inline-formatting">List with Inline Formatting</h2>
 
 <ul>
 <li><strong>Bold</strong> item</li>
@@ -41,7 +41,7 @@
 <li><a href="https://example.com">Link</a> item</li>
 </ul>
 
-<h2>Tight vs Loose Lists</h2>
+<h2 id="tight-vs-loose-lists">Tight vs Loose Lists</h2>
 
 <p>Tight list:</p>
 

--- a/MacDownTests/Fixtures/mathjax-in-code.html
+++ b/MacDownTests/Fixtures/mathjax-in-code.html
@@ -1,19 +1,19 @@
-<h1>MathJax in Code Blocks</h1>
+<h1 id="mathjax-in-code-blocks">MathJax in Code Blocks</h1>
 
-<h2>Regular Math</h2>
+<h2 id="regular-math">Regular Math</h2>
 
 <p>This math should be processed: ( x^2 + y^2 = z^2 )</p>
 
-<h2>Math in Code Block</h2>
+<h2 id="math-in-code-block">Math in Code Block</h2>
 
 <div><pre><code class="language-none">This math should NOT be processed: \( x^2 + y^2 = z^2 \)
 And display math: $$ E = mc^2 $$</code></pre></div>
 
-<h2>Math in Inline Code</h2>
+<h2 id="math-in-inline-code">Math in Inline Code</h2>
 
 <p>This math in inline code should be literal: <code>\( x^2 \)</code> and <code>$$ E = mc^2 $$</code></p>
 
-<h2>More Regular Math</h2>
+<h2 id="more-regular-math">More Regular Math</h2>
 
 <p>Display math should be processed:</p>
 

--- a/MacDownTests/Fixtures/mathjax-syntax.html
+++ b/MacDownTests/Fixtures/mathjax-syntax.html
@@ -1,12 +1,12 @@
-<h1>MathJax Syntax Tests</h1>
+<h1 id="mathjax-syntax-tests">MathJax Syntax Tests</h1>
 
-<h2>Inline Math</h2>
+<h2 id="inline-math">Inline Math</h2>
 
 <p>The Pythagorean theorem states that ( a^2 + b^2 = c^2 ) for right triangles.</p>
 
 <p>Einstein&#39;s famous equation is ( E = mc^2 ).</p>
 
-<h2>Display Math</h2>
+<h2 id="display-math">Display Math</h2>
 
 <p>The quadratic formula is:</p>
 
@@ -14,13 +14,13 @@
 x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
 $$</p>
 
-<h2>Integral</h2>
+<h2 id="integral">Integral</h2>
 
 <p>$$
 \int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}
 $$</p>
 
-<h2>Matrix</h2>
+<h2 id="matrix">Matrix</h2>
 
 <p>$$
 \begin{bmatrix}
@@ -30,11 +30,11 @@ $$</p>
 \end{bmatrix}
 $$</p>
 
-<h2>Greek Letters</h2>
+<h2 id="greek-letters">Greek Letters</h2>
 
 <p>Symbols like ( \alpha ), ( \beta ), ( \gamma ), and ( \Delta ) are common in mathematics.</p>
 
-<h2>Sum and Product</h2>
+<h2 id="sum-and-product">Sum and Product</h2>
 
 <p>$$
 \sum_{i=1}^{n} i = \frac{n(n+1)}{2}
@@ -44,6 +44,6 @@ $$</p>
 \prod_{i=1}^{n} i = n!
 $$</p>
 
-<h2>Fractions and Subscripts</h2>
+<h2 id="fractions-and-subscripts">Fractions and Subscripts</h2>
 
 <p>The formula ( \frac{x<em>1 + x</em>2}{2} ) calculates the average.</p>

--- a/MacDownTests/Fixtures/mixed-complex.html
+++ b/MacDownTests/Fixtures/mixed-complex.html
@@ -1,8 +1,8 @@
-<h1>MacDown Feature Guide</h1>
+<h1 id="macdown-feature-guide">MacDown Feature Guide</h1>
 
 <p>Welcome to <strong>MacDown</strong>, a powerful Markdown editor for <em>macOS</em>.</p>
 
-<h2>Introduction</h2>
+<h2 id="introduction">Introduction</h2>
 
 <p>MacDown is an <a href="https://github.com/MacDownApp/macdown">open source</a> Markdown editor that supports:</p>
 
@@ -15,7 +15,7 @@
 
 <hr>
 
-<h2>Code Examples</h2>
+<h2 id="code-examples">Code Examples</h2>
 
 <p>Here&#39;s a simple JavaScript function:</p>
 
@@ -30,7 +30,7 @@
 
 <p>Inline code like <code>const x = 42;</code> is also supported.</p>
 
-<h2>Feature Comparison</h2>
+<h2 id="feature-comparison">Feature Comparison</h2>
 
 <table>
 <thead>
@@ -65,7 +65,7 @@
 </tbody>
 </table>
 
-<h2>Task List</h2>
+<h2 id="task-list">Task List</h2>
 
 <p>Development progress:</p>
 
@@ -89,9 +89,9 @@
 </li>
 </ul>
 
-<h2>Advanced Features</h2>
+<h2 id="advanced-features">Advanced Features</h2>
 
-<h3>Nested Lists and Quotes</h3>
+<h3 id="nested-lists-and-quotes">Nested Lists and Quotes</h3>
 
 <blockquote>
 <p>Here&#39;s what users are saying:</p>
@@ -108,13 +108,13 @@
 </ol>
 </blockquote>
 
-<h3>Images and Links</h3>
+<h3 id="images-and-links">Images and Links</h3>
 
 <p>Check out the logo: <img src="https://macdown.example.com/logo.png" alt="MacDown Logo"></p>
 
 <p>Visit our website at <a href="https://macdown.example.com">https://macdown.example.com</a>.</p>
 
-<h3>Complex Nesting</h3>
+<h3 id="complex-nesting">Complex Nesting</h3>
 
 <ol>
 <li><p><strong>Installation Steps</strong></p>
@@ -153,7 +153,7 @@
 
 <hr>
 
-<h2>Contact</h2>
+<h2 id="contact">Contact</h2>
 
 <p>Email us at <a href="mailto:support@macdown.example.com">support@macdown.example.com</a> or open an issue on <a href="https://github.com/MacDownApp/macdown" title="MacDown on GitHub">GitHub</a>.</p>
 

--- a/MacDownTests/Fixtures/regression-issue25.html
+++ b/MacDownTests/Fixtures/regression-issue25.html
@@ -1,4 +1,4 @@
-<h1>Adjacent Shortcut Links (Issue #25)</h1>
+<h1 id="adjacent-shortcut-links-issue-25">Adjacent Shortcut Links (Issue #25)</h1>
 
 <p>Two shortcut-style links side by side should both render:</p>
 

--- a/MacDownTests/Fixtures/regression-issue34.html
+++ b/MacDownTests/Fixtures/regression-issue34.html
@@ -1,6 +1,6 @@
-<h1>Lists After Colons (Issue #34)</h1>
+<h1 id="lists-after-colons-issue-34">Lists After Colons (Issue #34)</h1>
 
-<h2>Test Case 1: Basic list after colon</h2>
+<h2 id="test-case-1-basic-list-after-colon">Test Case 1: Basic list after colon</h2>
 
 <p>Here is my list:</p>
 
@@ -10,7 +10,7 @@
 <li>Item 3</li>
 </ul>
 
-<h2>Test Case 2: Ordered list after colon</h2>
+<h2 id="test-case-2-ordered-list-after-colon">Test Case 2: Ordered list after colon</h2>
 
 <p>My grocery list:</p>
 
@@ -20,7 +20,7 @@
 <li>Bread</li>
 </ol>
 
-<h2>Test Case 3: Nested list after colon</h2>
+<h2 id="test-case-3-nested-list-after-colon">Test Case 3: Nested list after colon</h2>
 
 <p>My tasks:</p>
 
@@ -39,7 +39,7 @@
 </ul></li>
 </ul>
 
-<h2>Test Case 4: List with proper blank line (works correctly)</h2>
+<h2 id="test-case-4-list-with-proper-blank-line-works-correctly">Test Case 4: List with proper blank line (works correctly)</h2>
 
 <p>This should work:</p>
 

--- a/MacDownTests/Fixtures/regression-issue36.html
+++ b/MacDownTests/Fixtures/regression-issue36.html
@@ -1,6 +1,6 @@
-<h1>Code Blocks Without Blank Lines (Issue #36)</h1>
+<h1 id="code-blocks-without-blank-lines-issue-36">Code Blocks Without Blank Lines (Issue #36)</h1>
 
-<h2>Test Case 1: Fenced code block immediately after text</h2>
+<h2 id="test-case-1-fenced-code-block-immediately-after-text">Test Case 1: Fenced code block immediately after text</h2>
 
 <p>Here is some code:</p>
 
@@ -8,7 +8,7 @@
   return true;
 }</code></pre></div>
 
-<h2>Test Case 2: Multiple code blocks in sequence</h2>
+<h2 id="test-case-2-multiple-code-blocks-in-sequence">Test Case 2: Multiple code blocks in sequence</h2>
 
 <p>First block:</p>
 
@@ -19,7 +19,7 @@
 
 <div><pre><code class="language-python">y = 100</code></pre></div>
 
-<h2>Test Case 3: Code block with proper blank line (works correctly)</h2>
+<h2 id="test-case-3-code-block-with-proper-blank-line-works-correctly">Test Case 3: Code block with proper blank line (works correctly)</h2>
 
 <p>This should work:</p>
 
@@ -27,7 +27,7 @@
   return &#39;yes&#39;;
 }</code></pre></div>
 
-<h2>Test Case 4: Code block in list without blank line</h2>
+<h2 id="test-case-4-code-block-in-list-without-blank-line">Test Case 4: Code block in list without blank line</h2>
 
 <p>Steps to follow:</p>
 

--- a/MacDownTests/Fixtures/regression-issue37.html
+++ b/MacDownTests/Fixtures/regression-issue37.html
@@ -1,19 +1,19 @@
-<h1>Square Brackets in Code (Issue #37)</h1>
+<h1 id="square-brackets-in-code-issue-37">Square Brackets in Code (Issue #37)</h1>
 
-<h2>Test Case 1: TypeScript index signature</h2>
+<h2 id="test-case-1-typescript-index-signature">Test Case 1: TypeScript index signature</h2>
 
 <div><pre><code class="language-typescript">interface MyType {
   [key: string]​: any;
 }</code></pre></div>
 
-<h2>Test Case 2: JavaScript array access</h2>
+<h2 id="test-case-2-javascript-array-access">Test Case 2: JavaScript array access</h2>
 
 <div><pre><code class="language-javascript">const value = array[index];
 const obj = {
   [computed]​: &#39;value&#39;
 };</code></pre></div>
 
-<h2>Test Case 3: Multiple bracket patterns</h2>
+<h2 id="test-case-3-multiple-bracket-patterns">Test Case 3: Multiple bracket patterns</h2>
 
 <div><pre><code class="language-typescript">type Dict = {
   [id: number]​: string;
@@ -25,11 +25,11 @@ interface Config {
   };
 }</code></pre></div>
 
-<h2>Test Case 4: Inline code with brackets</h2>
+<h2 id="test-case-4-inline-code-with-brackets">Test Case 4: Inline code with brackets</h2>
 
 <p>Here&#39;s an example: <code>array[0]</code> and <code>obj[key]</code> should work.</p>
 
-<h2>Test Case 5: Python dictionary syntax</h2>
+<h2 id="test-case-5-python-dictionary-syntax">Test Case 5: Python dictionary syntax</h2>
 
 <div><pre><code class="language-python">my_dict = {
     &quot;key&quot;: &quot;value&quot;

--- a/MacDownTests/Fixtures/strikethrough.html
+++ b/MacDownTests/Fixtures/strikethrough.html
@@ -1,12 +1,12 @@
-<h1>Strikethrough Tests</h1>
+<h1 id="strikethrough-tests">Strikethrough Tests</h1>
 
-<h2>Basic Strikethrough</h2>
+<h2 id="basic-strikethrough">Basic Strikethrough</h2>
 
 <p>This is <del>strikethrough text</del>.</p>
 
 <p><del>Entire line strikethrough</del></p>
 
-<h2>Combined with Other Formatting</h2>
+<h2 id="combined-with-other-formatting">Combined with Other Formatting</h2>
 
 <p>This is <del>strikethrough with <strong>bold</strong></del>.</p>
 
@@ -16,11 +16,11 @@
 
 <p>This is <em>italic with <del>strikethrough</del></em>.</p>
 
-<h2>Multiple Strikethroughs</h2>
+<h2 id="multiple-strikethroughs">Multiple Strikethroughs</h2>
 
 <p><del>First</del> and <del>second</del> strikethrough.</p>
 
-<h2>Edge Cases</h2>
+<h2 id="edge-cases">Edge Cases</h2>
 
 <p>Not~strikethrough (single tilde).</p>
 
@@ -30,7 +30,7 @@
 
 <p>End of line <del>has strikethrough</del>.</p>
 
-<h2>In Lists</h2>
+<h2 id="in-lists">In Lists</h2>
 
 <ul>
 <li><del>Strikethrough list item</del></li>

--- a/MacDownTests/Fixtures/syntax-highlighting-aliases.html
+++ b/MacDownTests/Fixtures/syntax-highlighting-aliases.html
@@ -1,16 +1,16 @@
-<h1>Language Aliases Test</h1>
+<h1 id="language-aliases-test">Language Aliases Test</h1>
 
-<h2>JavaScript (js alias)</h2>
+<h2 id="javascript-js-alias">JavaScript (js alias)</h2>
 
 <div><pre><code class="language-javascript">const greeting = &quot;Hello, World!&quot;;
 console.log(greeting);</code></pre></div>
 
-<h2>Objective-C (objc alias)</h2>
+<h2 id="objective-c-objc-alias">Objective-C (objc alias)</h2>
 
 <div><pre><code class="language-objectivec">NSString *greeting = @&quot;Hello, World!&quot;;
 NSLog(@&quot;%@&quot;, greeting);</code></pre></div>
 
-<h2>HTML (maps to markup)</h2>
+<h2 id="html-maps-to-markup">HTML (maps to markup)</h2>
 
 <div><pre><code class="language-markup">&lt;!DOCTYPE html&gt;
 &lt;html&gt;
@@ -19,12 +19,12 @@ NSLog(@&quot;%@&quot;, greeting);</code></pre></div>
 &lt;/body&gt;
 &lt;/html&gt;</code></pre></div>
 
-<h2>Shell (sh alias for bash)</h2>
+<h2 id="shell-sh-alias-for-bash">Shell (sh alias for bash)</h2>
 
 <div><pre><code class="language-bash">#!/bin/sh
 echo &quot;Hello, World!&quot;</code></pre></div>
 
-<h2>C++ (c++ and cpp aliases)</h2>
+<h2 id="c-c-and-cpp-aliases">C++ (c++ and cpp aliases)</h2>
 
 <div><pre><code class="language-cpp">#include &lt;iostream&gt;
 int main() {

--- a/MacDownTests/Fixtures/syntax-highlighting-languages.html
+++ b/MacDownTests/Fixtures/syntax-highlighting-languages.html
@@ -1,41 +1,41 @@
-<h1>Common Programming Languages</h1>
+<h1 id="common-programming-languages">Common Programming Languages</h1>
 
-<h2>JavaScript</h2>
+<h2 id="javascript">JavaScript</h2>
 
 <div><pre><code class="language-javascript">function fibonacci(n) {
     if (n &lt;= 1) return n;
     return fibonacci(n - 1) + fibonacci(n - 2);
 }</code></pre></div>
 
-<h2>Python</h2>
+<h2 id="python">Python</h2>
 
 <div><pre><code class="language-python">def fibonacci(n):
     if n &lt;= 1:
         return n
     return fibonacci(n - 1) + fibonacci(n - 2)</code></pre></div>
 
-<h2>C</h2>
+<h2 id="c">C</h2>
 
 <div><pre><code class="language-c">int fibonacci(int n) {
     if (n &lt;= 1) return n;
     return fibonacci(n - 1) + fibonacci(n - 2);
 }</code></pre></div>
 
-<h2>C++</h2>
+<h2 id="c">C++</h2>
 
 <div><pre><code class="language-cpp">int fibonacci(int n) {
     if (n &lt;= 1) return n;
     return fibonacci(n - 1) + fibonacci(n - 2);
 }</code></pre></div>
 
-<h2>Java</h2>
+<h2 id="java">Java</h2>
 
 <div><pre><code class="language-java">public int fibonacci(int n) {
     if (n &lt;= 1) return n;
     return fibonacci(n - 1) + fibonacci(n - 2);
 }</code></pre></div>
 
-<h2>Go</h2>
+<h2 id="go">Go</h2>
 
 <div><pre><code class="language-go">func fibonacci(n int) int {
     if n &lt;= 1 {
@@ -44,7 +44,7 @@
     return fibonacci(n-1) + fibonacci(n-2)
 }</code></pre></div>
 
-<h2>Rust</h2>
+<h2 id="rust">Rust</h2>
 
 <div><pre><code class="language-rust">fn fibonacci(n: u32) -&gt; u32 {
     match n {
@@ -54,7 +54,7 @@
     }
 }</code></pre></div>
 
-<h2>TypeScript</h2>
+<h2 id="typescript">TypeScript</h2>
 
 <div><pre><code class="language-typescript">function fibonacci(n: number): number {
     if (n &lt;= 1) return n;

--- a/MacDownTests/Fixtures/syntax-highlighting-mixed.html
+++ b/MacDownTests/Fixtures/syntax-highlighting-mixed.html
@@ -1,24 +1,24 @@
-<h1>Mixed Code Blocks</h1>
+<h1 id="mixed-code-blocks">Mixed Code Blocks</h1>
 
-<h2>Labeled Code Block</h2>
+<h2 id="labeled-code-block">Labeled Code Block</h2>
 
 <div><pre><code class="language-python">def hello():
     print(&quot;Hello from Python&quot;)</code></pre></div>
 
-<h2>Unlabeled Code Block</h2>
+<h2 id="unlabeled-code-block">Unlabeled Code Block</h2>
 
 <div><pre><code class="language-none">This code has no language specified.
 It should get the &quot;language-none&quot; class.</code></pre></div>
 
-<h2>Another Labeled Block</h2>
+<h2 id="another-labeled-block">Another Labeled Block</h2>
 
 <div><pre><code class="language-javascript">console.log(&quot;Hello from JavaScript&quot;);</code></pre></div>
 
-<h2>Indented Code Block</h2>
+<h2 id="indented-code-block">Indented Code Block</h2>
 
 <div><pre><code class="language-none">This is indented code.
 It should not have language classes.</code></pre></div>
 
-<h2>Inline Code</h2>
+<h2 id="inline-code">Inline Code</h2>
 
 <p>Here is some <code>inline code</code> that should not have language classes.</p>

--- a/MacDownTests/Fixtures/tables.html
+++ b/MacDownTests/Fixtures/tables.html
@@ -1,6 +1,6 @@
-<h1>Table Tests</h1>
+<h1 id="table-tests">Table Tests</h1>
 
-<h2>Basic Table</h2>
+<h2 id="basic-table">Basic Table</h2>
 
 <table>
 <thead>
@@ -25,7 +25,7 @@
 </tbody>
 </table>
 
-<h2>Table with Alignment</h2>
+<h2 id="table-with-alignment">Table with Alignment</h2>
 
 <table>
 <thead>
@@ -55,14 +55,14 @@
 </tbody>
 </table>
 
-<h2>Minimal Table</h2>
+<h2 id="minimal-table">Minimal Table</h2>
 
 <p>| A | B |
 | - | - |
 | 1 | 2 |
 | 3 | 4 |</p>
 
-<h2>Table with Inline Formatting</h2>
+<h2 id="table-with-inline-formatting">Table with Inline Formatting</h2>
 
 <table>
 <thead>
@@ -87,7 +87,7 @@
 </tbody>
 </table>
 
-<h2>Table with Different Column Widths</h2>
+<h2 id="table-with-different-column-widths">Table with Different Column Widths</h2>
 
 <table>
 <thead>
@@ -112,7 +112,7 @@
 </tbody>
 </table>
 
-<h2>Empty Cells</h2>
+<h2 id="empty-cells">Empty Cells</h2>
 
 <table>
 <thead>

--- a/MacDownTests/Fixtures/tables.html
+++ b/MacDownTests/Fixtures/tables.html
@@ -137,7 +137,7 @@
 </tbody>
 </table>
 
-<h2>Wide Table (many columns, issue #432 regression)</h2>
+<h2 id="wide-table-many-columns-issue-432-regression">Wide Table (many columns, issue #432 regression)</h2>
 
 <table>
 <thead>

--- a/MacDownTests/Fixtures/task-lists.html
+++ b/MacDownTests/Fixtures/task-lists.html
@@ -1,6 +1,6 @@
-<h1>Task List Tests</h1>
+<h1 id="task-list-tests">Task List Tests</h1>
 
-<h2>Basic Task Lists</h2>
+<h2 id="basic-task-lists">Basic Task Lists</h2>
 
 <ul>
 <li class="task-list-item"><input type="checkbox" data-checkbox-index="0"> Unchecked task
@@ -12,7 +12,7 @@
 <li>[X] Checked with capital X</li>
 </ul>
 
-<h2>Nested Task Lists</h2>
+<h2 id="nested-task-lists">Nested Task Lists</h2>
 
 <ul>
 <li class="task-list-item"><input type="checkbox" data-checkbox-index="6"> Parent task
@@ -30,7 +30,7 @@
 </li>
 </ul>
 
-<h2>Mixed with Regular Lists</h2>
+<h2 id="mixed-with-regular-lists">Mixed with Regular Lists</h2>
 
 <ul>
 <li>Regular list item</li>
@@ -42,7 +42,7 @@
 <li>Final regular item</li>
 </ul>
 
-<h2>Tasks with Inline Formatting</h2>
+<h2 id="tasks-with-inline-formatting">Tasks with Inline Formatting</h2>
 
 <ul>
 <li class="task-list-item"><input type="checkbox" data-checkbox-index="10"> Task with <strong>bold text</strong>
@@ -55,7 +55,7 @@
 </li>
 </ul>
 
-<h2>Numbered Task Lists</h2>
+<h2 id="numbered-task-lists">Numbered Task Lists</h2>
 
 <ol>
 <li class="task-list-item"><input type="checkbox" data-checkbox-index="14"> First task
@@ -66,7 +66,7 @@
 </li>
 </ol>
 
-<h2>Edge Cases</h2>
+<h2 id="edge-cases">Edge Cases</h2>
 
 <ul>
 <li>[] Invalid (no space)</li>

--- a/MacDownTests/Fixtures/unicode.html
+++ b/MacDownTests/Fixtures/unicode.html
@@ -1,82 +1,82 @@
-<h1>Unicode Test</h1>
+<h1 id="unicode-test">Unicode Test</h1>
 
-<h2>Basic Latin and Symbols</h2>
+<h2 id="basic-latin-and-symbols">Basic Latin and Symbols</h2>
 
 <p>Regular text with special characters: © ® ™ § ¶</p>
 
-<h2>Accented Characters</h2>
+<h2 id="accented-characters">Accented Characters</h2>
 
 <p>Café, naïve, résumé, piñata, Zürich</p>
 
-<h2>Currency Symbols</h2>
+<h2 id="currency-symbols">Currency Symbols</h2>
 
 <p>Dollar: $ Euro: € Pound: £ Yen: ¥ Bitcoin: ₿</p>
 
-<h2>Mathematical Symbols</h2>
+<h2 id="mathematical-symbols">Mathematical Symbols</h2>
 
 <p>∀ ∃ ∅ ∞ ∫ ∑ ∏ ≈ ≠ ≤ ≥ ± × ÷</p>
 
-<h2>Arrows</h2>
+<h2 id="arrows">Arrows</h2>
 
 <p>← → ↑ ↓ ↔ ⇐ ⇒ ⇔</p>
 
-<h2>Chinese Characters</h2>
+<h2 id="chinese-characters">Chinese Characters</h2>
 
 <p>你好世界 (Hello World)</p>
 
 <p>中文字符测试</p>
 
-<h2>Japanese Characters</h2>
+<h2 id="japanese-characters">Japanese Characters</h2>
 
 <p>こんにちは世界 (Hello World)</p>
 
 <p>ひらがな、カタカナ、漢字</p>
 
-<h2>Korean Characters</h2>
+<h2 id="korean-characters">Korean Characters</h2>
 
 <p>안녕하세요 세계 (Hello World)</p>
 
 <p>한글 테스트</p>
 
-<h2>Emoji</h2>
+<h2 id="emoji">Emoji</h2>
 
 <p>😀 😃 😄 😁 🚀 🌟 ⭐ 💻 📱 🎉 ✨</p>
 
-<h2>Arabic</h2>
+<h2 id="arabic">Arabic</h2>
 
 <p>مرحبا بالعالم (Hello World)</p>
 
-<h2>Hebrew</h2>
+<h2 id="hebrew">Hebrew</h2>
 
 <p>שלום עולם (Hello World)</p>
 
-<h2>Cyrillic</h2>
+<h2 id="cyrillic">Cyrillic</h2>
 
 <p>Привет мир (Hello World)</p>
 
-<h2>Greek</h2>
+<h2 id="greek">Greek</h2>
 
 <p>Γεια σου κόσμε (Hello World)</p>
 
-<h2>Special Punctuation</h2>
+<h2 id="special-punctuation">Special Punctuation</h2>
 
 <p>Em dash: — En dash: – Ellipsis: … Quotes: &quot; &quot; &#39; &#39;</p>
 
-<h2>Combining Characters</h2>
+<h2 id="combining-characters">Combining Characters</h2>
 
 <p>Café (with combining accent: Café)</p>
 
-<h2>Zero-Width Characters</h2>
+<h2 id="zero-width-characters">Zero-Width Characters</h2>
 
 <p>Zero-width space: ​ (invisible)</p>
 
-<h2>Code Block with Unicode</h2>
+<h2 id="code-block-with-unicode">Code Block with Unicode</h2>
 
 <div><pre><code class="language-python">def greet():
     print(&quot;Hello 世界 🌍&quot;)
     # Comment with unicode: ñ á é í ó ú</code></pre></div>
 
-<h2>Bullet List with Unicode</h2>
+<h2 id="bullet-list-with-unicode">Bullet List with Unicode</h2>
 
 <ul>
 <li>Item with emoji 🎯</li>
@@ -85,10 +85,10 @@
 <li>Item with special char ©</li>
 </ul>
 
-<h2>Links with Unicode</h2>
+<h2 id="links-with-unicode">Links with Unicode</h2>
 
 <p><a href="https://example.com/test">Unicode Test 测试</a></p>
 
-<h2>Emphasis with Unicode</h2>
+<h2 id="emphasis-with-unicode">Emphasis with Unicode</h2>
 
 <p><strong>Bold 粗体</strong> and <em>italic 斜体</em></p>

--- a/MacDownTests/MPHTMLExportTests.m
+++ b/MacDownTests/MPHTMLExportTests.m
@@ -401,7 +401,7 @@
                                                      error:&error];
     XCTAssertNil(error, @"Should read file without error");
     XCTAssertEqualObjects(readBack, html, @"Content should match");
-    XCTAssertTrue([readBack containsString:@"<h1>Test Document</h1>"], @"Should contain heading");
+    XCTAssertTrue([readBack containsString:@"<h1 id=\"test-document\">Test Document</h1>"], @"Should contain heading");
     XCTAssertTrue([readBack containsString:@"<strong>paragraph</strong>"], @"Should contain bold text");
 }
 
@@ -431,7 +431,7 @@
     NSString *readBack = [NSString stringWithContentsOfURL:fileURL
                                                   encoding:NSUTF8StringEncoding
                                                      error:&error];
-    XCTAssertTrue([readBack containsString:@"<h1>New Content</h1>"], @"Should have new content");
+    XCTAssertTrue([readBack containsString:@"<h1 id=\"new-content\">New Content</h1>"], @"Should have new content");
     XCTAssertFalse([readBack containsString:@"Initial"], @"Should not have old content");
 }
 
@@ -460,8 +460,8 @@
                   @"Should be complete HTML document");
     XCTAssertTrue([content containsString:@"<head>"], @"Should have head");
     XCTAssertTrue([content containsString:@"<body"], @"Should have body");
-    XCTAssertTrue([content containsString:@"<h1>"], @"Should have h1");
-    XCTAssertTrue([content containsString:@"<h2>"], @"Should have h2");
+    XCTAssertTrue([content containsString:@"<h1 "], @"Should have h1");
+    XCTAssertTrue([content containsString:@"<h2 "], @"Should have h2");
     XCTAssertTrue([content containsString:@"<ul>"], @"Should have list");
     XCTAssertTrue([content containsString:@"<li>"], @"Should have list items");
     XCTAssertTrue([content containsString:@"<pre>"] || [content containsString:@"<code>"],

--- a/MacDownTests/MPImageExportTests.m
+++ b/MacDownTests/MPImageExportTests.m
@@ -405,7 +405,7 @@
     [self.renderer parseMarkdown:self.dataSource.markdown];
     NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
 
-    XCTAssertTrue([html containsString:@"<h1>"], @"Should have heading");
+    XCTAssertTrue([html containsString:@"<h1 "], @"Should have heading");
     XCTAssertTrue([html containsString:@"example.com/1.png"], @"Should have first image");
     XCTAssertTrue([html containsString:@"example.com/2.png"], @"Should have second image");
 }

--- a/MacDownTests/MPMarkdownRenderingTests.m
+++ b/MacDownTests/MPMarkdownRenderingTests.m
@@ -799,4 +799,74 @@
                   @"Heading id must be emitted independent of TOC preference. Got: %@", html);
 }
 
+// Rendered heading content always escapes special characters to HTML entities
+// (&amp; / &lt; / &gt; ...), so the slug must skip &...; sequences the same way
+// it already skips <...> tags. Otherwise literal letters leak into the id and
+// anchor links like [text](#qa) silently fail to navigate.
+
+- (void)testHeadingAnchorIdSkipsAmpEntity
+{
+    // "Q&A" renders as "Q&amp;A"; the slug must be "qa", not "qampa".
+    NSString *html = [self renderMarkdown:@"## Q&A"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"qa\""],
+                  @"Heading id must skip the &amp; entity. Got: %@", html);
+}
+
+- (void)testHeadingAnchorIdSkipsLtGtEntity
+{
+    // "A < B" renders as "A &lt; B"; the slug must be "a-b", not "a-lt-b".
+    NSString *html = [self renderMarkdown:@"## A < B"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"a-b\""],
+                  @"Heading id must skip the &lt; entity. Got: %@", html);
+}
+
+- (void)testHeadingAnchorIdSkipsMultipleEntities
+{
+    // "Tips & Tricks" renders as "Tips &amp; Tricks"; the slug must be
+    // "tips-tricks", not "tips-amp-tricks".
+    NSString *html = [self renderMarkdown:@"## Tips & Tricks"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"tips-tricks\""],
+                  @"Heading id must skip every HTML entity. Got: %@", html);
+}
+
+// Documents the current slug contract: identical headings are not uniquified,
+// so "## C" and "## C++" both collapse to id="c". This pins the behavior so a
+// future change to deduplication is a conscious decision, not a silent side
+// effect.
+
+- (void)testDuplicateHeadingsCollapseToSameId
+{
+    NSString *html = [self renderMarkdown:@"## C\n\n## C++\n"
+                           withExtensions:0
+                            rendererFlags:0];
+    NSUInteger firstC = [html rangeOfString:@"id=\"c\""].location;
+    NSUInteger secondC = [html rangeOfString:@"id=\"c\""
+                                  options:0
+                                    range:NSMakeRange(firstC + 1, html.length - firstC - 1)].location;
+    XCTAssertNotEqual(firstC, NSNotFound, @"First heading should have id=\"c\". Got: %@", html);
+    XCTAssertNotEqual(secondC, NSNotFound, @"Second heading should also have id=\"c\". Got: %@", html);
+}
+
+// Because this PR changes both the heading id and the TOC href, lock in the
+// navigation guarantee: the TOC href must equal the heading id for the same
+// heading text.
+
+- (void)testTOCHrefMatchesHeadingId
+{
+    self.delegate.renderTOC = YES;
+    NSString *html = [self renderMarkdown:@"[TOC]\n\n## Foo Bar"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"href=\"#foo-bar\""],
+                  @"TOC entry must link to the heading slug. Got: %@", html);
+    XCTAssertTrue([html containsString:@"id=\"foo-bar\""],
+                  @"Heading must carry the matching id. Got: %@", html);
+}
+
 @end

--- a/MacDownTests/MPMarkdownRenderingTests.m
+++ b/MacDownTests/MPMarkdownRenderingTests.m
@@ -689,8 +689,8 @@
                                 rendererFlags:rendFlags];
 
     XCTAssertNotNil(crlfHtml, @"CRLF content should produce non-nil HTML");
-    XCTAssertTrue([crlfHtml containsString:@"<h1>"],
-                  @"CRLF heading should render as <h1>");
+    XCTAssertTrue([crlfHtml containsString:@"<h1 "],
+                  @"CRLF heading should render as an <h1> element");
     XCTAssertTrue([crlfHtml containsString:@"Heading"],
                   @"CRLF heading text should appear in output");
     XCTAssertTrue([crlfHtml containsString:@"<p>"],
@@ -751,6 +751,52 @@
                   @"CRLF fenced code content should appear in output");
     XCTAssertEqualObjects(lfHtml, crlfHtml,
                           @"CRLF and LF fenced-code-after-text should produce identical HTML");
+}
+
+
+#pragma mark - Heading Anchor ID Tests
+
+// Headings should always receive a text-derived id attribute so that
+// CommonMark/GFM-style anchor links like [text](#section) navigate to
+// the corresponding heading in the preview.
+
+- (void)testHeadingHasSlugBasedAnchorId
+{
+    NSString *html = [self renderMarkdown:@"## Foo Bar"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"foo-bar\""],
+                  @"Heading should have a slug-based id derived from its text. Got: %@", html);
+}
+
+- (void)testHeadingAnchorIdPreservesUTF8
+{
+    NSString *html = [self renderMarkdown:@"## Introducción"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"introducción\""],
+                  @"Heading id should preserve UTF-8 multi-byte characters. Got: %@", html);
+}
+
+- (void)testHeadingAnchorIdStripsPunctuation
+{
+    NSString *html = [self renderMarkdown:@"# Hello, World!"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"hello-world\""],
+                  @"Heading id should drop ASCII punctuation. Got: %@", html);
+}
+
+- (void)testHeadingAnchorIdEmittedWithoutTOCPreference
+{
+    // Regression guard: ids must be emitted regardless of the
+    // "Detect TOC token" preference state.
+    self.delegate.renderTOC = NO;
+    NSString *html = [self renderMarkdown:@"### Some Section"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"some-section\""],
+                  @"Heading id must be emitted independent of TOC preference. Got: %@", html);
 }
 
 @end

--- a/MacDownTests/MPQuickLookRendererTests.m
+++ b/MacDownTests/MPQuickLookRendererTests.m
@@ -670,6 +670,36 @@
     XCTAssertNotNil(error, @"Should populate error for nil URL");
 }
 
+
+#pragma mark - Heading Anchor ID Tests
+
+// Quick Look mirrors the preview slugify(), so heading ids must match exactly.
+// See MPMarkdownRenderingTests for the full slug contract.
+
+- (void)testQuickLookHeadingAnchorIdSkipsAmpEntity
+{
+    // "Q&A" renders as "Q&amp;A"; the slug must be "qa", not "qampa".
+    NSString *html = [self.renderer renderMarkdown:@"## Q&A"];
+    XCTAssertTrue([html containsString:@"id=\"qa\""],
+                  @"Quick Look heading id must skip the &amp; entity. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdSkipsMultipleEntities
+{
+    // "Tips & Tricks" renders as "Tips &amp; Tricks"; slug must be "tips-tricks".
+    NSString *html = [self.renderer renderMarkdown:@"## Tips & Tricks"];
+    XCTAssertTrue([html containsString:@"id=\"tips-tricks\""],
+                  @"Quick Look heading id must skip every HTML entity. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdStripsPunctuation
+{
+    // Parity with the preview: punctuation drops, spaces become hyphens.
+    NSString *html = [self.renderer renderMarkdown:@"# Hello, World!"];
+    XCTAssertTrue([html containsString:@"id=\"hello-world\""],
+                  @"Quick Look heading id should drop ASCII punctuation. Got: %@", html);
+}
+
 @end
 
 #else

--- a/MacDownTests/MPQuickLookRendererTests.m
+++ b/MacDownTests/MPQuickLookRendererTests.m
@@ -124,8 +124,8 @@
     NSString *html = [self.renderer renderMarkdown:markdown];
 
     XCTAssertNotNil(html, @"Should return non-nil HTML");
-    XCTAssertTrue([html containsString:@"<h1>"],
-                  @"Should render heading as <h1>");
+    XCTAssertTrue([html containsString:@"<h1 "],
+                  @"Should render heading as an <h1> element");
     XCTAssertTrue([html containsString:@"Hello World"],
                   @"Should include heading text");
     XCTAssertTrue([html containsString:@"<p>"],
@@ -640,8 +640,8 @@
 
     XCTAssertNil(error, @"Should render CRLF file without error");
     XCTAssertNotNil(html, @"Should produce HTML from CRLF file");
-    XCTAssertTrue([html containsString:@"<h1>"],
-                  @"CRLF heading should render as <h1>");
+    XCTAssertTrue([html containsString:@"<h1 "],
+                  @"CRLF heading should render as an <h1> element");
     XCTAssertTrue([html containsString:@"Heading"],
                   @"Heading text should appear in output");
     XCTAssertTrue([html containsString:@"<p>"],

--- a/MacDownTests/MPRendererEdgeCaseTests.m
+++ b/MacDownTests/MPRendererEdgeCaseTests.m
@@ -534,8 +534,8 @@
     NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
 
     XCTAssertNotNil(html, @"Should handle many headings");
-    XCTAssertTrue([html containsString:@"<h1>"], @"Should have h1");
-    XCTAssertTrue([html containsString:@"<h6>"], @"Should have h6");
+    XCTAssertTrue([html containsString:@"<h1 "], @"Should have h1");
+    XCTAssertTrue([html containsString:@"<h6 "], @"Should have h6");
 }
 
 - (void)testRendererWithDeeplyNestedLists

--- a/MacDownTests/MPRendererStateTests.m
+++ b/MacDownTests/MPRendererStateTests.m
@@ -295,7 +295,7 @@
     XCTAssertNotNil(html, @"Should produce HTML");
     XCTAssertTrue([html containsString:@"<style"],
                   @"Should include embedded styles");
-    XCTAssertTrue([html containsString:@"<h1>"],
+    XCTAssertTrue([html containsString:@"<h1 "],
                   @"Should include heading");
 }
 
@@ -308,7 +308,7 @@
     NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
 
     XCTAssertNotNil(html, @"Should produce HTML");
-    XCTAssertTrue([html containsString:@"<h1>"],
+    XCTAssertTrue([html containsString:@"<h1 "],
                   @"Should include heading");
 }
 


### PR DESCRIPTION
## Summary
- Headings now receive text-derived `id` attributes regardless of the "Detect TOC token" preference, enabling standard `[text](#section)` anchor links in the preview.
- The visible `[TOC]` renderer uses the same slugs.
- Applied to both the main preview (`hoedown_html_patch.c`) and the Quick Look renderer (`MPQuickLookRenderer.m`) for parity.

## Tests
- `xcodebuild test -workspace "MacDown 3000.xcworkspace" -scheme MacDown -destination 'platform=macOS'` — 875 / 875 passing locally.
- Four new tests in `MPMarkdownRenderingTests.m` for slug behavior.
- 28 golden fixtures regenerated mechanically (uniform `id="..."` additions only).

Related to #429
