### PR TITLE
Fix table rendering regression in preview panel

### DIFF
--- a/MacDown/Resources/Extensions/export.css
+++ b/MacDown/Resources/Extensions/export.css
@@ -23,10 +23,15 @@ li {
     overflow-wrap: break-word;
 }
 
-/* Table cells - handle long content in tables */
-td, th {
-    word-break: break-word;
-    overflow-wrap: break-word;
+/* Tables - allow horizontal scrolling for wide tables (Issue #432)
+ * Replaces previous td/th word-break rules that caused column compression.
+ * Pattern from GitHub-2020.css which handles table overflow correctly.
+ */
+table {
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    overflow: auto;
 }
 
 /* Blockquotes - ensure quoted content wraps */


### PR DESCRIPTION
## Summary

Fixes the table rendering regression where tables display with aggressively compressed column widths in the preview panel.

## Problem

`export.css` applied `word-break: break-word` on `td, th` elements (added for issue #30), causing table columns to wrap text at every opportunity and compress to unusably narrow widths. This rule was never in the upstream MacDownApp/macdown PR #1320 — it was added during the macdown3000 implementation.

## Fix

- **Removed** the `td, th { word-break: break-word }` block
- **Added** table-level overflow rules: `table { display: block; width: max-content; max-width: 100%; overflow: auto; }`

This follows the proven pattern from GitHub-2020.css (the only theme that previously handled tables correctly). Since `export.css` loads last in the stylesheet cascade, this fix applies to all 11 themes.

## Behavior Change

- Wide tables now scroll horizontally instead of compressing columns
- Table cell text still wraps via the `body { overflow-wrap: break-word }` inheritance (gentler than explicit word-break on cells)

Related to #432