### PR TITLE
Fix wide table horizontal scroll regression (Issue #432)

### DIFF
--- a/MacDown/Resources/Extensions/export.css
+++ b/MacDown/Resources/Extensions/export.css
@@ -23,10 +23,15 @@ li {
     overflow-wrap: break-word;
 }
 
-/* Table cells - handle long content in tables */
-td, th {
-    word-break: break-word;
-    overflow-wrap: break-word;
+/* Table overflow - allow wide tables to scroll horizontally (Issue #432).
+ * Uses the same pattern as GitHub-2020.css, promoted here to cover all themes.
+ * Note: word-break is intentionally NOT applied to td/th — cells should
+ * expand to natural width; the table-level overflow provides the safety valve. */
+table {
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    overflow: auto;
 }
 
 /* Blockquotes - ensure quoted content wraps */


### PR DESCRIPTION
## Problem

Wide Markdown tables were being squeezed to fit the preview viewport width with no horizontal scrolling, instead of expanding to their natural column width. This regressed from MacDown v0.7.2 behavior.

## Root Cause

`export.css` was applying `word-break: break-word` to `td, th` elements, forcing cell content to wrap aggressively and preventing columns from reaching natural width. Combined with most themes having no `overflow: auto` on tables, wide tables had nowhere to go.

## Fix

Replaced the `td, th` word-break block in `export.css` with a `table` overflow block:

```css
/* before */
td, th {
    word-break: break-word;
    overflow-wrap: break-word;
}

/* after */
table {
    display: block;
    width: max-content;
    max-width: 100%;
    overflow: auto;
}
```

This promotes the proven pattern already used in `GitHub-2020.css` to the universal CSS layer, fixing all 10 affected themes at once.

- `display: block` + `width: max-content` lets the table grow to its natural width
- `max-width: 100%` caps it at the viewport
- `overflow: auto` provides a horizontal scrollbar only when needed
- Removing `td, th` word-break restores natural cell expansion (the original MacDown behavior)

Closes #432