### PR TITLE
Fix blank preview for Markdown files with the execute bit set

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1193,6 +1193,30 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             // Otherwise this is somewhere else on the same page. Jump there.
             break;
         default:
+            // Issue #431: Our own loadHTMLString:baseURL: render arrives
+            // here as a main-frame navigation of type "other" targeting the
+            // base URL (the document file itself). Rendering a document is
+            // not executing it, so the render load must bypass the
+            // content-initiated navigation policy below. Without this, a
+            // Markdown file with the POSIX execute bit set (common for
+            // files that lived on Windows/exFAT/SMB volumes) renders a
+            // permanently blank preview, because the executable check
+            // below vetoes the entire page load.
+            //
+            // A render load is identified by: a render in flight
+            // (alreadyRenderingInWeb), targeting the main frame, with the
+            // exact URL the renderer uses as its base. Worst case for a
+            // same-URL JS navigation slipping through this window is the
+            // raw Markdown bytes displayed as text — never execution.
+            if (self.alreadyRenderingInWeb && frame == webView.mainFrame
+                && url.isFileURL)
+            {
+                NSURL *renderBase = self.fileURL
+                    ?: self.preferences.htmlDefaultDirectoryUrl;
+                if ([url isEqual:renderBase]
+                    || [url isEqual:self.currentBaseUrl])
+                    break;
+            }
             // CVE-2019-12173: Block file:// navigations from non-user-initiated
             // actions (e.g., JavaScript auto-click) unless they target the
             // current document scope and are not executable.


### PR DESCRIPTION
## Summary
Fixes the blank-preview bug in #431: a Markdown file with the POSIX execute bit set (`chmod +x`) shows an empty preview pane while the editor works normally.

## Root cause
The CVE-2019-12173 navigation guard in `MPDocument.m` vetoes non-user-initiated `file://` navigations that target executables. The catch: legacy WebView reports the app's **own `loadHTMLString:baseURL:` render** to the policy delegate as a main-frame navigation of type "other," whose URL is the base URL — i.e. **the document file itself**. `MPURLSecurityPolicy isExecutableOrAppBundleAtURL:` flags any regular file with an exec bit, so the guard vetoed the entire preview load. (`log stream` shows the repeated `MacDown: Blocked file:// navigation for security` messages during render.)

This is why `chmod -x` fixes it (as discovered in the issue thread), and why affected files tend to be ones that lived on Windows/exFAT/SMB volumes, which routinely surface with `0777` modes.

## Fix
Recognize the in-flight render load — render in progress (`alreadyRenderingInWeb`), main frame, URL equal to the renderer base URL — and let it through before the content-navigation policy runs. **Rendering a document is not executing it.**

The guard is unchanged for content-initiated navigations:
- Clicking a Markdown link to an executable still raises the security alert (re-verified manually)
- Out-of-scope JS navigations are still blocked
- Worst case for a same-URL JS navigation during the brief render window is raw Markdown bytes displayed as text — never execution

## Verification (macOS 26.5 Tahoe, Apple Silicon)
- [x] `chmod +x` file: preview renders (previously blank)
- [x] Normal file: renders, no regression
- [x] Executable-link guard: still fires
- [x] Full test suite: 871 tests pass

Related to #431
