### PR TITLE
Open only the help document on first launch

### DIFF
--- a/MacDown/Code/Application/MPMainController.m
+++ b/MacDown/Code/Application/MPMainController.m
@@ -354,8 +354,11 @@ NS_INLINE void treat()
 
 - (void)showFirstLaunchTips
 {
+    // Issue #428: Open only the help document on first launch. Together
+    // with the standard untitled document this makes two windows; also
+    // opening contribute.md made it three, which users reported as
+    // confusing. Contributing remains available in the Help menu.
     [self showHelp:nil];
-    [self showContributing:nil];
 }
 
 


### PR DESCRIPTION
## Summary
Addresses #428: first launch opened three windows (untitled + `help.md` + `contribute.md`), which users on multiple machines reported as confusing.

## Change
`showFirstLaunchTips` now opens only `help.md`. With the standard untitled document that makes two windows. Contributing remains one click away in the Help menu (`Help → Contribute`), where returning users — the ones actually in a position to contribute — can find it.

For context: the three-window behavior was inherited from classic MacDown (contribute.md was added to the first-launch tips in 2017), so this is a deliberate UX change, not a regression fix. Happy to adjust if you'd prefer different first-launch behavior.

## Verification (macOS 26.5 Tahoe, Apple Silicon)
- [x] Simulated fresh install (cleared `firstVersionInstalled`): exactly two windows — untitled + help.md
- [x] Second launch: only the untitled document, tips don't re-fire
- [x] Full test suite passes (871 tests)

Related to #428
