### PR TITLE
Fix blank preview for documents with execute bit set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fix blank preview for documents with the execute bit set, which some sync clients (e.g. OneDrive) apply to every synced file (#431, #405) -- thanks @maskedspitz, @songjianbupt, and @craigrodger for the diagnosis!
 - Improve render-path responsiveness: single-pass word/character counting, cached body-extraction regex, and bounded renderer polling with cancellation (#388)
 - Restrict auto-created link targets to the current document's folder scope (#388)
 - Fix line enumeration in scroll sync header scanning to handle `\r\n` and bare `\r` line endings (#388)

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1384,6 +1384,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     NSURL *baseUrl = self.fileURL;
     if (!baseUrl)   // Unsaved doument; just use the default URL.
         baseUrl = self.preferences.htmlDefaultDirectoryUrl;
+    baseUrl = [self previewSafeBaseURL:baseUrl];
 
     self.manualRender = self.preferences.markdownManualRender;
 
@@ -1529,7 +1530,29 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     NSURL *baseUrl = self.fileURL;
     if (!baseUrl)
         baseUrl = self.preferences.htmlDefaultDirectoryUrl;
-    return baseUrl;
+    return [self previewSafeBaseURL:baseUrl];
+}
+
+// Issue #431: On macOS 26, WebKit silently refuses to load file:// preview
+// content whose base resource is an executable file. Some sync clients (notably
+// OneDrive) set the execute bit (0700) on every synced file and revert any
+// manual `chmod -x`, so externally-originated documents render blank even though
+// the editor — which reads bytes via NSDocument, not WebKit — works fine.
+//
+// When the document file is executable, substitute a non-existent sentinel in
+// the same directory as the base URL. WebKit no longer sees an executable base
+// resource, while everything that actually depends on the base URL — relative
+// resource resolution, MPLocalFilePathsInHTML, cache busting, and the
+// MPURLSecurityPolicy scope check (which keys off the base URL's parent
+// directory) — is unchanged, since the sentinel lives in the same directory.
+- (NSURL *)previewSafeBaseURL:(NSURL *)baseURL
+{
+    if (!baseURL || !baseURL.isFileURL)
+        return baseURL;
+    if (![MPURLSecurityPolicy isExecutableOrAppBundleAtURL:baseURL])
+        return baseURL;
+    return [baseURL.URLByDeletingLastPathComponent
+            URLByAppendingPathComponent:@".macdown-preview-base"];
 }
 
 #pragma mark - Resource Watcher Delegate (Issue #110)

--- a/MacDownTests/MPDocumentIOTests.m
+++ b/MacDownTests/MPDocumentIOTests.m
@@ -13,6 +13,7 @@
 @interface MPDocument (LinkTargetTesting)
 @property (strong) NSURL *currentBaseUrl;
 - (BOOL)canAutomaticallyCreateLinkedFileAtURL:(NSURL *)url;
+- (NSURL *)previewSafeBaseURL:(NSURL *)baseURL;
 @end
 
 @interface MPDocumentIOTests : XCTestCase
@@ -118,6 +119,42 @@
 
     XCTAssertTrue(success, @"readFromData:ofType:error: should succeed with CRLF data");
     XCTAssertNil(error, @"No error should occur loading CRLF-terminated content");
+}
+
+- (void)testPreviewSafeBaseURLLeavesNonExecutableFileUnchanged
+{
+    // Issue #431: a normal (non-executable) document file must be used as-is so
+    // relative resources and security scope behave exactly as before.
+    NSString *content = @"# Test\n";
+    [content writeToURL:self.testFileURL atomically:YES
+               encoding:NSUTF8StringEncoding error:nil];
+
+    NSURL *safe = [self.document previewSafeBaseURL:self.testFileURL];
+    XCTAssertEqualObjects(safe, self.testFileURL,
+        @"Non-executable files should be returned unchanged");
+}
+
+- (void)testPreviewSafeBaseURLRewritesExecutableFile
+{
+    // Issue #431: WebKit blanks the preview for executable base resources (e.g.
+    // OneDrive's 0700 files). The base URL should be swapped for a non-existent
+    // sentinel in the SAME directory, so WebKit no longer sees an executable
+    // base while the directory — all the scope/resolution code depends on —
+    // stays identical.
+    NSString *content = @"# Test\n";
+    [content writeToURL:self.testFileURL atomically:YES
+               encoding:NSUTF8StringEncoding error:nil];
+    chmod(self.testFileURL.path.fileSystemRepresentation, 0700);
+
+    NSURL *safe = [self.document previewSafeBaseURL:self.testFileURL];
+
+    XCTAssertNotEqualObjects(safe, self.testFileURL,
+        @"Executable files should not be used as the preview base URL");
+    XCTAssertEqualObjects(safe.URLByDeletingLastPathComponent.path,
+                          self.testFileURL.URLByDeletingLastPathComponent.path,
+        @"Sentinel base URL must live in the same directory as the document");
+    XCTAssertFalse([self.fileManager fileExistsAtPath:safe.path],
+        @"Sentinel base URL must not point at a real (executable) file");
 }
 
 - (void)testWritableTypes


### PR DESCRIPTION
## Summary

Fixes an issue where Markdown previews render blank when the document file has the execute bit set. Some sync clients (notably OneDrive) automatically set the execute bit (0700) on synced files, causing WebKit to silently refuse to load the preview content.

## Changes

- **MPDocument.m**: Added `previewSafeBaseURL:` method that detects executable files and substitutes a non-existent sentinel URL in the same directory. This allows WebKit to render the preview while preserving all path resolution and security scope behavior.
  - Updated `renderer:didProduceHTMLOutput:` to use the safe base URL
  - Updated `rendererBaseURL:` to use the safe base URL
  
- **MPDocumentIOTests.m**: Added two test cases to verify the fix:
  - `testPreviewSafeBaseURLLeavesNonExecutableFileUnchanged`: Ensures normal files are used as-is
  - `testPreviewSafeBaseURLRewritesExecutableFile`: Verifies executable files are replaced with a sentinel in the same directory

- **CHANGELOG.md**: Documented the fix

## Implementation Details

The solution works by:
1. Checking if the base URL points to an executable file using `MPURLSecurityPolicy`
2. If executable, replacing it with a non-existent sentinel file (`.macdown-preview-base`) in the same directory
3. This keeps WebKit happy (no executable base resource) while maintaining all existing behavior since relative resource resolution, security scope checks, and other features depend on the directory, not the specific file

Related to #431, #405

https://claude.ai/code/session_01R7hAw42Bbyo9kMrtUGxyN2