### PR TITLE
Address issue #341: regression coverage for preview image rendering

### DIFF
--- a/MacDown 3000.xcodeproj/project.pbxproj
+++ b/MacDown 3000.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		D29776CC6E7EB5B4AA2E0537 /* MPFileWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = A81247E840EB5C07669FF165 /* MPFileWatcher.m */; };
 		D3877A6637DE48017448C8DB /* MPRendererTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E2FC4B9389A012264DC6214 /* MPRendererTestHelpers.m */; };
 		E087CFBB2125A4D2B37C132F /* MPHTMLResourceURLsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8552820CEE8D00E83AEE3897 /* MPHTMLResourceURLsTests.m */; };
+		ISSUE341IMGRENDERBUILDFILE /* MPImageRenderingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE341IMGRENDERFILEREF /* MPImageRenderingTests.m */; };
 		EA2D3FB9196BC4F7CA0235DC /* MPFileWatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 779606A8E0525000200B4EC5 /* MPFileWatcherTests.m */; };
 		EBFE3157737058F5A63699C8 /* libPods-MacDownTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C949FDE45493AE77DAD9BF4 /* libPods-MacDownTests.a */; };
 		ISSUE16RNDRDEFRBUILDFILE /* MPRenderDeferralTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE16RNDRDEFRFILEREF /* MPRenderDeferralTests.m */; };
@@ -531,6 +532,7 @@
 		852D52391E260A6400BA7162 /* MPTerminalPreferencesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPTerminalPreferencesViewController.h; sourceTree = "<group>"; };
 		852D523A1E260A6400BA7162 /* MPTerminalPreferencesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPTerminalPreferencesViewController.m; sourceTree = "<group>"; };
 		8552820CEE8D00E83AEE3897 /* MPHTMLResourceURLsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPHTMLResourceURLsTests.m; sourceTree = "<group>"; };
+		ISSUE341IMGRENDERFILEREF /* MPImageRenderingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPImageRenderingTests.m; sourceTree = "<group>"; };
 		8579778C7BF70F28920CE089 /* MPResourceWatcherSetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPResourceWatcherSetTests.m; sourceTree = "<group>"; };
 		85E24E5A1E5019C00056E696 /* MPToolbarController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MPToolbarController.h; path = Code/Application/MPToolbarController.h; sourceTree = "<group>"; };
 		85E24E5B1E5019C00056E696 /* MPToolbarController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MPToolbarController.m; path = Code/Application/MPToolbarController.m; sourceTree = "<group>"; };
@@ -979,6 +981,7 @@
 				779606A8E0525000200B4EC5 /* MPFileWatcherTests.m */,
 				8579778C7BF70F28920CE089 /* MPResourceWatcherSetTests.m */,
 				8552820CEE8D00E83AEE3897 /* MPHTMLResourceURLsTests.m */,
+				ISSUE341IMGRENDERFILEREF /* MPImageRenderingTests.m */,
 				ISSUE325MJSCRLFILEREF /* MPMathJaxScrollTests.m */,
 				1FCDCA371944F97800B1F966 /* Supporting Files */,
 				B3BD139B59E787FBB9F38228 /* MPEditorViewSubstitutionTests.m */,
@@ -1457,6 +1460,7 @@
 				EA2D3FB9196BC4F7CA0235DC /* MPFileWatcherTests.m in Sources */,
 				B9A9E04CBEE140C3AF8880B9 /* MPResourceWatcherSetTests.m in Sources */,
 				E087CFBB2125A4D2B37C132F /* MPHTMLResourceURLsTests.m in Sources */,
+				ISSUE341IMGRENDERBUILDFILE /* MPImageRenderingTests.m in Sources */,
 				ISSUE318STYLERELBUILDFILE /* MPDocumentStyleUpdateTests.m in Sources */,
 				ISSUE331MRMDRNDRBUILDFILE /* MPMermaidRenderingTests.m in Sources */,
 				ISSUE332GVIZRNDRBUILDFILE /* MPGraphvizRenderingTests.m in Sources */,

--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -488,6 +488,12 @@ NS_INLINE NSString *MPPreviewContentSecurityPolicy(void)
 {
     // MathJax 2.x relies on eval/new Function during startup, and bundled
     // preview libraries inject inline styles while rendering annotated output.
+    //
+    // Issue #341: img-src and media-src must keep data:, file:, http: and
+    // https: allowed. Dropping any scheme silently breaks image rendering for
+    // that source — the <img> container still lays out, but the bits never
+    // load. MPImageRenderingTests pins this contract; update it deliberately
+    // if you tighten the policy.
     return @"default-src 'none'; "
            @"base-uri 'none'; "
            @"form-action 'none'; "

--- a/MacDownTests/MPImageRenderingTests.m
+++ b/MacDownTests/MPImageRenderingTests.m
@@ -1,0 +1,150 @@
+//
+//  MPImageRenderingTests.m
+//  MacDownTests
+//
+//  Regression coverage for GitHub issue #341: "Loss of all image rendering
+//  in preview." Images that container-render (correct size/border) but never
+//  load their bits are the symptom of something in the render pipeline
+//  dropping or blocking the image source.
+//
+//  Nothing in MacDown's current code blocks image subresources, and these
+//  tests are tripwires that keep it that way: they pin the end-to-end image
+//  contract of the preview HTML so a future change (e.g. tightening the
+//  Content-Security-Policy the way preview-hardening work did, or rewriting
+//  the resource-load path) fails loudly in CI instead of silently breaking
+//  image rendering for every source at once.
+//
+//  These are pipeline-level tests; they cannot catch a failure that lives in
+//  the deprecated legacy WebView itself (the likely real-world trigger of
+//  #341). See the PR's manual testing plan for verifying the live WebView.
+//
+
+#import <XCTest/XCTest.h>
+#import "MPRenderer.h"
+#import "MPRendererTestHelpers.h"
+#import "hoedown/document.h"
+#import "hoedown_html_patch.h"
+
+
+@interface MPImageRenderingTests : XCTestCase
+@property (nonatomic, strong) MPRenderer *renderer;
+@property (nonatomic, strong) MPMockRendererDataSource *dataSource;
+@property (nonatomic, strong) MPMockRendererDelegate *delegate;
+@end
+
+
+@implementation MPImageRenderingTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    self.dataSource = [[MPMockRendererDataSource alloc] init];
+    self.delegate = [[MPMockRendererDelegate alloc] init];
+
+    self.renderer = [[MPRenderer alloc] init];
+    self.renderer.dataSource = self.dataSource;
+    self.renderer.delegate = self.delegate;
+}
+
+- (void)tearDown
+{
+    self.renderer = nil;
+    self.dataSource = nil;
+    self.delegate = nil;
+    [super tearDown];
+}
+
+// Renders the given markdown through the live preview path and returns the
+// full preview HTML (including head/CSP) captured by the mock delegate.
+- (NSString *)previewHTMLForMarkdown:(NSString *)markdown
+{
+    self.dataSource.markdown = markdown;
+    [self.renderer parseMarkdown:markdown];
+    [self.renderer render];
+    return self.delegate.lastHTML;
+}
+
+
+#pragma mark - Image src is preserved end-to-end across all sources
+
+- (void)testPreviewPreservesHTTPSImageSource
+{
+    NSString *html =
+        [self previewHTMLForMarkdown:@"![alt](https://example.com/photo.png)"];
+
+    XCTAssertNotNil(html, @"Preview render should produce HTML");
+    XCTAssertTrue([html containsString:@"<img"],
+                  @"Preview HTML should contain an image element");
+    XCTAssertTrue([html containsString:@"https://example.com/photo.png"],
+                  @"Preview HTML must preserve the https image source");
+}
+
+- (void)testPreviewPreservesHTTPImageSource
+{
+    NSString *html =
+        [self previewHTMLForMarkdown:@"![alt](http://example.com/photo.png)"];
+
+    XCTAssertTrue([html containsString:@"http://example.com/photo.png"],
+                  @"Preview HTML must preserve the http image source");
+}
+
+- (void)testPreviewPreservesLocalFileImageSource
+{
+    // Relative local path, as written for a sidecar image next to the document.
+    NSString *html =
+        [self previewHTMLForMarkdown:@"![alt](images/photo.png)"];
+
+    XCTAssertTrue([html containsString:@"images/photo.png"],
+                  @"Preview HTML must preserve the local file image source");
+}
+
+- (void)testPreviewPreservesAbsoluteFileURLImageSource
+{
+    NSString *html =
+        [self previewHTMLForMarkdown:@"![alt](file:///tmp/photo.png)"];
+
+    XCTAssertTrue([html containsString:@"file:///tmp/photo.png"],
+                  @"Preview HTML must preserve the file:// image source");
+}
+
+- (void)testPreviewPreservesDataURIImageSource
+{
+    // A 1x1 transparent PNG as a data URI.
+    NSString *dataURI = @"data:image/png;base64,"
+        @"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+    NSString *markdown =
+        [NSString stringWithFormat:@"![alt](%@)", dataURI];
+
+    NSString *html = [self previewHTMLForMarkdown:markdown];
+
+    XCTAssertTrue([html containsString:@"data:image/png;base64,"],
+                  @"Preview HTML must preserve the data URI image source");
+}
+
+
+#pragma mark - CSP must keep every image scheme allowed (#341 tripwire)
+
+- (void)testPreviewCSPAllowsAllImageSchemes
+{
+    NSString *html = [self previewHTMLForMarkdown:@"# Heading"];
+
+    XCTAssertTrue([html containsString:@"Content-Security-Policy"],
+                  @"Preview HTML should include a CSP meta tag");
+    // Issue #341: if any of these schemes is dropped from img-src, images
+    // from that source silently stop rendering even though the <img>
+    // container still lays out. Keep all four allowed.
+    XCTAssertTrue([html containsString:@"img-src data: file: http: https:"],
+                  @"CSP img-src must allow data:, file:, http:, and https: images");
+}
+
+- (void)testPreviewCSPAllowsAllMediaSchemes
+{
+    NSString *html = [self previewHTMLForMarkdown:@"# Heading"];
+
+    // The same loss-of-rendering risk applies to <video>/<audio>/<source>.
+    XCTAssertTrue([html containsString:@"media-src data: file: http: https:"],
+                  @"CSP media-src must allow data:, file:, http:, and https: media");
+}
+
+@end


### PR DESCRIPTION
## Summary

Issue #341 reported that **all** preview images stopped rendering — the `<img>` container lays out at the correct size with styling applied, but the image bits never load — across local-file, web (`http`/`https`), and local-server sources, with no app update preceding the breakage.

Tracing the current codebase, **nothing in MacDown blocks image subresources**: App Transport Security allows arbitrary loads, the preview CSP permits every image scheme (`img-src data: file: http: https:`), the `WebResourceLoadDelegate` only rewrites `MathJax.js` and passes everything else through, and the navigation policy only gates `file://` *navigations* rather than subresource loads. The CSP also didn't exist when the issue was filed, so it can't be the original cause. The most likely real-world trigger is the **deprecated legacy `WebView`** reacting to a macOS system update — which a unit test cannot reproduce, and whose only real fix (migrating to `WKWebView`) is out of scope here per the "keep it small" decision.

This PR therefore adds a **tripwire against the class of regression that is within the code's control**: a future change silently dropping an image source (e.g. a CSP-tightening pass like the preview-hardening work, or a rewrite of the resource-load path).

### Changes
- **`MacDownTests/MPImageRenderingTests.m`** (new) — renders markdown through the live preview path and asserts the full preview HTML:
  - preserves the `<img>` `src` for `http://`, `https://`, relative local-file, `file://`, and `data:` sources;
  - keeps the CSP `img-src` **and** `media-src` directives allowing `data: file: http: https:`.
- **`MacDown 3000.xcodeproj/project.pbxproj`** — registers the new test file in the `MacDownTests` target.
- **`MacDown/Code/Document/MPRenderer.m`** — a comment above `MPPreviewContentSecurityPolicy` documenting that the image schemes must stay allowed, so a future hardening pass doesn't regress them.

No production behavior changes — this is test coverage plus a documentation tripwire.

## Related Issue

Related to #341

## Manual Testing Plan

The automated tests guard the HTML pipeline but cannot exercise the live legacy `WebView`. To verify actual rendering on a Mac:

1. **Setup:** Build and run from this branch. Create a new document.
2. **Web image (https):** `[web](https://www.gnu.org/graphics/heckert_gnu.transp.small.png)` — image should render in the preview pane.
3. **Web image (http):** an `http://` image URL — should render (ATS allows arbitrary loads).
4. **Local file (relative):** save the document, drop a `photo.png` next to it, add `[local](photo.png)` — should render.
5. **Local file (`file://`):** `[abs](file:///full/path/to/photo.png)` — should render.
6. **Data URI:** a small `data:image/png;base64,...` image — should render.
7. **Edge:** confirm the `<img>` lays out at the correct size in every case (the #341 symptom was the container rendering without the image).

**Expected:** images render from every source. If any source fails on a current macOS while the container still lays out, that confirms the legacy-`WebView`/system-level hypothesis and would justify a follow-up `WKWebView` migration.

## Review Notes

- The repo's `/issue` workflow references specialized review agents (Groucho/Zeppo/Chico/Harpo); those subagents weren't available in this session, so the architecture and test-design reasoning was done inline.
- This is intentionally scoped to test coverage + documentation. It does **not** claim to fix a legacy-WebView/macOS-level subresource failure — that limitation is called out so the change isn't mistaken for a complete fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhiCCrJzuw1kUHdG3LKf1G)_