### PR TITLE
Address issue #405: never use the document file as the preview base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fix blank preview for documents with the execute bit set, which some sync clients (e.g. OneDrive) apply to every synced file (#431, #405) -- thanks @maskedspitz, @songjianbupt, and @craigrodger for the diagnosis!
+- Fix blank preview when opening saved or externally-originated documents: the real document file is no longer used as the preview's base resource, which WebKit on macOS 26 can silently refuse to load (e.g. files with the execute bit set by sync clients like OneDrive, or stale TCC/provenance state) (#431, #405) -- thanks @maskedspitz, @songjianbupt, and @craigrodger for the diagnosis!
 - Improve render-path responsiveness: single-pass word/character counting, cached body-extraction regex, and bounded renderer polling with cancellation (#388)
 - Restrict auto-created link targets to the current document's folder scope (#388)
 - Fix line enumeration in scroll sync header scanning to handle `\r\n` and bare `\r` line endings (#388)

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1533,24 +1533,43 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     return [self previewSafeBaseURL:baseUrl];
 }
 
-// Issue #431: On macOS 26, WebKit silently refuses to load file:// preview
-// content whose base resource is an executable file. Some sync clients (notably
-// OneDrive) set the execute bit (0700) on every synced file and revert any
-// manual `chmod -x`, so externally-originated documents render blank even though
-// the editor — which reads bytes via NSDocument, not WebKit — works fine.
+// Issues #405 and #431: On macOS 26, WebKit silently refuses to load file://
+// preview content when the base resource is the real document file, based on
+// file metadata WebKit inspects but the editor — which reads bytes via
+// NSDocument, not WebKit — does not. The preview blanks while the editor works
+// fine. Two known triggers, neither of which lives in the document bytes:
 //
-// When the document file is executable, substitute a non-existent sentinel in
-// the same directory as the base URL. WebKit no longer sees an executable base
-// resource, while everything that actually depends on the base URL — relative
-// resource resolution, MPLocalFilePathsInHTML, cache busting, and the
-// MPURLSecurityPolicy scope check (which keys off the base URL's parent
-// directory) — is unchanged, since the sentinel lives in the same directory.
+//   * The execute bit (0700) that some sync clients (notably OneDrive) set on
+//     every synced file and revert after any manual `chmod -x`.
+//   * Stale TCC / provenance / app-association state carried by a file's inode
+//     and birthtime across its history (issue #431). `xattr -c` cannot clear it
+//     because the relevant attributes are kernel-protected, and copying the
+//     bytes to a fresh inode makes the very same content render correctly.
+//
+// Because there is no reliable runtime signal that a given file will trigger a
+// blank load, and because the base URL is only ever needed for the document's
+// *directory* — relative resource resolution, MPLocalFilePathsInHTML, cache
+// busting, and the MPURLSecurityPolicy scope check (which keys off the base
+// URL's parent directory) — the real document file never needs to be the base
+// resource at all. Whenever the base URL points at a real file, substitute a
+// non-existent sentinel in the same directory. WebKit then never inspects the
+// document file as its base resource, while everything that depends on the
+// directory is unchanged. Directory base URLs (unsaved documents use the default
+// HTML directory), non-existent paths, and non-file URLs are already safe and
+// pass through untouched.
 - (NSURL *)previewSafeBaseURL:(NSURL *)baseURL
 {
     if (!baseURL || !baseURL.isFileURL)
         return baseURL;
-    if (![MPURLSecurityPolicy isExecutableOrAppBundleAtURL:baseURL])
+
+    NSString *path = baseURL.URLByResolvingSymlinksInPath.path;
+    BOOL isDirectory = NO;
+    if (![[NSFileManager defaultManager] fileExistsAtPath:path
+                                              isDirectory:&isDirectory])
         return baseURL;
+    if (isDirectory)
+        return baseURL;
+
     return [baseURL.URLByDeletingLastPathComponent
             URLByAppendingPathComponent:@".macdown-preview-base"];
 }

--- a/MacDownTests/MPDocumentIOTests.m
+++ b/MacDownTests/MPDocumentIOTests.m
@@ -121,17 +121,27 @@
     XCTAssertNil(error, @"No error should occur loading CRLF-terminated content");
 }
 
-- (void)testPreviewSafeBaseURLLeavesNonExecutableFileUnchanged
+- (void)testPreviewSafeBaseURLRewritesRegularFile
 {
-    // Issue #431: a normal (non-executable) document file must be used as-is so
-    // relative resources and security scope behave exactly as before.
+    // Issues #405 / #431: WebKit on macOS 26 can silently blank the preview
+    // based on file metadata it inspects but the editor does not (execute bit,
+    // stale TCC/provenance state). There is no reliable runtime signal for this,
+    // so the real document file is NEVER used as the preview base resource — even
+    // an ordinary, non-executable file is swapped for a non-existent sentinel in
+    // the SAME directory. The directory is all the scope/resolution code needs.
     NSString *content = @"# Test\n";
     [content writeToURL:self.testFileURL atomically:YES
                encoding:NSUTF8StringEncoding error:nil];
 
     NSURL *safe = [self.document previewSafeBaseURL:self.testFileURL];
-    XCTAssertEqualObjects(safe, self.testFileURL,
-        @"Non-executable files should be returned unchanged");
+
+    XCTAssertNotEqualObjects(safe, self.testFileURL,
+        @"A real document file must never be used as the preview base URL");
+    XCTAssertEqualObjects(safe.URLByDeletingLastPathComponent.path,
+                          self.testFileURL.URLByDeletingLastPathComponent.path,
+        @"Sentinel base URL must live in the same directory as the document");
+    XCTAssertFalse([self.fileManager fileExistsAtPath:safe.path],
+        @"Sentinel base URL must not point at a real file");
 }
 
 - (void)testPreviewSafeBaseURLRewritesExecutableFile
@@ -155,6 +165,47 @@
         @"Sentinel base URL must live in the same directory as the document");
     XCTAssertFalse([self.fileManager fileExistsAtPath:safe.path],
         @"Sentinel base URL must not point at a real (executable) file");
+}
+
+- (void)testPreviewSafeBaseURLLeavesDirectoryUnchanged
+{
+    // An unsaved document has no fileURL, so the base URL is the default HTML
+    // directory rather than a document file. A directory is already a safe base
+    // resource (relative resolution uses the directory itself) and must pass
+    // through untouched.
+    NSURL *dirURL = [NSURL fileURLWithPath:self.testDirectory isDirectory:YES];
+
+    NSURL *safe = [self.document previewSafeBaseURL:dirURL];
+    XCTAssertEqualObjects(safe, dirURL,
+        @"Directory base URLs must be returned unchanged");
+}
+
+- (void)testPreviewSafeBaseURLLeavesNonexistentPathUnchanged
+{
+    // A file URL that does not resolve to anything on disk has no real base
+    // resource for WebKit to inspect, so there is nothing to make safe.
+    NSURL *missingURL = [NSURL fileURLWithPath:
+        [self.testDirectory stringByAppendingPathComponent:@"missing.md"]];
+
+    NSURL *safe = [self.document previewSafeBaseURL:missingURL];
+    XCTAssertEqualObjects(safe, missingURL,
+        @"Non-existent file paths must be returned unchanged");
+}
+
+- (void)testPreviewSafeBaseURLLeavesNonFileURLUnchanged
+{
+    // Only file:// base URLs can trigger the WebKit blanking behavior.
+    NSURL *httpURL = [NSURL URLWithString:@"https://example.com/page.html"];
+
+    NSURL *safe = [self.document previewSafeBaseURL:httpURL];
+    XCTAssertEqualObjects(safe, httpURL,
+        @"Non-file URLs must be returned unchanged");
+}
+
+- (void)testPreviewSafeBaseURLLeavesNilUnchanged
+{
+    XCTAssertNil([self.document previewSafeBaseURL:nil],
+        @"A nil base URL must be returned as nil");
 }
 
 - (void)testWritableTypes

--- a/MacDownTests/MPDocumentLifecycleTests.m
+++ b/MacDownTests/MPDocumentLifecycleTests.m
@@ -864,4 +864,35 @@
     }
 }
 
+
+#pragma mark - Opened-File Preview Base URL (Issue #405)
+
+// Simulate the open-file state: the document has a fileURL pointing at a real
+// on-disk .md file, exactly as it does after opening a saved document. The base
+// URL handed to the preview WebView — through the MPRendererDelegate
+// rendererBaseURL: hook that MPRenderer queries before producing HTML — must
+// never be the real document file, because WebKit on macOS 26 can silently blank
+// the preview when its base resource is that file (issues #405 / #431). Full
+// WebView rendering can't be asserted headlessly, but this exercises the
+// document-level base-URL path where the blank-preview bug lives.
+- (void)testRendererBaseURLForOpenedFileAvoidsRealDocumentFile
+{
+    NSString *content = @"# Opened\n\nBody text.\n";
+    [content writeToURL:self.testFileURL atomically:YES
+               encoding:NSUTF8StringEncoding error:nil];
+    self.document.fileURL = self.testFileURL;
+
+    NSURL *base = [(id<MPRendererDelegate>)self.document rendererBaseURL:nil];
+
+    XCTAssertNotNil(base, @"An opened document must still provide a base URL");
+    XCTAssertNotEqualObjects(base, self.testFileURL,
+        @"The opened document's own file must never be the preview base resource");
+    XCTAssertEqualObjects(base.URLByDeletingLastPathComponent.path,
+                          self.testFileURL.URLByDeletingLastPathComponent.path,
+        @"The base URL must stay in the document's directory so relative "
+         "resources and the security scope check are unchanged");
+    XCTAssertFalse([self.fileManager fileExistsAtPath:base.path],
+        @"The base URL must point at a non-existent sentinel, not a real file");
+}
+
 @end


### PR DESCRIPTION
## Summary

A **new** document previews fine, but **opening a saved `.md` file** leaves the preview empty while the editor works. On macOS 26, WebKit silently refuses to load the `file://` preview content when its *base resource* is the real document file, based on metadata WebKit inspects but the editor (which reads bytes via `NSDocument`) does not — e.g. the execute bit set by sync clients like OneDrive (#431/#454), or stale TCC/provenance state carried by a file's inode across its history (#431). There's no signal in the document bytes, so there is no reliable runtime detector.

This generalizes the previously execute-bit-only `previewSafeBaseURL:` so the **real document file is never handed to WebKit as the base resource**. Whenever the base URL points at a real file, a non-existent sentinel in the *same directory* is substituted. The base URL is only ever needed for the document's directory — relative resource resolution, `MPLocalFilePathsInHTML`, cache busting, and the `MPURLSecurityPolicy` scope check (which keys off the parent directory) — so all of that is unchanged, while the broader blank-preview class is covered.

### Changes
- **`MPDocument.m`** — `previewSafeBaseURL:` now substitutes the sentinel for any real file base URL (not just executable ones); directories, non-existent paths, and non-file URLs pass through. Updated the explanatory comment. Single-point change; both preview load paths already route through this method.
- **`MPDocumentIOTests.m`** — unit tests for regular file, executable file, directory, non-existent path, non-file URL, and nil.
- **`MPDocumentLifecycleTests.m`** — opened-file test asserting `rendererBaseURL:` never returns the real document file when a `fileURL` is set.
- **`CHANGELOG.md`** — updated the entry to describe the generalized fix.

## Related Issue

Related to #405 (and the same root cause as #431).

## Manual Testing Plan

On macOS 26 with a sync client (or any file that previously rendered blank on open):
1. Create a new document, type Markdown, confirm the preview renders.
2. Save it as a `.md` file, close the window, reopen the file → the preview should now render (previously empty).
3. Set the execute bit on a saved `.md` file (`chmod +x file.md`) and open it → preview should render.
4. Open a document that references a relative local image (`[](image.png)` alongside the file) → the image should still load, confirming relative resource resolution is unaffected by the sentinel base URL.
5. Edit an opened document → the DOM-replacement fast path should keep working (base URL is deterministic across renders).

## Review Notes

- The key assumption — relative resources still load with a non-existent same-directory sentinel base URL — is already proven and shipped by #454 for executable files; this PR applies the same mechanism to all files.
- `MPURLSecurityPolicy.isExecutableOrAppBundleAtURL:` is still used by the resource security checks, so it remains in use.
- WebView rendering can't be asserted in headless CI, so coverage is at the base-URL / delegate level.

