### PR TITLE
Add regression tests for uppercase [X] task list checkboxes (#369)

### DIFF
--- a/MacDownTests/MPCheckboxToggleTests.m
+++ b/MacDownTests/MPCheckboxToggleTests.m
@@ -326,6 +326,95 @@
                           @"Checkbox with Unicode content should toggle correctly");
 }
 
+#pragma mark - Case Insensitivity (Issue #369)
+
+/**
+ * Test that toggling an uppercase [X] checkbox unchecks it to [ ].
+ */
+- (void)testToggleUppercaseCheckedToUnchecked
+{
+    NSString *markdown = @"- [X] Capital X task\n- [ ] Pending task";
+    NSString *expected = @"- [ ] Capital X task\n- [ ] Pending task";
+
+    NSString *result = [MPDocument toggleCheckboxAtIndex:0 inMarkdown:markdown];
+
+    XCTAssertEqualObjects(result, expected,
+                          @"Uppercase [X] checkbox should toggle to unchecked");
+}
+
+/**
+ * Test that re-checking after an uppercase [X] normalizes to lowercase [x].
+ * Index 1 is the unchecked item, which should become [x] (not [X]).
+ */
+- (void)testReCheckNormalizesToLowercase
+{
+    NSString *markdown = @"- [X] Capital X task\n- [ ] Pending task";
+    NSString *expected = @"- [X] Capital X task\n- [x] Pending task";
+
+    NSString *result = [MPDocument toggleCheckboxAtIndex:1 inMarkdown:markdown];
+
+    XCTAssertEqualObjects(result, expected,
+                          @"Re-checking should write lowercase [x]");
+}
+
+/**
+ * Test that an uppercase [X] occupies an index, keeping subsequent checkboxes
+ * aligned with the renderer. Toggling index 1 must hit the second item, not
+ * skip over the uppercase one.
+ */
+- (void)testUppercaseCheckboxOccupiesIndex
+{
+    NSString *markdown = @"- [X] First (capital)\n- [ ] Second\n- [x] Third";
+    NSString *expected = @"- [X] First (capital)\n- [x] Second\n- [x] Third";
+
+    NSString *result = [MPDocument toggleCheckboxAtIndex:1 inMarkdown:markdown];
+
+    XCTAssertEqualObjects(result, expected,
+                          @"[X] should occupy index 0 so index 1 hits the second item");
+}
+
+/**
+ * Test toggling an uppercase [X] checkbox with an asterisk marker.
+ */
+- (void)testToggleUppercaseCheckboxWithAsteriskMarker
+{
+    NSString *markdown = @"* [X] Asterisk capital task";
+    NSString *expected = @"* [ ] Asterisk capital task";
+
+    NSString *result = [MPDocument toggleCheckboxAtIndex:0 inMarkdown:markdown];
+
+    XCTAssertEqualObjects(result, expected,
+                          @"Asterisk marker [X] checkbox should toggle correctly");
+}
+
+/**
+ * Test toggling an uppercase [X] checkbox with a plus marker.
+ */
+- (void)testToggleUppercaseCheckboxWithPlusMarker
+{
+    NSString *markdown = @"+ [X] Plus capital task";
+    NSString *expected = @"+ [ ] Plus capital task";
+
+    NSString *result = [MPDocument toggleCheckboxAtIndex:0 inMarkdown:markdown];
+
+    XCTAssertEqualObjects(result, expected,
+                          @"Plus marker [X] checkbox should toggle correctly");
+}
+
+/**
+ * Test toggling an uppercase [X] checkbox in a numbered list.
+ */
+- (void)testToggleUppercaseNumberedListCheckbox
+{
+    NSString *markdown = @"1. [X] First numbered\n2. [ ] Second numbered";
+    NSString *expected = @"1. [ ] First numbered\n2. [ ] Second numbered";
+
+    NSString *result = [MPDocument toggleCheckboxAtIndex:0 inMarkdown:markdown];
+
+    XCTAssertEqualObjects(result, expected,
+                          @"Numbered list [X] checkbox should toggle correctly");
+}
+
 #pragma mark - URL Scheme Tests
 
 /**

--- a/MacDownTests/MPMarkdownRenderingTests.m
+++ b/MacDownTests/MPMarkdownRenderingTests.m
@@ -404,6 +404,49 @@
                   @"Third numbered task should have index 2");
 }
 
+/**
+ * Test that an uppercase [X] checkbox renders as a checked checkbox, matching
+ * the GFM spec. Related to GitHub issue #369.
+ */
+- (void)testUppercaseCheckboxRendersChecked
+{
+    self.delegate.extensions = 0;
+    self.renderer.rendererFlags = HOEDOWN_HTML_USE_TASK_LIST;
+    self.dataSource.markdown = @"- [X] Capital X task";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    XCTAssertTrue([html containsString:@"task-list-item"],
+                  @"Uppercase [X] should render as a task-list item, not plain text");
+    XCTAssertTrue([html containsString:@"checked"],
+                  @"Uppercase [X] should render as a checked checkbox");
+    XCTAssertFalse([html containsString:@"[X]"],
+                   @"Uppercase [X] should not appear as literal text");
+}
+
+/**
+ * Test that [x] and [X] share a single sequential index space, so the rendered
+ * data-checkbox-index values stay aligned with the editor-side toggle logic.
+ * Related to GitHub issue #369.
+ */
+- (void)testMixedCaseCheckboxesShareIndexSpace
+{
+    self.delegate.extensions = 0;
+    self.renderer.rendererFlags = HOEDOWN_HTML_USE_TASK_LIST;
+    self.dataSource.markdown = @"- [ ] Lower unchecked\n- [X] Capital checked\n- [x] Lower checked";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer currentHtml];
+
+    XCTAssertTrue([html containsString:@"data-checkbox-index=\"0\""],
+                  @"First checkbox should have index 0");
+    XCTAssertTrue([html containsString:@"data-checkbox-index=\"1\""],
+                  @"Uppercase [X] checkbox should take the next sequential index 1");
+    XCTAssertTrue([html containsString:@"data-checkbox-index=\"2\""],
+                  @"Third checkbox should have index 2");
+}
+
 - (void)testStrikethrough
 {
     // Strikethrough requires the STRIKETHROUGH extension


### PR DESCRIPTION
## Summary

The production fix for #369 (rendering `[X]` task-list checkboxes as checked, and recognizing uppercase markers in the editor-side toggle) **already landed on `main` via #410**. After rebasing, this PR's production changes and golden-fixture update collapsed away — they were equivalent to what #410 introduced.

**This PR now contains only additional regression-test coverage** layered on top of #410's fix:

- **`MPMarkdownRenderingTests.m`**
  - `testUppercaseCheckboxRendersChecked` — `[X]` renders as a `checked` task-list item, not literal text.
  - `testMixedCaseCheckboxesShareIndexSpace` — `[x]` and `[X]` share one sequential `data-checkbox-index` space (guards the renderer ↔ editor-toggle index-alignment invariant).
- **`MPCheckboxToggleTests.m`**
  - Toggle an `[X]` item to unchecked; re-checking normalizes to lowercase `[x]`.
  - `[X]` occupies its index so subsequent toggles stay aligned.
  - Uppercase coverage for `*`, `+`, and numbered-list markers.

No method-name collisions with #410's tests; they run alongside each other.

## Related Issue

Related to #369 (production fix delivered by #410; this PR adds regression coverage).

## Manual Testing Plan

N/A — test-only change. Coverage is validated by the macOS CI test run.

## Review Notes

Kept open intentionally as added regression coverage after #410 resolved the underlying bug.