### PR TITLE
Address issue #443: Color HTML in default editor themes

### DIFF
--- a/MacDown/Resources/Themes/Mou Fresh Air+.style
+++ b/MacDown/Resources/Themes/Mou Fresh Air+.style
@@ -75,6 +75,12 @@ foreground: 008c00
 VERBATIM
 foreground: 008c00
 
+HTML
+foreground: 6c71c4
+
+HTMLBLOCK
+foreground: 6c71c4
+
 HTML_ENTITY
 foreground: 6c71c4
 

--- a/MacDown/Resources/Themes/Mou Fresh Air.style
+++ b/MacDown/Resources/Themes/Mou Fresh Air.style
@@ -68,6 +68,12 @@ foreground: 008c00
 VERBATIM
 foreground: 008c00
 
+HTML
+foreground: 6c71c4
+
+HTMLBLOCK
+foreground: 6c71c4
+
 HTML_ENTITY
 foreground: 6c71c4
 

--- a/MacDown/Resources/Themes/Mou Night+.style
+++ b/MacDown/Resources/Themes/Mou Night+.style
@@ -71,6 +71,12 @@ foreground: cf009a
 VERBATIM
 foreground: cf009a
 
+HTML
+foreground: 6c71c4
+
+HTMLBLOCK
+foreground: 6c71c4
+
 HTML_ENTITY
 foreground: 6c71c4
 

--- a/MacDown/Resources/Themes/Mou Night.style
+++ b/MacDown/Resources/Themes/Mou Night.style
@@ -69,6 +69,12 @@ foreground: cf009a
 VERBATIM
 foreground: cf009a
 
+HTML
+foreground: 6c71c4
+
+HTMLBLOCK
+foreground: 6c71c4
+
 HTML_ENTITY
 foreground: 6c71c4
 

--- a/MacDown/Resources/Themes/Mou Paper+.style
+++ b/MacDown/Resources/Themes/Mou Paper+.style
@@ -66,6 +66,12 @@ foreground: 555555
 VERBATIM
 foreground: 555555
 
+HTML
+foreground: 555555
+
+HTMLBLOCK
+foreground: 555555
+
 HTML_ENTITY
 foreground: 555555
 

--- a/MacDown/Resources/Themes/Mou Paper.style
+++ b/MacDown/Resources/Themes/Mou Paper.style
@@ -57,6 +57,12 @@ foreground: 555555
 VERBATIM
 foreground: 555555
 
+HTML
+foreground: 555555
+
+HTMLBLOCK
+foreground: 555555
+
 HTML_ENTITY
 foreground: 555555
 

--- a/MacDown/Resources/Themes/Solarized (Dark)+.style
+++ b/MacDown/Resources/Themes/Solarized (Dark)+.style
@@ -77,6 +77,12 @@ VERBATIM
 foreground: 93a1a1
 background: 073642
 
+HTML
+foreground: 586e75
+
+HTMLBLOCK
+foreground: 586e75
+
 HTML_ENTITY
 foreground: 586e75
 

--- a/MacDown/Resources/Themes/Solarized (Dark).style
+++ b/MacDown/Resources/Themes/Solarized (Dark).style
@@ -65,6 +65,12 @@ VERBATIM
 foreground: 93a1a1
 background: 073642
 
+HTML
+foreground: 586e75
+
+HTMLBLOCK
+foreground: 586e75
+
 HTML_ENTITY
 foreground: 586e75
 

--- a/MacDown/Resources/Themes/Solarized (Light)+.style
+++ b/MacDown/Resources/Themes/Solarized (Light)+.style
@@ -77,6 +77,12 @@ VERBATIM
 foreground: 586e75
 background: eee8d5
 
+HTML
+foreground: 93a1a1
+
+HTMLBLOCK
+foreground: 93a1a1
+
 HTML_ENTITY
 foreground: 93a1a1
 

--- a/MacDown/Resources/Themes/Solarized (Light).style
+++ b/MacDown/Resources/Themes/Solarized (Light).style
@@ -65,6 +65,12 @@ VERBATIM
 foreground: 586e75
 background: eee8d5
 
+HTML
+foreground: 93a1a1
+
+HTMLBLOCK
+foreground: 93a1a1
+
 HTML_ENTITY
 foreground: 93a1a1
 

--- a/MacDown/Resources/Themes/Tomorrow Blue.style
+++ b/MacDown/Resources/Themes/Tomorrow Blue.style
@@ -69,6 +69,12 @@ foreground: 7285b7
 VERBATIM
 foreground: 7285b7
 
+HTML
+foreground: ebbbff
+
+HTMLBLOCK
+foreground: ebbbff
+
 HTML_ENTITY
 foreground: ebbbff
 

--- a/MacDown/Resources/Themes/Tomorrow+.style
+++ b/MacDown/Resources/Themes/Tomorrow+.style
@@ -71,6 +71,12 @@ foreground: 999999
 VERBATIM
 foreground: 999999
 
+HTML
+foreground: cc99cc
+
+HTMLBLOCK
+foreground: cc99cc
+
 HTML_ENTITY
 foreground: cc99cc
 

--- a/MacDown/Resources/Themes/Tomorrow.style
+++ b/MacDown/Resources/Themes/Tomorrow.style
@@ -69,6 +69,12 @@ foreground: 999999
 VERBATIM
 foreground: 999999
 
+HTML
+foreground: cc99cc
+
+HTMLBLOCK
+foreground: cc99cc
+
 HTML_ENTITY
 foreground: cc99cc
 

--- a/MacDown/Resources/Themes/Writer+.style
+++ b/MacDown/Resources/Themes/Writer+.style
@@ -63,6 +63,12 @@ foreground: 555555
 VERBATIM
 foreground: 555555
 
+HTML
+foreground: 555555
+
+HTMLBLOCK
+foreground: 555555
+
 HTML_ENTITY
 foreground: 555555
 

--- a/MacDown/Resources/Themes/Writer.style
+++ b/MacDown/Resources/Themes/Writer.style
@@ -57,6 +57,12 @@ foreground: 555555
 VERBATIM
 foreground: 555555
 
+HTML
+foreground: 555555
+
+HTMLBLOCK
+foreground: 555555
+
 HTML_ENTITY
 foreground: 555555
 

--- a/MacDownTests/HGMarkdownHighlighterTests.m
+++ b/MacDownTests/HGMarkdownHighlighterTests.m
@@ -12,6 +12,7 @@
 #import "HGMarkdownHighlighter.h"
 #import "HGMarkdownHighlightingStyle.h"
 #import "pmh_definitions.h"
+#import "MPUtilities.h"
 
 
 @interface HGMarkdownHighlighterTests : XCTestCase
@@ -463,6 +464,73 @@
     }
 
     XCTAssertNoThrow([self.highlighter deactivate], @"Should be stable after rapid toggling");
+}
+
+
+#pragma mark - Bundled Theme HTML Coloring Tests (Issue #443)
+
+// Returns the parsed style matching the given element type, or nil if the
+// stylesheet does not define one.
+- (HGMarkdownHighlightingStyle *)styleForType:(pmh_element_type)type
+                                  inStylesheet:(NSString *)stylesheet
+{
+    HGMarkdownHighlighter *hl = [[HGMarkdownHighlighter alloc] init];
+    [hl applyStylesFromStylesheet:stylesheet withErrorHandler:nil];
+    for (HGMarkdownHighlightingStyle *style in hl.styles) {
+        if (style.elementType == type)
+            return style;
+    }
+    return nil;
+}
+
+// Every bundled editor theme should color inline HTML so that markup such as
+// <br> or <span> stands out from body text in the editor.
+- (void)testAllBundledThemesDefineHTMLForegroundColor
+{
+    NSArray *themeNames = MPListEntriesForDirectory(
+        kMPThemesDirectoryName,
+        MPFileNameHasExtensionProcessor(kMPThemeFileExtension));
+    XCTAssertTrue(themeNames.count > 0,
+                  @"Should find bundled editor themes to test");
+
+    for (NSString *name in themeNames) {
+        NSString *stylesheet = MPReadFileOfPath(MPThemePathForName(name));
+        XCTAssertTrue(stylesheet.length > 0,
+                      @"Theme '%@' should have readable content", name);
+
+        HGMarkdownHighlightingStyle *htmlStyle =
+            [self styleForType:pmh_HTML inStylesheet:stylesheet];
+        XCTAssertNotNil(htmlStyle,
+                        @"Theme '%@' should define an HTML style", name);
+        XCTAssertNotNil(htmlStyle.attributesToAdd[NSForegroundColorAttributeName],
+                        @"Theme '%@' HTML style should set a foreground color",
+                        name);
+    }
+}
+
+// Every bundled editor theme should also color block-level HTML (e.g. a
+// <div>...</div> block) so it is visually distinct in the editor.
+- (void)testAllBundledThemesDefineHTMLBlockForegroundColor
+{
+    NSArray *themeNames = MPListEntriesForDirectory(
+        kMPThemesDirectoryName,
+        MPFileNameHasExtensionProcessor(kMPThemeFileExtension));
+    XCTAssertTrue(themeNames.count > 0,
+                  @"Should find bundled editor themes to test");
+
+    for (NSString *name in themeNames) {
+        NSString *stylesheet = MPReadFileOfPath(MPThemePathForName(name));
+        XCTAssertTrue(stylesheet.length > 0,
+                      @"Theme '%@' should have readable content", name);
+
+        HGMarkdownHighlightingStyle *htmlBlockStyle =
+            [self styleForType:pmh_HTMLBLOCK inStylesheet:stylesheet];
+        XCTAssertNotNil(htmlBlockStyle,
+                        @"Theme '%@' should define an HTMLBLOCK style", name);
+        XCTAssertNotNil(htmlBlockStyle.attributesToAdd[NSForegroundColorAttributeName],
+                        @"Theme '%@' HTMLBLOCK style should set a foreground color",
+                        name);
+    }
 }
 
 @end


### PR DESCRIPTION
## Summary

The editor highlighter (peg-markdown-highlight) recognizes two HTML element types that themes can style — `HTML` (inline tags like `<br>`, `<span>`) and `HTMLBLOCK` (block-level HTML such as a `<div>…</div>` block) — but none of the bundled themes defined them, so HTML markup rendered in the default body text color.

This PR colors HTML in all **15** bundled editor themes:

- Adds `HTML` and `HTMLBLOCK` style sections to every bundled `.style` theme.
- Each theme reuses its own existing `HTML_ENTITY` foreground color, so HTML tags, blocks, and entities are styled consistently and the colors are guaranteed in-palette for both light and dark themes.
- Adds a data-driven `XCTest` that enumerates every bundled theme and asserts each defines an `HTML` and `HTMLBLOCK` style with a foreground color — a regression guard against future themes omitting HTML coloring.

No parser changes; this is theme data plus a test. Attribute-level coloring (e.g. distinct colors for tag attributes) is intentionally out of scope, matching the one-color-for-markup behavior requested in the issue.

## Related Issue

Related to #443

## Manual Testing Plan

1. Build and run MacDown on macOS.
2. Open a document containing inline HTML (e.g. `Some text <span>inline</span> and a <br> tag`) and a block of HTML (e.g. a `<div>…</div>` spanning multiple lines).
3. In Preferences → Editor, switch the editor theme through each bundled theme (Mou Fresh Air, Mou Night, Mou Paper, Solarized Light/Dark, Tomorrow, Tomorrow Blue, Writer, and their `+` variants).
4. **Expected:** the HTML tags and HTML block are tinted with the same color the theme uses for HTML entities (e.g. `&amp;`), distinct from surrounding body text, with good contrast on each theme's background.

## Review Notes

- Colors per theme (reused from each theme's `HTML_ENTITY`): Mou Fresh Air / Mou Night → `6c71c4`; Mou Paper / Writer → `555555`; Solarized Dark → `586e75`; Solarized Light → `93a1a1`; Tomorrow → `cc99cc`; Tomorrow Blue → `ebbbff`.
- Tests run on macOS CI only (this is a macOS app).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYHfSKebnyaCZTeTCmiM8d)_