### PR TITLE
Add File menu autosave toggle

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -899,6 +899,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             return NO;
         }
     }
+    else if (action == @selector(toggleAutoSave:))
+    {
+        if ([(id)item isKindOfClass:[NSMenuItem class]])
+            ((NSMenuItem *)item).state = self.preferences.editorAutoSave ?
+                NSControlStateValueOn : NSControlStateValueOff;
+    }
     return result;
 }
 
@@ -2063,6 +2069,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 - (IBAction)toggleEditorPane:(id)sender
 {
     [self toggleSplitterCollapsingEditorPane:YES];
+}
+
+- (IBAction)toggleAutoSave:(id)sender
+{
+    self.preferences.editorAutoSave = !self.preferences.editorAutoSave;
+    [self.preferences synchronize];
 }
 
 - (IBAction)render:(id)sender

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -115,6 +115,12 @@
                                     <action selector="revertDocumentToSaved:" target="-1" id="iJ3-Pv-kwq"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Auto Save" id="aSv-FL-tgl">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleAutoSave:" target="-1" id="aSv-FL-act"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="oOV-6A-wGe"/>
                             <menuItem title="Export" id="5mp-ev-1el">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/MacDownTests/MPDocumentIOTests.m
+++ b/MacDownTests/MPDocumentIOTests.m
@@ -14,6 +14,7 @@
 @property (strong) NSURL *currentBaseUrl;
 - (BOOL)canAutomaticallyCreateLinkedFileAtURL:(NSURL *)url;
 - (NSURL *)previewSafeBaseURL:(NSURL *)baseURL;
+- (IBAction)toggleAutoSave:(id)sender;
 @end
 
 @interface MPDocumentIOTests : XCTestCase
@@ -290,6 +291,44 @@
                    @"MPDocument should not autosave when editorAutoSave is NO");
 
     // Restore
+    prefs.editorAutoSave = original;
+}
+
+- (void)testToggleAutoSaveActionUpdatesPreference
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    BOOL original = prefs.editorAutoSave;
+
+    prefs.editorAutoSave = YES;
+    [self.document toggleAutoSave:nil];
+    XCTAssertFalse(prefs.editorAutoSave,
+                   @"File menu auto-save toggle should disable autosave");
+
+    [self.document toggleAutoSave:nil];
+    XCTAssertTrue(prefs.editorAutoSave,
+                  @"File menu auto-save toggle should re-enable autosave");
+
+    prefs.editorAutoSave = original;
+}
+
+- (void)testToggleAutoSaveMenuValidationReflectsPreference
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    BOOL original = prefs.editorAutoSave;
+    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@"Auto Save"
+                                                  action:@selector(toggleAutoSave:)
+                                           keyEquivalent:@""];
+
+    prefs.editorAutoSave = YES;
+    [self.document validateUserInterfaceItem:item];
+    XCTAssertEqual(item.state, NSControlStateValueOn,
+                   @"Auto-save menu item should be checked when autosave is enabled");
+
+    prefs.editorAutoSave = NO;
+    [self.document validateUserInterfaceItem:item];
+    XCTAssertEqual(item.state, NSControlStateValueOff,
+                   @"Auto-save menu item should be unchecked when autosave is disabled");
+
     prefs.editorAutoSave = original;
 }
 


### PR DESCRIPTION
Adds an **Auto Save** toggle to the File menu, wired to the existing `editorAutoSave` preference (used by `MPDocument.autosavesInPlace`), with standard menu-item validation keeping it checked/unchecked.

This is @yusufm's work from #412, rebased onto current `main` to resolve a conflict in `MPDocumentIOTests.m` (both that PR and a since-merged change added a method declaration to the same test category interface — both are kept). The original commit and authorship are preserved.

Supersedes #412 (which targets a fork branch that can't be updated here). Related to #301.
