### PR TITLE
Address issue #452: Selection character/word count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Show a live word/character/character-no-spaces count for the current editor selection in the count widget, reverting to document totals when nothing is selected (#452)
+
 ### Security
 
 - Restrict auto-created link targets to the current document's folder to prevent unauthorized file creation (#386)

--- a/MacDown 3000.xcodeproj/project.pbxproj
+++ b/MacDown 3000.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		ISSUE16RNDRDEFRBUILDFILE /* MPRenderDeferralTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE16RNDRDEFRFILEREF /* MPRenderDeferralTests.m */; };
 		ISSUE285SMARTQTBUILDFILE /* MPSmartQuoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE285SMARTQTFILEREF /* MPSmartQuoteTests.m */; };
 		ISSUE294WRDCNTBUILDFILE /* MPWordCountUpdateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE294WRDCNTFILEREF /* MPWordCountUpdateTests.m */; };
+		ISSUE452SELCNTBUILDFILE /* MPSelectionCountTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE452SELCNTFILEREF /* MPSelectionCountTests.m */; };
 		ISSUE313TOOLBARBUILDFILE /* MPToolbarControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE313TOOLBARFILEREF /* MPToolbarControllerTests.m */; };
 		ISSUE318STYLERELBUILDFILE /* MPDocumentStyleUpdateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE318STYLERELFILEREF /* MPDocumentStyleUpdateTests.m */; };
 		ISSUE325MJSCRLBUILDFILE /* MPMathJaxScrollTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE325MJSCRLFILEREF /* MPMathJaxScrollTests.m */; };
@@ -598,6 +599,7 @@
 		ISSUE16RNDRDEFRFILEREF /* MPRenderDeferralTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPRenderDeferralTests.m; sourceTree = "<group>"; };
 		ISSUE285SMARTQTFILEREF /* MPSmartQuoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPSmartQuoteTests.m; sourceTree = "<group>"; };
 		ISSUE294WRDCNTFILEREF /* MPWordCountUpdateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPWordCountUpdateTests.m; sourceTree = "<group>"; };
+		ISSUE452SELCNTFILEREF /* MPSelectionCountTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPSelectionCountTests.m; sourceTree = "<group>"; };
 		ISSUE313TOOLBARFILEREF /* MPToolbarControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPToolbarControllerTests.m; sourceTree = "<group>"; };
 		ISSUE318STYLERELFILEREF /* MPDocumentStyleUpdateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPDocumentStyleUpdateTests.m; sourceTree = "<group>"; };
 		ISSUE325MJSCRLFILEREF /* MPMathJaxScrollTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPMathJaxScrollTests.m; sourceTree = "<group>"; };
@@ -978,6 +980,7 @@
 				PHASE1B00000005IMGEXPORT /* MPImageExportTests.m */,
 				ISSUE16RNDRDEFRFILEREF /* MPRenderDeferralTests.m */,
 				ISSUE294WRDCNTFILEREF /* MPWordCountUpdateTests.m */,
+				ISSUE452SELCNTFILEREF /* MPSelectionCountTests.m */,
 				779606A8E0525000200B4EC5 /* MPFileWatcherTests.m */,
 				8579778C7BF70F28920CE089 /* MPResourceWatcherSetTests.m */,
 				8552820CEE8D00E83AEE3897 /* MPHTMLResourceURLsTests.m */,
@@ -1454,6 +1457,7 @@
 				PHASE1BBLD0005IMGEXPORT /* MPImageExportTests.m in Sources */,
 				ISSUE16RNDRDEFRBUILDFILE /* MPRenderDeferralTests.m in Sources */,
 				ISSUE294WRDCNTBUILDFILE /* MPWordCountUpdateTests.m in Sources */,
+				ISSUE452SELCNTBUILDFILE /* MPSelectionCountTests.m in Sources */,
 				ISSUE325MJSCRLBUILDFILE /* MPMathJaxScrollTests.m in Sources */,
 				5AD88BF0766B938F9D61A831 /* MPEditorViewSubstitutionTests.m in Sources */,
 				ISSUE313TOOLBARBUILDFILE /* MPToolbarControllerTests.m in Sources */,

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -237,6 +237,7 @@ typedef NS_ENUM(NSUInteger, MPScrollOwner) {
 @property (strong) NSArray<NSNumber *> *editorHeaderLocations;
 @property (nonatomic) MPScrollOwner scrollOwner;  // Issue #342: Scroll ownership model
 @property (nonatomic) NSTimeInterval lastWordCountUpdate;  // Issue #294: Throttle timestamp
+@property (nonatomic) BOOL showingSelectionCount;  // Issue #452: Widget showing selection counts
 
 // Issue #290: File watching for auto-reload
 @property (strong) MPFileWatcher *fileWatcher;
@@ -383,35 +384,61 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     return (self.previewVisible || self.preferences.editorShowWordCount);
 }
 
+// Issue #452: Build a localized, pluralized count title. The `selected` flag
+// chooses the "… selected" variant of each key.
+- (NSString *)wordCountTitleForKey:(NSString *)key number:(NSUInteger)value
+{
+    NSInteger rule = kJJPluralFormRule.integerValue;
+    return [JJPluralForm pluralStringForNumber:value
+                               withPluralForms:NSLocalizedString(key, @"")
+                               usingPluralRule:rule localizeNumeral:NO];
+}
+
+- (void)applyWordsTitle:(NSUInteger)value selected:(BOOL)selected
+{
+    self.wordsMenuItem.title = [self wordCountTitleForKey:
+        (selected ? @"WORDS_SELECTED_PLURAL_STRING" : @"WORDS_PLURAL_STRING")
+                                                   number:value];
+}
+
+- (void)applyCharactersTitle:(NSUInteger)value selected:(BOOL)selected
+{
+    self.charMenuItem.title = [self wordCountTitleForKey:
+        (selected ? @"CHARACTERS_SELECTED_PLURAL_STRING"
+                  : @"CHARACTERS_PLURAL_STRING")
+                                                  number:value];
+}
+
+- (void)applyCharactersNoSpacesTitle:(NSUInteger)value selected:(BOOL)selected
+{
+    self.charNoSpacesMenuItem.title = [self wordCountTitleForKey:
+        (selected ? @"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING"
+                  : @"CHARACTERS_NO_SPACES_PLURAL_STRING")
+                                                          number:value];
+}
+
+// Issue #452: Document-total setters always store the latest value, but only
+// write the menu titles when the widget isn't showing selection counts — this
+// keeps a throttled updateWordCount from clobbering the selection display.
 - (void)setTotalWords:(NSUInteger)value
 {
     _totalWords = value;
-    NSString *key = NSLocalizedString(@"WORDS_PLURAL_STRING", @"");
-    NSInteger rule = kJJPluralFormRule.integerValue;
-    self.wordsMenuItem.title =
-        [JJPluralForm pluralStringForNumber:value withPluralForms:key
-                            usingPluralRule:rule localizeNumeral:NO];
+    if (!self.showingSelectionCount)
+        [self applyWordsTitle:value selected:NO];
 }
 
 - (void)setTotalCharacters:(NSUInteger)value
 {
     _totalCharacters = value;
-    NSString *key = NSLocalizedString(@"CHARACTERS_PLURAL_STRING", @"");
-    NSInteger rule = kJJPluralFormRule.integerValue;
-    self.charMenuItem.title =
-        [JJPluralForm pluralStringForNumber:value withPluralForms:key
-                            usingPluralRule:rule localizeNumeral:NO];
+    if (!self.showingSelectionCount)
+        [self applyCharactersTitle:value selected:NO];
 }
 
 - (void)setTotalCharactersNoSpaces:(NSUInteger)value
 {
     _totalCharactersNoSpaces = value;
-    NSString *key = NSLocalizedString(@"CHARACTERS_NO_SPACES_PLURAL_STRING",
-                                      @"");
-    NSInteger rule = kJJPluralFormRule.integerValue;
-    self.charNoSpacesMenuItem.title =
-        [JJPluralForm pluralStringForNumber:value withPluralForms:key
-                            usingPluralRule:rule localizeNumeral:NO];
+    if (!self.showingSelectionCount)
+        [self applyCharactersNoSpacesTitle:value selected:NO];
 }
 
 - (void)setAutosaveName:(NSString *)autosaveName
@@ -500,6 +527,10 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
     [center addObserver:self selector:@selector(editorTextDidChange:)
                    name:NSTextDidChangeNotification object:self.editor];
+    // Issue #452: Update the count widget to reflect the editor selection.
+    [center addObserver:self selector:@selector(editorSelectionDidChange:)
+                   name:NSTextViewDidChangeSelectionNotification
+                 object:self.editor];
     // Issue #320: Use block-based observer with mainQueue to guarantee
     // main-thread delivery of NSUserDefaultsDidChangeNotification.
     __weak typeof(self) weakSelf = self;
@@ -1607,6 +1638,46 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     _scrollOwner = MPScrollOwnerEditor;
 }
 
+// Issue #452: When the editor has a non-empty selection, show the selection's
+// word/character/character-no-spaces counts in the count widget; otherwise
+// revert to the document-wide totals.
+- (void)editorSelectionDidChange:(NSNotification *)notification
+{
+    if (!self.preferences.editorShowWordCount)
+        return;
+
+    NSString *string = self.editor.string;
+    NSRange selection = self.editor.selectedRange;
+
+    // Empty selection (caret only), or a stale range during a rapid
+    // edit-and-select race: fall back to document totals.
+    if (selection.length == 0
+            || NSMaxRange(selection) > string.length)
+    {
+        [self refreshDocumentWordCountTitles];
+        return;
+    }
+
+    NSString *selected = [string substringWithRange:selection];
+    DOMNodeTextCount count = MPTextCountForString(selected);
+
+    self.showingSelectionCount = YES;
+    [self applyWordsTitle:count.words selected:YES];
+    [self applyCharactersTitle:count.characters selected:YES];
+    [self applyCharactersNoSpacesTitle:count.characterWithoutSpaces
+                              selected:YES];
+}
+
+// Issue #452: Restore the document-wide totals to the count widget titles.
+- (void)refreshDocumentWordCountTitles
+{
+    self.showingSelectionCount = NO;
+    [self applyWordsTitle:self.totalWords selected:NO];
+    [self applyCharactersTitle:self.totalCharacters selected:NO];
+    [self applyCharactersNoSpacesTitle:self.totalCharactersNoSpaces
+                              selected:NO];
+}
+
 - (void)userDefaultsDidChange:(NSNotification *)notification
 {
     MPRenderer *renderer = self.renderer;
@@ -2298,6 +2369,8 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         {
             self.wordCountWidget.hidden = YES;
             self.editorPaddingBottom.constant = 0.0;
+            // Issue #452: Reset selection mode so re-enabling starts on totals.
+            self.showingSelectionCount = NO;
         }
     }
 

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1646,6 +1646,13 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     if (!self.preferences.editorShowWordCount)
         return;
 
+    // No editor yet (e.g. before the nib loads): nothing is selected.
+    if (!self.editor)
+    {
+        [self refreshDocumentWordCountTitles];
+        return;
+    }
+
     NSString *string = self.editor.string;
     NSRange selection = self.editor.selectedRange;
 

--- a/MacDown/Code/Extension/DOMNode+Text.h
+++ b/MacDown/Code/Extension/DOMNode+Text.h
@@ -18,6 +18,14 @@ struct DOMNodeTextCount
 typedef struct DOMNodeTextCount DOMNodeTextCount;
 
 
+/**
+ * Issue #452: Count words, characters, and characters-without-spaces for an
+ * arbitrary string, using the same algorithm the document-wide word count
+ * applies to DOM text nodes. Used to count the editor's selected text.
+ */
+FOUNDATION_EXPORT DOMNodeTextCount MPTextCountForString(NSString *string);
+
+
 @interface DOMNode (Text)
 
 @property (readonly, nonatomic) DOMNodeTextCount textCount;

--- a/MacDown/Code/Extension/DOMNode+Text.m
+++ b/MacDown/Code/Extension/DOMNode+Text.m
@@ -123,6 +123,20 @@ NS_INLINE MPAccumulatedTextCount MPGetNodeAccumulatedTextCount(DOMNode *node)
 }
 
 
+// Issue #452: Public wrapper so the editor can count its selected text using
+// the exact same per-string algorithm as the document-wide word count.
+DOMNodeTextCount MPTextCountForString(NSString *string)
+{
+    MPAccumulatedTextCount accumulatedCount =
+        MPGetStringAccumulatedTextCount(string);
+    DOMNodeTextCount count;
+    count.words = accumulatedCount.words;
+    count.characters = accumulatedCount.characters;
+    count.characterWithoutSpaces = accumulatedCount.charactersWithoutSpaces;
+    return count;
+}
+
+
 @implementation DOMNode (Text)
 
 - (DOMNodeTextCount)textCount

--- a/MacDown/Localization/en.lproj/Localizable.strings
+++ b/MacDown/Localization/en.lproj/Localizable.strings
@@ -14,6 +14,13 @@
 
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ character (no spaces);%@ characters (no spaces)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ word selected;%@ words selected";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ character selected;%@ characters selected";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ character (no spaces) selected;%@ characters (no spaces) selected";
+
 /* Shell utility installation (Issue #38) */
 "Installation Failed" = "Installation Failed";
 "Installation Successful" = "Installation Successful";

--- a/MacDownTests/MPSelectionCountTests.m
+++ b/MacDownTests/MPSelectionCountTests.m
@@ -1,0 +1,214 @@
+//
+//  MPSelectionCountTests.m
+//  MacDownTests
+//
+//  Tests for Issue #452: Selection character/word count.
+//  Verifies the pure string-counting helper (MPTextCountForString) and the
+//  selection/document display-mode coordination on MPDocument.
+//
+//  Copyright (c) 2026 Tzu-ping Chung. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "MPDocument.h"
+#import "MPPreferences.h"
+#import "DOMNode+Text.h"
+
+
+#pragma mark - Test Category to Expose Private API
+
+@interface MPDocument (SelectionCountTesting)
+@property (nonatomic) NSUInteger totalWords;
+@property (nonatomic) NSUInteger totalCharacters;
+@property (nonatomic) NSUInteger totalCharactersNoSpaces;
+@property (nonatomic) BOOL showingSelectionCount;
+- (void)editorSelectionDidChange:(NSNotification *)notification;
+- (void)refreshDocumentWordCountTitles;
+@end
+
+
+#pragma mark - Test Case
+
+@interface MPSelectionCountTests : XCTestCase
+@property (strong) MPDocument *document;
+@end
+
+
+@implementation MPSelectionCountTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.document = [[MPDocument alloc] init];
+}
+
+- (void)tearDown
+{
+    self.document = nil;
+    [super tearDown];
+}
+
+
+#pragma mark - MPTextCountForString: Core Counting Logic
+
+/**
+ * An empty string counts as zero on all three metrics.
+ */
+- (void)testCountEmptyString
+{
+    DOMNodeTextCount count = MPTextCountForString(@"");
+    XCTAssertEqual(count.words, (NSUInteger)0);
+    XCTAssertEqual(count.characters, (NSUInteger)0);
+    XCTAssertEqual(count.characterWithoutSpaces, (NSUInteger)0);
+}
+
+/**
+ * A nil string is handled gracefully as zero.
+ */
+- (void)testCountNilString
+{
+    DOMNodeTextCount count = MPTextCountForString(nil);
+    XCTAssertEqual(count.words, (NSUInteger)0);
+    XCTAssertEqual(count.characters, (NSUInteger)0);
+    XCTAssertEqual(count.characterWithoutSpaces, (NSUInteger)0);
+}
+
+/**
+ * A simple two-word string: 2 words, 11 characters (incl. the space),
+ * 10 characters excluding the space.
+ */
+- (void)testCountSimpleSentence
+{
+    DOMNodeTextCount count = MPTextCountForString(@"hello world");
+    XCTAssertEqual(count.words, (NSUInteger)2);
+    XCTAssertEqual(count.characters, (NSUInteger)11);
+    XCTAssertEqual(count.characterWithoutSpaces, (NSUInteger)10);
+}
+
+/**
+ * Multiple/leading/trailing spaces do not change the word count, but are
+ * reflected in the character (with spaces) count and excluded from the
+ * no-spaces count.
+ */
+- (void)testCountExtraSpaces
+{
+    DOMNodeTextCount count = MPTextCountForString(@"  hi   there  ");
+    XCTAssertEqual(count.words, (NSUInteger)2);
+    XCTAssertEqual(count.characters, (NSUInteger)14);
+    XCTAssertEqual(count.characterWithoutSpaces, (NSUInteger)7);
+}
+
+/**
+ * Newlines are excluded from the character count (matching the document-wide
+ * algorithm) but words on either side are still counted.
+ */
+- (void)testCountNewlinesExcludedFromCharacters
+{
+    DOMNodeTextCount count = MPTextCountForString(@"a\nb");
+    XCTAssertEqual(count.words, (NSUInteger)2);
+    XCTAssertEqual(count.characters, (NSUInteger)2);
+    XCTAssertEqual(count.characterWithoutSpaces, (NSUInteger)2);
+}
+
+/**
+ * Whitespace-only content has zero words and zero no-space characters, but
+ * non-newline whitespace still contributes to the character count.
+ */
+- (void)testCountWhitespaceOnly
+{
+    DOMNodeTextCount count = MPTextCountForString(@"   \n  ");
+    XCTAssertEqual(count.words, (NSUInteger)0);
+    XCTAssertEqual(count.characters, (NSUInteger)5);   // newline excluded
+    XCTAssertEqual(count.characterWithoutSpaces, (NSUInteger)0);
+}
+
+/**
+ * Single word with no whitespace: all character metrics agree.
+ */
+- (void)testCountSingleWord
+{
+    DOMNodeTextCount count = MPTextCountForString(@"command");
+    XCTAssertEqual(count.words, (NSUInteger)1);
+    XCTAssertEqual(count.characters, (NSUInteger)7);
+    XCTAssertEqual(count.characterWithoutSpaces, (NSUInteger)7);
+}
+
+
+#pragma mark - Display-Mode Coordination
+
+/**
+ * A freshly initialized document is not in selection-display mode.
+ */
+- (void)testShowingSelectionCountDefaultsToNo
+{
+    XCTAssertFalse(self.document.showingSelectionCount,
+                   @"Document should start showing totals, not selection");
+}
+
+/**
+ * refreshDocumentWordCountTitles clears selection-display mode.
+ */
+- (void)testRefreshDocumentTitlesClearsSelectionMode
+{
+    self.document.showingSelectionCount = YES;
+    [self.document refreshDocumentWordCountTitles];
+    XCTAssertFalse(self.document.showingSelectionCount,
+                   @"Refreshing document titles should leave selection mode");
+}
+
+/**
+ * While in selection-display mode, assigning a document total must not be
+ * blocked — the stored value updates even though the title write is skipped.
+ */
+- (void)testTotalsStillStoredWhileShowingSelection
+{
+    self.document.showingSelectionCount = YES;
+    self.document.totalWords = 42;
+    self.document.totalCharacters = 100;
+    self.document.totalCharactersNoSpaces = 80;
+    XCTAssertEqual(self.document.totalWords, (NSUInteger)42);
+    XCTAssertEqual(self.document.totalCharacters, (NSUInteger)100);
+    XCTAssertEqual(self.document.totalCharactersNoSpaces, (NSUInteger)80);
+}
+
+/**
+ * editorSelectionDidChange: must early-return safely when the word-count
+ * preference is disabled, leaving display mode untouched.
+ */
+- (void)testSelectionChangeRespectsDisabledPreference
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    BOOL original = prefs.editorShowWordCount;
+    prefs.editorShowWordCount = NO;
+    @try {
+        XCTAssertNoThrow([self.document editorSelectionDidChange:nil],
+                         @"Should not crash when preference disabled");
+        XCTAssertFalse(self.document.showingSelectionCount);
+    }
+    @finally {
+        prefs.editorShowWordCount = original;
+    }
+}
+
+/**
+ * With no editor (bare document), a selection change resolves to an empty
+ * selection and reverts to document totals without crashing.
+ */
+- (void)testSelectionChangeWithNoEditorRevertsToTotals
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    BOOL original = prefs.editorShowWordCount;
+    prefs.editorShowWordCount = YES;
+    @try {
+        self.document.showingSelectionCount = YES;
+        XCTAssertNoThrow([self.document editorSelectionDidChange:nil],
+                         @"Should not crash without an editor");
+        XCTAssertFalse(self.document.showingSelectionCount,
+                       @"Empty selection should revert to document totals");
+    }
+    @finally {
+        prefs.editorShowWordCount = original;
+    }
+}
+
+@end


### PR DESCRIPTION
## Summary

Adds a live count of the **current editor selection** to the existing bottom count widget. When text is selected, the widget shows the selection's **words**, **characters**, and **characters (no spaces)** — each title carrying a "selected" indicator. When the selection is empty, it reverts to the document-wide totals exactly as before.

This lets users writing length-limited content (e.g. command entries) verify selection length without leaving the app.

### Approach
- Reuses the existing three-item count popup rather than adding new UI, so all three count types are supported automatically and honor whichever type the user has selected in the dropdown. Respects the `editorShowWordCount` preference and reuses the existing localized plural-string machinery.
- Selection counts are computed from the editor's selected substring via a new public `MPTextCountForString()` wrapper over the same per-string algorithm used for the document-wide count, guaranteeing consistent results.
- A `showingSelectionCount` flag ensures a throttled document `updateWordCount` cannot clobber the selection display; document-total setters keep storing values but skip title writes while a selection is shown.

### Changed files
- `MacDown/Code/Extension/DOMNode+Text.{h,m}` — expose `MPTextCountForString()`.
- `MacDown/Code/Document/MPDocument.m` — observe `NSTextViewDidChangeSelectionNotification`; add `editorSelectionDidChange:` / `refreshDocumentWordCountTitles`; refactor count-title writing into `selected:`-aware helpers; nil-editor guard; reset selection mode when the preference is disabled.
- `MacDown/Localization/en.lproj/Localizable.strings` — three new "… selected" plural keys (other locales fall back to English until translated).
- `MacDownTests/MPSelectionCountTests.m` (new, wired into the Xcode project) — unit tests for the pure counting logic and display-mode coordination.
- `CHANGELOG.md` — Unreleased entry.

## Related Issue

Related to #452

## Manual Testing Plan

1. Enable the word count widget (View / preferences) so the count popup is visible at the bottom of the editor.
2. Type some text. With no selection, the popup shows document totals (unchanged behavior).
3. Select a run of text. The popup should switch to the selection's counts, e.g. "12 words selected"; use the dropdown to confirm words / characters / characters (no spaces) all reflect the selection.
4. Extend/shrink the selection (shift-arrow, drag) and confirm the count updates live.
5. Collapse the selection to a caret — the popup reverts to document totals.
6. Select text that spans newlines and includes leading/trailing spaces; confirm characters excludes newlines and characters-no-spaces excludes all whitespace.
7. Type while a selection exists (replacing it) and confirm no stale "selected" title lingers.
8. Toggle the word-count preference off and on; confirm it returns in document-totals mode.

## Review Notes

- Architecture validated against the existing counting code; the change intentionally reuses `MPGetStringAccumulatedTextCount` so selection and document counts use the same algorithm.
- Fresh-eyes code review found no build/behavior defects; its one hardening suggestion (explicit nil-editor guard) is included.
- Tests run on macOS CI only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWi58BoPcxDzFbyTBYnQyf)_