### PR TITLE
Fix preference pane layout for localized text wrapping

### DIFF
--- a/MacDown/Code/Preferences/MPPreferencesViewController.m
+++ b/MacDown/Code/Preferences/MPPreferencesViewController.m
@@ -28,17 +28,29 @@ NSString * const MPDidRequestEditorSetupNotification =
     [super loadView];  // loads NIB named after the concrete subclass
 
     NSView *contentView = self.view;
-    NSRect frame = contentView.frame;
-
-    NSView *wrapper = [[NSView alloc] initWithFrame:frame];
+    NSRect designFrame = contentView.frame;
     contentView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // Keep the panel's designed width, then measure the height the content
+    // actually needs at that width for the active locale. Longer localized
+    // strings (e.g. French, Italian) wrap onto extra lines, so the panel must
+    // grow vertically to fit them instead of clipping. The English design
+    // height acts as a floor so we never shrink a panel.
+    CGFloat width = NSWidth(designFrame);
+    NSLayoutConstraint *widthConstraint =
+        [contentView.widthAnchor constraintEqualToConstant:width];
+    widthConstraint.active = YES;
+    [contentView layoutSubtreeIfNeeded];
+    CGFloat height = MAX(contentView.fittingSize.height, NSHeight(designFrame));
+
+    NSView *wrapper =
+        [[NSView alloc] initWithFrame:NSMakeRect(0.0, 0.0, width, height)];
     [wrapper addSubview:contentView];
 
     [NSLayoutConstraint activateConstraints:@[
         [contentView.centerXAnchor constraintEqualToAnchor:wrapper.centerXAnchor],
         [contentView.centerYAnchor constraintEqualToAnchor:wrapper.centerYAnchor],
-        [contentView.widthAnchor  constraintEqualToConstant:NSWidth(frame)],
-        [contentView.heightAnchor constraintEqualToConstant:NSHeight(frame)],
+        [contentView.heightAnchor constraintEqualToConstant:height],
     ]];
 
     self.view = wrapper;

--- a/MacDown/Code/Preferences/MPPreferencesViewController.m
+++ b/MacDown/Code/Preferences/MPPreferencesViewController.m
@@ -32,6 +32,15 @@ NSString * const MPDidRequestEditorSetupNotification =
 
     NSView *wrapper = [[NSView alloc] initWithFrame:frame];
     contentView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // When the NIB loaded, NSViewController linked the content view's next
+    // responder back to this controller. Re-homing the content view inside a
+    // wrapper and then re-pointing -view at that wrapper leaves a responder
+    // cycle, which trips "The next responder should never be yourself!" the
+    // first time the responder chain is traversed (e.g. during layout in a
+    // unit test). Detach the link before re-homing, then restore a clean
+    // chain (content -> wrapper -> controller) afterward.
+    contentView.nextResponder = nil;
     [wrapper addSubview:contentView];
 
     // Keep the panel's designed width and start at the designed height. The
@@ -46,6 +55,7 @@ NSString * const MPDidRequestEditorSetupNotification =
     ]];
 
     self.view = wrapper;
+    contentView.nextResponder = wrapper;
 
     // Now that the content is wrapped at its designed width, grow the height to
     // fit the content for the active locale: longer localized strings (e.g.

--- a/MacDown/Code/Preferences/MPPreferencesViewController.m
+++ b/MacDown/Code/Preferences/MPPreferencesViewController.m
@@ -32,15 +32,6 @@ NSString * const MPDidRequestEditorSetupNotification =
 
     NSView *wrapper = [[NSView alloc] initWithFrame:frame];
     contentView.translatesAutoresizingMaskIntoConstraints = NO;
-
-    // When the NIB loaded, NSViewController linked the content view's next
-    // responder back to this controller. Re-homing the content view inside a
-    // wrapper and then re-pointing -view at that wrapper leaves a responder
-    // cycle, which trips "The next responder should never be yourself!" the
-    // first time the responder chain is traversed (e.g. during layout in a
-    // unit test). Detach the link before re-homing, then restore a clean
-    // chain (content -> wrapper -> controller) afterward.
-    contentView.nextResponder = nil;
     [wrapper addSubview:contentView];
 
     // Keep the panel's designed width and start at the designed height. The
@@ -55,7 +46,6 @@ NSString * const MPDidRequestEditorSetupNotification =
     ]];
 
     self.view = wrapper;
-    contentView.nextResponder = wrapper;
 
     // Now that the content is wrapped at its designed width, grow the height to
     // fit the content for the active locale: longer localized strings (e.g.
@@ -69,6 +59,21 @@ NSString * const MPDidRequestEditorSetupNotification =
     NSRect wrapperFrame = wrapper.frame;
     wrapperFrame.size.height = height;
     wrapper.frame = wrapperFrame;
+}
+
+- (void)dealloc
+{
+    // -loadView wraps the NIB's content view in a centering wrapper, which
+    // leaves the responder chain routed through this controller. When the
+    // controller is later deallocated, NSViewController's own teardown tries to
+    // splice itself out of that chain and can hit "The next responder should
+    // never be yourself!". Detaching both ends of the link first makes the
+    // superclass cleanup a no-op. (In the running app the preference panes are
+    // retained for the process lifetime, so this only bites short-lived
+    // instances such as those created in unit tests.)
+    self.nextResponder = nil;
+    if (self.isViewLoaded)
+        self.view.nextResponder = nil;
 }
 
 - (BOOL)hasResizableWidth  { return YES; }

--- a/MacDown/Code/Preferences/MPPreferencesViewController.m
+++ b/MacDown/Code/Preferences/MPPreferencesViewController.m
@@ -28,32 +28,37 @@ NSString * const MPDidRequestEditorSetupNotification =
     [super loadView];  // loads NIB named after the concrete subclass
 
     NSView *contentView = self.view;
-    NSRect designFrame = contentView.frame;
+    NSRect frame = contentView.frame;
+
+    NSView *wrapper = [[NSView alloc] initWithFrame:frame];
     contentView.translatesAutoresizingMaskIntoConstraints = NO;
-
-    // Keep the panel's designed width, then measure the height the content
-    // actually needs at that width for the active locale. Longer localized
-    // strings (e.g. French, Italian) wrap onto extra lines, so the panel must
-    // grow vertically to fit them instead of clipping. The English design
-    // height acts as a floor so we never shrink a panel.
-    CGFloat width = NSWidth(designFrame);
-    NSLayoutConstraint *widthConstraint =
-        [contentView.widthAnchor constraintEqualToConstant:width];
-    widthConstraint.active = YES;
-    [contentView layoutSubtreeIfNeeded];
-    CGFloat height = MAX(contentView.fittingSize.height, NSHeight(designFrame));
-
-    NSView *wrapper =
-        [[NSView alloc] initWithFrame:NSMakeRect(0.0, 0.0, width, height)];
     [wrapper addSubview:contentView];
 
+    // Keep the panel's designed width and start at the designed height. The
+    // height is grown below once the content has been laid out.
+    NSLayoutConstraint *heightConstraint =
+        [contentView.heightAnchor constraintEqualToConstant:NSHeight(frame)];
     [NSLayoutConstraint activateConstraints:@[
         [contentView.centerXAnchor constraintEqualToAnchor:wrapper.centerXAnchor],
         [contentView.centerYAnchor constraintEqualToAnchor:wrapper.centerYAnchor],
-        [contentView.heightAnchor constraintEqualToConstant:height],
+        [contentView.widthAnchor  constraintEqualToConstant:NSWidth(frame)],
+        heightConstraint,
     ]];
 
     self.view = wrapper;
+
+    // Now that the content is wrapped at its designed width, grow the height to
+    // fit the content for the active locale: longer localized strings (e.g.
+    // French, Italian) wrap onto extra lines, so the panel must expand to fit
+    // them instead of clipping. The English design height acts as a floor so we
+    // never shrink a panel.
+    [wrapper layoutSubtreeIfNeeded];
+    CGFloat height = MAX(contentView.fittingSize.height, NSHeight(frame));
+    heightConstraint.constant = height;
+
+    NSRect wrapperFrame = wrapper.frame;
+    wrapperFrame.size.height = height;
+    wrapper.frame = wrapperFrame;
 }
 
 - (BOOL)hasResizableWidth  { return YES; }

--- a/MacDown/Localization/Base.lproj/MPEditorPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPEditorPreferencesViewController.xib
@@ -354,7 +354,6 @@
                 <constraint firstItem="77u-zZ-bC0" firstAttribute="leading" secondItem="3ow-hg-Gmo" secondAttribute="trailing" constant="5" id="6Tk-8W-iSy"/>
                 <constraint firstItem="77u-zZ-bC0" firstAttribute="top" secondItem="uUN-8R-G1c" secondAttribute="top" id="7tN-YB-ZdQ"/>
                 <constraint firstItem="6JP-Pc-JFd" firstAttribute="centerX" secondItem="Hz6-mo-xeY" secondAttribute="centerX" id="80z-Pl-92m"/>
-                <constraint firstItem="6JP-Pc-JFd" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="17" id="397-ld-box"/>
                 <constraint firstItem="g0N-qr-H8K" firstAttribute="leading" secondItem="JZh-8k-zMC" secondAttribute="leading" id="8Oh-FM-4u7"/>
                 <constraint firstItem="jde-Kw-4ly" firstAttribute="leading" secondItem="JZh-8k-zMC" secondAttribute="trailing" constant="8" symbolic="YES" id="8tY-NH-DnD"/>
                 <constraint firstItem="lt1-Up-OVO" firstAttribute="leading" secondItem="pwq-Pg-zCk" secondAttribute="leading" id="BD0-LL-mdF"/>

--- a/MacDown/Localization/Base.lproj/MPEditorPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPEditorPreferencesViewController.xib
@@ -184,7 +184,7 @@
                 </stepper>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="JV2-Ef-pKx">
                     <rect key="frame" x="18" y="246" width="144" height="18"/>
-                    <buttonCell key="cell" type="check" title="Limit editor width to" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="bhL-NA-9No">
+                    <buttonCell key="cell" type="check" title="Limit editor width to" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="bhL-NA-9No">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -251,7 +251,7 @@
                         <subviews>
                             <button verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Hdc-ZZ-0Bg">
                                 <rect key="frame" x="16" y="137" width="415" height="18"/>
-                                <buttonCell key="cell" type="check" title="Insert spaces instead of tabs" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="XSN-mi-gbk">
+                                <buttonCell key="cell" type="check" title="Insert spaces instead of tabs" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="XSN-mi-gbk">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -261,7 +261,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="nxG-74-mdM">
                                 <rect key="frame" x="16" y="117" width="415" height="18"/>
-                                <buttonCell key="cell" type="check" title="Auto-complete matching characters" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="o4K-iG-sGA">
+                                <buttonCell key="cell" type="check" title="Auto-complete matching characters" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="o4K-iG-sGA">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -271,7 +271,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="NV7-zh-ydN">
                                 <rect key="frame" x="16" y="77" width="415" height="18"/>
-                                <buttonCell key="cell" type="check" title="⌘← jumps to first non-whitespace character in line" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2Yf-FT-MDH">
+                                <buttonCell key="cell" type="check" title="⌘← jumps to first non-whitespace character in line" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2Yf-FT-MDH">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -281,7 +281,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="B3N-s7-0vd">
                                 <rect key="frame" x="16" y="57" width="415" height="18"/>
-                                <buttonCell key="cell" type="check" title="Scroll past end" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="nBR-LK-G9a">
+                                <buttonCell key="cell" type="check" title="Scroll past end" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="nBR-LK-G9a">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -291,7 +291,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="tes-GA-Mpn">
                                 <rect key="frame" x="16" y="37" width="415" height="18"/>
-                                <buttonCell key="cell" type="check" title="Ensure newline at end of file on save" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="9Wp-5V-GeQ">
+                                <buttonCell key="cell" type="check" title="Ensure newline at end of file on save" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="9Wp-5V-GeQ">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -301,7 +301,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="hSa-rl-wPT">
                                 <rect key="frame" x="16" y="17" width="415" height="18"/>
-                                <buttonCell key="cell" type="check" title="Auto-increment numbering in ordered lists" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="UPm-G1-Bc6">
+                                <buttonCell key="cell" type="check" title="Auto-increment numbering in ordered lists" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="UPm-G1-Bc6">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -312,7 +312,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="CXK-QF-WSK">
                                 <rect key="frame" x="16" y="97" width="415" height="18"/>
-                                <buttonCell key="cell" type="check" title="Automatically insert line prefix for the current block" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="zGb-kg-2CJ">
+                                <buttonCell key="cell" type="check" title="Automatically insert line prefix for the current block" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="zGb-kg-2CJ">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -343,11 +343,9 @@
                             <constraint firstItem="NV7-zh-ydN" firstAttribute="top" secondItem="CXK-QF-WSK" secondAttribute="bottom" constant="6" symbolic="YES" id="oAM-9C-rnP"/>
                             <constraint firstItem="Hdc-ZZ-0Bg" firstAttribute="leading" secondItem="nxG-74-mdM" secondAttribute="leading" id="pGd-1r-h4g"/>
                             <constraint firstItem="B3N-s7-0vd" firstAttribute="top" secondItem="NV7-zh-ydN" secondAttribute="bottom" constant="6" symbolic="YES" id="z6Q-dF-r1X"/>
+                            <constraint firstAttribute="bottom" secondItem="hSa-rl-wPT" secondAttribute="bottom" constant="10" id="397-bm-hSa"/>
                         </constraints>
                     </view>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="200" id="8f4-Vw-KzM"/>
-                    </constraints>
                 </box>
             </subviews>
             <constraints>

--- a/MacDown/Localization/Base.lproj/MPEditorPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPEditorPreferencesViewController.xib
@@ -354,6 +354,7 @@
                 <constraint firstItem="77u-zZ-bC0" firstAttribute="leading" secondItem="3ow-hg-Gmo" secondAttribute="trailing" constant="5" id="6Tk-8W-iSy"/>
                 <constraint firstItem="77u-zZ-bC0" firstAttribute="top" secondItem="uUN-8R-G1c" secondAttribute="top" id="7tN-YB-ZdQ"/>
                 <constraint firstItem="6JP-Pc-JFd" firstAttribute="centerX" secondItem="Hz6-mo-xeY" secondAttribute="centerX" id="80z-Pl-92m"/>
+                <constraint firstItem="6JP-Pc-JFd" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="17" id="397-ld-box"/>
                 <constraint firstItem="g0N-qr-H8K" firstAttribute="leading" secondItem="JZh-8k-zMC" secondAttribute="leading" id="8Oh-FM-4u7"/>
                 <constraint firstItem="jde-Kw-4ly" firstAttribute="leading" secondItem="JZh-8k-zMC" secondAttribute="trailing" constant="8" symbolic="YES" id="8tY-NH-DnD"/>
                 <constraint firstItem="lt1-Up-OVO" firstAttribute="leading" secondItem="pwq-Pg-zCk" secondAttribute="leading" id="BD0-LL-mdF"/>

--- a/MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib
@@ -27,7 +27,7 @@
                         <subviews>
                             <button enabled="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jet-bG-trd">
                                 <rect key="frame" x="16" y="12" width="285" height="18"/>
-                                <buttonCell key="cell" type="check" title="Include pre-releases (unavailable)" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="vbz-fv-8BX">
+                                <buttonCell key="cell" type="check" title="Include pre-releases (unavailable)" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="vbz-fv-8BX">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -54,7 +54,7 @@
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="6Nz-Ft-FbR">
                                 <rect key="frame" x="16" y="113" width="285" height="18"/>
-                                <buttonCell key="cell" type="check" title="Update preview automatically as you type" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="npz-xj-plX">
+                                <buttonCell key="cell" type="check" title="Update preview automatically as you type" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="npz-xj-plX">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -69,7 +69,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="Vab-4T-IU5">
                                 <rect key="frame" x="16" y="93" width="285" height="18"/>
-                                <buttonCell key="cell" type="check" title="Sync preview scrollbar when editor scrolls" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2Uj-Sx-FjV">
+                                <buttonCell key="cell" type="check" title="Sync preview scrollbar when editor scrolls" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2Uj-Sx-FjV">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -79,7 +79,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="fjb-tU-1Kw">
                                 <rect key="frame" x="16" y="73" width="285" height="18"/>
-                                <buttonCell key="cell" type="check" title="Put editor on the right" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="bUn-PQ-5Ez">
+                                <buttonCell key="cell" type="check" title="Put editor on the right" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="bUn-PQ-5Ez">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -89,7 +89,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="V1d-g4-bk8">
                                 <rect key="frame" x="16" y="53" width="285" height="18"/>
-                                <buttonCell key="cell" type="check" title="Start in preview mode" bezelStyle="regularSquare" imagePosition="left" state="off" inset="2" id="aYQ-0c-EOQ">
+                                <buttonCell key="cell" type="check" title="Start in preview mode" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="off" inset="2" id="aYQ-0c-EOQ">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -99,7 +99,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="WVd-hz-Dcr">
                                 <rect key="frame" x="16" y="33" width="285" height="18"/>
-                                <buttonCell key="cell" type="check" title="Show word count" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oeW-bF-ybW">
+                                <buttonCell key="cell" type="check" title="Show word count" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oeW-bF-ybW">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -114,7 +114,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="hqr-gd-6gi">
                                 <rect key="frame" x="16" y="153" width="285" height="18"/>
-                                <buttonCell key="cell" type="check" title="Ensure open document on launch" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="l9N-wk-WRY">
+                                <buttonCell key="cell" type="check" title="Ensure open document on launch" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="l9N-wk-WRY">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -129,7 +129,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="UZT-HE-EaK">
                                 <rect key="frame" x="16" y="12" width="285" height="18"/>
-                                <buttonCell key="cell" type="check" title="Automatically create files for link targets" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="hpF-zP-3cM">
+                                <buttonCell key="cell" type="check" title="Automatically create files for link targets" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="hpF-zP-3cM">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -139,7 +139,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="aSv-Qd-7kR">
                                 <rect key="frame" x="16" y="133" width="285" height="18"/>
-                                <buttonCell key="cell" type="check" title="Auto-save and auto-reload documents" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aSv-Bc-cel">
+                                <buttonCell key="cell" type="check" title="Auto-save and auto-reload documents" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aSv-Bc-cel">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>

--- a/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
@@ -76,7 +76,7 @@
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="Zna-RM-nBO">
                     <rect key="frame" x="106" y="295" width="281" height="18"/>
-                    <buttonCell key="cell" type="check" title="Syntax highlighted code block" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="BuQ-02-oQB">
+                    <buttonCell key="cell" type="check" title="Syntax highlighted code block" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="BuQ-02-oQB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -120,7 +120,7 @@
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="ysT-Br-eSf">
                     <rect key="frame" x="127" y="221" width="260" height="18"/>
-                    <buttonCell key="cell" type="check" title="Show line numbers" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="WZa-V6-vvf">
+                    <buttonCell key="cell" type="check" title="Show line numbers" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="WZa-V6-vvf">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="smallSystem"/>
                     </buttonCell>
@@ -131,7 +131,7 @@
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="Qe1-sK-Yxe">
                     <rect key="frame" x="247" y="221" width="69" height="18"/>
-                    <buttonCell key="cell" type="check" title="Graphviz" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="Lnj-HG-QHi">
+                    <buttonCell key="cell" type="check" title="Graphviz" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="Lnj-HG-QHi">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="smallSystem"/>
                     </buttonCell>
@@ -142,7 +142,7 @@
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="bWg-uC-6W8">
                     <rect key="frame" x="318" y="221" width="68" height="18"/>
-                    <buttonCell key="cell" type="check" title="Mermaid" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="bda-Ft-ecb">
+                    <buttonCell key="cell" type="check" title="Mermaid" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="bda-Ft-ecb">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="smallSystem"/>
                     </buttonCell>
@@ -153,7 +153,7 @@
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="5mI-gS-xH9">
                     <rect key="frame" x="106" y="197" width="281" height="18"/>
-                    <buttonCell key="cell" type="check" title="TeX-like math syntax" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="6vg-3f-KWk">
+                    <buttonCell key="cell" type="check" title="TeX-like math syntax" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="6vg-3f-KWk">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -171,7 +171,7 @@
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="u5h-MS-cR3">
                     <rect key="frame" x="127" y="176" width="260" height="18"/>
-                    <buttonCell key="cell" type="check" title="Use dollar sign ($) as inline delimiter" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="GF9-Dm-IoB">
+                    <buttonCell key="cell" type="check" title="Use dollar sign ($) as inline delimiter" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="GF9-Dm-IoB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="smallSystem"/>
                     </buttonCell>
@@ -182,7 +182,7 @@
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="P7Z-ag-nPR">
                     <rect key="frame" x="106" y="133" width="281" height="18"/>
-                    <buttonCell key="cell" type="check" title="Task list syntax" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="kBf-iW-HlH">
+                    <buttonCell key="cell" type="check" title="Task list syntax" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="kBf-iW-HlH">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -192,7 +192,7 @@
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="hfI-Rf-3Cr">
                     <rect key="frame" x="106" y="113" width="281" height="18"/>
-                    <buttonCell key="cell" type="check" title="Hide YAML front matter" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="iXi-Pv-mFl">
+                    <buttonCell key="cell" type="check" title="Hide YAML front matter" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="iXi-Pv-mFl">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -202,7 +202,7 @@
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="6BB-rh-ZwZ">
                     <rect key="frame" x="106" y="93" width="281" height="18"/>
-                    <buttonCell key="cell" type="check" title="Detect table of contents token" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="nvS-dZ-eHT">
+                    <buttonCell key="cell" type="check" title="Detect table of contents token" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="nvS-dZ-eHT">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -212,7 +212,7 @@
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="lxX-Pm-dhn">
                     <rect key="frame" x="106" y="73" width="281" height="18"/>
-                    <buttonCell key="cell" type="check" title="Render newline literally" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Sty-qG-J6K">
+                    <buttonCell key="cell" type="check" title="Render newline literally" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Sty-qG-J6K">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -222,7 +222,7 @@
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="RCL-iK-kgx">
                     <rect key="frame" x="106" y="53" width="281" height="18"/>
-                    <buttonCell key="cell" type="check" title="Scale preview based on editor font size" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aWw-Wb-pBl">
+                    <buttonCell key="cell" type="check" title="Scale preview based on editor font size" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aWw-Wb-pBl">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -277,7 +277,7 @@
                 <constraint firstAttribute="trailing" secondItem="bih-Hu-dSj" secondAttribute="trailing" constant="20" id="9gU-rZ-Jh2"/>
                 <constraint firstItem="6BB-rh-ZwZ" firstAttribute="trailing" secondItem="RCL-iK-kgx" secondAttribute="trailing" id="ASs-te-jBE"/>
                 <constraint firstItem="RCL-iK-kgx" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="108" id="CtD-Eh-Skz"/>
-                <constraint firstItem="0ez-nk-c3q" firstAttribute="width" secondItem="f62-wu-Z6p" secondAttribute="width" id="Dr9-sw-xuw"/>
+                <constraint firstItem="0ez-nk-c3q" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="397-ld-css"/>
                 <constraint firstItem="6BB-rh-ZwZ" firstAttribute="leading" secondItem="RCL-iK-kgx" secondAttribute="leading" id="Ec3-wV-wvF"/>
                 <constraint firstItem="f62-wu-Z6p" firstAttribute="top" secondItem="RCL-iK-kgx" secondAttribute="bottom" constant="18" id="Efm-pX-TpX"/>
                 <constraint firstItem="bih-Hu-dSj" firstAttribute="centerY" secondItem="f62-wu-Z6p" secondAttribute="centerY" id="G5f-va-qLZ"/>
@@ -303,7 +303,6 @@
                 <constraint firstItem="lxX-Pm-dhn" firstAttribute="trailing" secondItem="RCL-iK-kgx" secondAttribute="trailing" id="aU1-Lx-0W1"/>
                 <constraint firstItem="vVI-g8-EhH" firstAttribute="centerY" secondItem="M0W-YD-Ouk" secondAttribute="centerY" id="bnP-5M-kyi"/>
                 <constraint firstItem="bih-Hu-dSj" firstAttribute="leading" secondItem="f62-wu-Z6p" secondAttribute="trailing" constant="8" id="ejW-lN-d1f"/>
-                <constraint firstItem="0ez-nk-c3q" firstAttribute="trailing" secondItem="f62-wu-Z6p" secondAttribute="trailing" id="fLc-Tu-YjS"/>
                 <constraint firstItem="RCL-iK-kgx" firstAttribute="leading" secondItem="5mI-gS-xH9" secondAttribute="leading" id="fcQ-VR-b98"/>
                 <constraint firstItem="f62-wu-Z6p" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="fpW-YQ-VfI"/>
                 <constraint firstItem="hfI-Rf-3Cr" firstAttribute="trailing" secondItem="RCL-iK-kgx" secondAttribute="trailing" id="hTq-GU-Cn7"/>

--- a/MacDown/Localization/Base.lproj/MPMarkdownPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPMarkdownPreferencesViewController.xib
@@ -24,7 +24,7 @@
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="J8u-0k-Z3s">
                                 <rect key="frame" x="16" y="32" width="147" height="18"/>
-                                <buttonCell key="cell" type="check" title="Table" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="z8g-3M-hbc">
+                                <buttonCell key="cell" type="check" title="Table" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="z8g-3M-hbc">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -34,7 +34,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="fhk-gr-iF0">
                                 <rect key="frame" x="16" y="12" width="147" height="18"/>
-                                <buttonCell key="cell" type="check" title="Fenced code block" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ELg-sx-vIf">
+                                <buttonCell key="cell" type="check" title="Fenced code block" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ELg-sx-vIf">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -66,7 +66,7 @@
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="iwB-ah-rER">
                                 <rect key="frame" x="16" y="132" width="149" height="18"/>
-                                <buttonCell key="cell" type="check" title="Strikethrough" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="RjP-zE-c6b">
+                                <buttonCell key="cell" type="check" title="Strikethrough" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="RjP-zE-c6b">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -76,7 +76,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="CCI-wC-lHw">
                                 <rect key="frame" x="16" y="112" width="149" height="18"/>
-                                <buttonCell key="cell" type="check" title="Underline" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Gdr-Ro-ZnW">
+                                <buttonCell key="cell" type="check" title="Underline" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Gdr-Ro-ZnW">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -86,7 +86,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="gtf-xR-sKM">
                                 <rect key="frame" x="16" y="92" width="149" height="18"/>
-                                <buttonCell key="cell" type="check" title="Quote" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2lB-hq-5eX">
+                                <buttonCell key="cell" type="check" title="Quote" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2lB-hq-5eX">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -96,7 +96,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="tqY-25-uOh">
                                 <rect key="frame" x="16" y="152" width="149" height="18"/>
-                                <buttonCell key="cell" type="check" title="Intra-word emphasis" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="D7l-nP-P0y">
+                                <buttonCell key="cell" type="check" title="Intra-word emphasis" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="D7l-nP-P0y">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -106,7 +106,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="lYF-J6-3YU">
                                 <rect key="frame" x="16" y="52" width="149" height="18"/>
-                                <buttonCell key="cell" type="check" title="Superscript" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="k2n-VN-cKT">
+                                <buttonCell key="cell" type="check" title="Superscript" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="k2n-VN-cKT">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -116,7 +116,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="QMR-TV-GNi">
                                 <rect key="frame" x="16" y="72" width="149" height="18"/>
-                                <buttonCell key="cell" type="check" title="Highlight" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="8kI-gm-5Lo">
+                                <buttonCell key="cell" type="check" title="Highlight" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="8kI-gm-5Lo">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -126,7 +126,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="T31-Sx-beD">
                                 <rect key="frame" x="16" y="32" width="149" height="18"/>
-                                <buttonCell key="cell" type="check" title="Autolink" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Roe-rh-8f9">
+                                <buttonCell key="cell" type="check" title="Autolink" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Roe-rh-8f9">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -136,7 +136,7 @@
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="Y8p-KQ-Vis">
                                 <rect key="frame" x="16" y="12" width="149" height="18"/>
-                                <buttonCell key="cell" type="check" title="Footnote" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="0yU-vT-72e">
+                                <buttonCell key="cell" type="check" title="Footnote" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="0yU-vT-72e">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
@@ -184,7 +184,7 @@
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="rDS-Bm-rxW">
                                 <rect key="frame" x="16" y="12" width="101" height="18"/>
-                                <buttonCell key="cell" type="check" title="Smartypants" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aSK-nR-xMr">
+                                <buttonCell key="cell" type="check" title="Smartypants" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aSK-nR-xMr">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>

--- a/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
+++ b/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
@@ -7,11 +7,65 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <Cocoa/Cocoa.h>
+#import "MPPreferencesViewController.h"
 #import "MPGeneralPreferencesViewController.h"
 #import "MPMarkdownPreferencesViewController.h"
 #import "MPEditorPreferencesViewController.h"
 #import "MPHtmlPreferencesViewController.h"
 #import "MPTerminalPreferencesViewController.h"
+
+#pragma mark - View-tree helpers
+
+/// Recursively gathers every descendant of @c view (including @c view itself)
+/// that is a kind of @c cls. NSBox content views are reached because an
+/// NSBox lists its content view among its subviews.
+static void MPCollectViews(NSView *view, Class cls, NSMutableArray *out)
+{
+    if ([view isKindOfClass:cls])
+        [out addObject:view];
+    for (NSView *sub in view.subviews)
+        MPCollectViews(sub, cls, out);
+}
+
+/// Returns the first descendant (including @c view) with ambiguous layout, or
+/// nil if the whole tree is unambiguous.
+static NSView *MPFirstAmbiguousView(NSView *view)
+{
+    if (view.hasAmbiguousLayout)
+        return view;
+    for (NSView *sub in view.subviews)
+    {
+        NSView *found = MPFirstAmbiguousView(sub);
+        if (found)
+            return found;
+    }
+    return nil;
+}
+
+/// Loads a preference controller's view and returns the wrapped content view
+/// (the original XIB view, which loadView centers inside a resizable wrapper).
+static NSView *MPContentView(MPPreferencesViewController *vc)
+{
+    NSView *wrapper = vc.view;          // triggers loadView
+    [wrapper layoutSubtreeIfNeeded];
+    return wrapper.subviews.firstObject;
+}
+
+/// Collects the checkbox buttons in a pane. Checkboxes use the regular-square
+/// bezel; push buttons (e.g. "Change…") are rounded, so this excludes them.
+static NSArray<NSButton *> *MPCheckboxes(NSView *content)
+{
+    NSMutableArray<NSButton *> *buttons = [NSMutableArray array];
+    MPCollectViews(content, [NSButton class], buttons);
+    NSMutableArray<NSButton *> *checkboxes = [NSMutableArray array];
+    for (NSButton *button in buttons)
+    {
+        if (button.bezelStyle == NSBezelStyleRegularSquare)
+            [checkboxes addObject:button];
+    }
+    return checkboxes;
+}
 
 @interface MPPreferencesViewControllerResizabilityTests : XCTestCase
 @end
@@ -152,6 +206,144 @@
 {
     MPTerminalPreferencesViewController *vc = [[MPTerminalPreferencesViewController alloc] init];
     XCTAssertTrue([vc hasResizableHeight], @"Terminal panel hasResizableHeight should return YES");
+}
+
+#pragma mark - Locale-aware layout (Issue #397)
+
+// Every preference controller, keyed by a readable name, for table-driven tests.
+- (NSDictionary<NSString *, MPPreferencesViewController *> *)allControllers
+{
+    return @{
+        @"General":  [[MPGeneralPreferencesViewController alloc] init],
+        @"Markdown": [[MPMarkdownPreferencesViewController alloc] init],
+        @"Editor":   [[MPEditorPreferencesViewController alloc] init],
+        @"Html":     [[MPHtmlPreferencesViewController alloc] init],
+        @"Terminal": [[MPTerminalPreferencesViewController alloc] init],
+    };
+}
+
+// The boxes that group checkboxes must hug their content rather than fixing a
+// height, otherwise wrapped (e.g. French) text gets clipped — the Editor
+// "Behavior" box did this with a hard height=200 constraint.
+- (void)testGroupingBoxesHaveNoFixedHeight
+{
+    [self.allControllers enumerateKeysAndObjectsUsingBlock:
+     ^(NSString *name, MPPreferencesViewController *vc, BOOL *stop) {
+        NSView *content = MPContentView(vc);
+        NSMutableArray<NSBox *> *boxes = [NSMutableArray array];
+        MPCollectViews(content, [NSBox class], boxes);
+        for (NSBox *box in boxes)
+        {
+            for (NSLayoutConstraint *c in box.constraints)
+            {
+                BOOL fixesHeight = (c.active
+                    && c.firstItem == box && c.secondItem == nil
+                    && c.firstAttribute == NSLayoutAttributeHeight
+                    && c.relation == NSLayoutRelationEqual
+                    && c.constant > 0);
+                XCTAssertFalse(fixesHeight,
+                    @"%@ pane: grouping box must hug its content, not pin a fixed "
+                    @"height (found %@)", name, c);
+            }
+        }
+    }];
+}
+
+// Coupling two labels' widths makes the longer localized label dictate the
+// other's column width, which pushes adjacent controls into overlap (the
+// Compilation pane coupled "CSS:" to "Default path:"). Labels must size
+// independently.
+- (void)testHtmlLabelWidthsAreIndependent
+{
+    MPHtmlPreferencesViewController *vc = [[MPHtmlPreferencesViewController alloc] init];
+    NSView *content = MPContentView(vc);
+    for (NSLayoutConstraint *c in content.constraints)
+    {
+        BOOL couplesLabelWidths = (c.active
+            && c.firstAttribute == NSLayoutAttributeWidth
+            && c.secondAttribute == NSLayoutAttributeWidth
+            && [c.firstItem isKindOfClass:[NSTextField class]]
+            && [c.secondItem isKindOfClass:[NSTextField class]]);
+        XCTAssertFalse(couplesLabelWidths,
+            @"Html pane: label widths must be independent so a long localized "
+            @"label cannot force an adjacent column to overlap (found %@)", c);
+    }
+}
+
+// Checkbox titles must wrap; otherwise long localized titles are truncated or
+// clipped instead of flowing onto a second line.
+- (void)testCheckboxTitlesWrap
+{
+    // Terminal has no checkboxes; track the total so the suite still proves it
+    // exercised real controls across the panes that do.
+    __block NSUInteger totalCheckboxes = 0;
+    [self.allControllers enumerateKeysAndObjectsUsingBlock:
+     ^(NSString *name, MPPreferencesViewController *vc, BOOL *stop) {
+        NSView *content = MPContentView(vc);
+        NSArray<NSButton *> *checkboxes = MPCheckboxes(content);
+        totalCheckboxes += checkboxes.count;
+        for (NSButton *checkbox in checkboxes)
+        {
+            NSCell *cell = checkbox.cell;
+            XCTAssertEqual(cell.lineBreakMode, NSLineBreakByWordWrapping,
+                @"%@ pane: checkbox '%@' must wrap long localized titles",
+                name, checkbox.title);
+        }
+    }];
+    XCTAssertGreaterThan(totalCheckboxes, 0,
+        @"expected to find checkboxes across the preference panes");
+}
+
+// No pane should ship with ambiguous Auto Layout — that would make localized
+// positioning undefined.
+- (void)testPanesHaveNoAmbiguousLayout
+{
+    [self.allControllers enumerateKeysAndObjectsUsingBlock:
+     ^(NSString *name, MPPreferencesViewController *vc, BOOL *stop) {
+        NSView *content = MPContentView(vc);
+        NSView *ambiguous = MPFirstAmbiguousView(content);
+        XCTAssertNil(ambiguous,
+            @"%@ pane: view has ambiguous layout: %@", name, ambiguous);
+    }];
+}
+
+// loadView must size each pane to fit its content for the active locale rather
+// than the static English design frame, so localized text is never clipped.
+- (void)testContentIsSizedToFitItsContent
+{
+    [self.allControllers enumerateKeysAndObjectsUsingBlock:
+     ^(NSString *name, MPPreferencesViewController *vc, BOOL *stop) {
+        NSView *content = MPContentView(vc);
+
+        // The width/height pins loadView applies to the content view.
+        NSLayoutConstraint *widthPin = nil, *heightPin = nil;
+        for (NSLayoutConstraint *c in content.constraints)
+        {
+            if (c.firstItem != content || c.secondItem != nil
+                || c.relation != NSLayoutRelationEqual)
+                continue;
+            if (c.firstAttribute == NSLayoutAttributeWidth)
+                widthPin = c;
+            else if (c.firstAttribute == NSLayoutAttributeHeight)
+                heightPin = c;
+        }
+        XCTAssertNotNil(widthPin,
+            @"%@ pane: loadView should pin the content width", name);
+        XCTAssertNotNil(heightPin,
+            @"%@ pane: loadView should pin the content height", name);
+
+        // Measure the height the content needs at its pinned width (the width
+        // must stay fixed, or wrapping labels would balloon the height). The
+        // applied height must accommodate that — i.e. nothing is clipped.
+        CGFloat appliedHeight = heightPin.constant;
+        heightPin.active = NO;
+        [content layoutSubtreeIfNeeded];
+        CGFloat neededHeight = content.fittingSize.height;
+
+        XCTAssertGreaterThanOrEqual(appliedHeight + 0.5, neededHeight,
+            @"%@ pane: content height (%g) must accommodate its content (%g)",
+            name, appliedHeight, neededHeight);
+    }];
 }
 
 @end

--- a/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
+++ b/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
@@ -236,7 +236,11 @@ static NSArray<NSButton *> *MPCheckboxes(NSView *content)
         {
             for (NSLayoutConstraint *c in box.constraints)
             {
+                // Only author-set, required-priority height pins are a problem.
+                // AppKit installs a low-priority NSContentSizeLayoutConstraint
+                // for every box's intrinsic height; that one is expected.
                 BOOL fixesHeight = (c.active
+                    && c.priority == NSLayoutPriorityRequired
                     && c.firstItem == box && c.secondItem == nil
                     && c.firstAttribute == NSLayoutAttributeHeight
                     && c.relation == NSLayoutRelationEqual

--- a/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
+++ b/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
@@ -236,11 +236,12 @@ static NSArray<NSButton *> *MPCheckboxes(NSView *content)
         {
             for (NSLayoutConstraint *c in box.constraints)
             {
-                // Only author-set, required-priority height pins are a problem.
-                // AppKit installs a low-priority NSContentSizeLayoutConstraint
-                // for every box's intrinsic height; that one is expected.
+                // Only an author-set height pin is a problem. AppKit installs an
+                // NSContentSizeLayoutConstraint (a private NSLayoutConstraint
+                // subclass) for every box's intrinsic height; that one is
+                // expected, so consider only plain NSLayoutConstraint instances.
                 BOOL fixesHeight = (c.active
-                    && c.priority == NSLayoutPriorityRequired
+                    && [c isMemberOfClass:[NSLayoutConstraint class]]
                     && c.firstItem == box && c.secondItem == nil
                     && c.firstAttribute == NSLayoutAttributeHeight
                     && c.relation == NSLayoutRelationEqual


### PR DESCRIPTION
## Summary
Fixes preference pane layouts to properly accommodate localized text that wraps onto multiple lines, preventing text clipping in languages like French and Italian. This addresses Issue #397.

## Key Changes

- **Dynamic height calculation in `MPPreferencesViewController.loadView()`**: Modified to measure the actual height needed by content at its designed width, accounting for text wrapping in different locales. The panel now grows vertically to fit wrapped text instead of using a fixed English design height.

- **Checkbox text wrapping enabled**: Added `lineBreakMode="wordWrap"` to all checkbox buttons across preference panes (General, Markdown, Editor, Html) so long localized titles wrap to multiple lines instead of being truncated or clipped.

- **Comprehensive locale-aware layout tests**: Added four new test methods to `MPPreferencesViewControllerResizabilityTests`:
  - `testGroupingBoxesHaveNoFixedHeight`: Ensures grouping boxes hug their content rather than pinning fixed heights
  - `testHtmlLabelWidthsAreIndependent`: Verifies label widths aren't coupled, preventing layout overlap with longer localized text
  - `testCheckboxTitlesWrap`: Confirms all checkboxes have word wrapping enabled
  - `testPanesHaveNoAmbiguousLayout`: Validates no pane has ambiguous Auto Layout constraints
  - `testContentIsSizedToFitItsContent`: Verifies content is sized to fit at the active locale

- **Helper utilities**: Added static helper functions for view tree traversal and analysis (`MPCollectViews`, `MPFirstAmbiguousView`, `MPContentView`, `MPCheckboxes`) to support the new tests.

## Implementation Details

The core fix in `loadView()` now:
1. Pins the content view width to the designed width
2. Measures the actual height needed via `fittingSize` at that width
3. Uses the maximum of the measured height and English design height (as a floor)
4. Applies this calculated height to the content view constraint

This ensures preference panes expand vertically for longer localized text while maintaining the designed width and never shrinking below the English baseline.
