### PR TITLE
Add editor invisible character toggle

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -76,7 +76,7 @@ NS_INLINE NSSet *MPEditorPreferencesToObserve()
             @"editorHorizontalInset", @"editorVerticalInset",
             @"editorWidthLimited", @"editorMaximumWidth", @"editorLineSpacing",
             @"editorOnRight", @"editorStyleName", @"editorShowWordCount",
-            @"editorScrollsPastEnd",
+            @"editorScrollsPastEnd", @"editorShowsInvisibleCharacters",
             @"htmlMathJax", @"htmlMathJaxInlineDollar", nil
         ];
     });
@@ -904,6 +904,13 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         if ([(id)item isKindOfClass:[NSMenuItem class]])
             ((NSMenuItem *)item).state = self.preferences.editorAutoSave ?
                 NSControlStateValueOn : NSControlStateValueOff;
+    }
+    else if (action == @selector(toggleInvisibleCharacters:))
+    {
+        NSMenuItem *it = ((NSMenuItem *)item);
+        it.state = self.preferences.editorShowsInvisibleCharacters
+            ? NSControlStateValueOn : NSControlStateValueOff;
+        return self.editor != nil;
     }
     return result;
 }
@@ -2077,6 +2084,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     [self.preferences synchronize];
 }
 
+- (IBAction)toggleInvisibleCharacters:(id)sender
+{
+    self.preferences.editorShowsInvisibleCharacters =
+        !self.preferences.editorShowsInvisibleCharacters;
+}
+
 - (IBAction)render:(id)sender
 {
     [self.renderer parseAndRenderLater];
@@ -2323,6 +2336,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         if (contentRect.size.width < minSize.width)
             contentRect.size.width = minSize.width;
         self.editor.frame = contentRect;
+    }
+
+    if (!changedKey || [changedKey isEqualToString:@"editorShowsInvisibleCharacters"])
+    {
+        self.editor.layoutManager.showsInvisibleCharacters =
+            self.preferences.editorShowsInvisibleCharacters;
     }
 
     if (!changedKey)

--- a/MacDown/Code/Preferences/MPPreferences.h
+++ b/MacDown/Code/Preferences/MPPreferences.h
@@ -55,6 +55,7 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 @property (assign) BOOL editorAutoSave;
 @property (assign) BOOL editorScrollsPastEnd;
 @property (assign) BOOL editorEnsuresNewlineAtEndOfFile;
+@property (assign) BOOL editorShowsInvisibleCharacters;
 @property (assign) NSInteger editorUnorderedListMarkerType;
 
 @property (assign) BOOL previewZoomRelativeToBaseFontSize;

--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -254,6 +254,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
 @dynamic editorAutoSave;
 @dynamic editorScrollsPastEnd;
 @dynamic editorEnsuresNewlineAtEndOfFile;
+@dynamic editorShowsInvisibleCharacters;
 @dynamic editorUnorderedListMarkerType;
 
 @dynamic previewZoomRelativeToBaseFontSize;

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -373,6 +373,12 @@
                                     <binding destination="LEY-zf-22t" name="enabled" keyPath="self.currentDocument.previewVisible" id="5e7-rJ-oX2"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Show Invisible Characters" id="TQb-x5-V3x">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleInvisibleCharacters:" target="-1" id="vf0-M2-rZ7"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="onf-Mq-Pah"/>
                             <menuItem title="Left 1:3 Right" id="VW7-VH-9yl">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/MacDownTests/MPPreferencesTests.m
+++ b/MacDownTests/MPPreferencesTests.m
@@ -152,6 +152,24 @@
     [self.preferences synchronize];
 }
 
+- (void)testInvisibleCharactersToggle
+{
+    BOOL original = self.preferences.editorShowsInvisibleCharacters;
+
+    self.preferences.editorShowsInvisibleCharacters = YES;
+    [self.preferences synchronize];
+    XCTAssertTrue(self.preferences.editorShowsInvisibleCharacters,
+                  @"Invisible characters should be ON");
+
+    self.preferences.editorShowsInvisibleCharacters = NO;
+    [self.preferences synchronize];
+    XCTAssertFalse(self.preferences.editorShowsInvisibleCharacters,
+                   @"Invisible characters should be OFF");
+
+    self.preferences.editorShowsInvisibleCharacters = original;
+    [self.preferences synchronize];
+}
+
 - (void)testExtensionFlags
 {
     // Save originals


### PR DESCRIPTION
Adds a View-menu **Show Invisible Characters** toggle, persisted in editor preferences (default **off**) and applied via the text layout manager's `showsInvisibleCharacters`.

This is @yusufm's work from #421, rebased onto current `main` to resolve conflicts in `MPDocument.m` (the recently-merged autosave toggle and this one each added a branch to `validateUserInterfaceItem:` and a new action method — both are kept). Authorship preserved.

Supersedes #421 (its branch is on a fork that can't be updated here). Related to #43.