### PR TITLE
Address issue #441: honor Sync Panes toggle mid-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Fix the Preview pane still auto-scrolling toward the editor when typing after Sync Panes was turned off mid-session; toggling Sync Panes now takes effect immediately (settling the panes on disable, re-syncing on enable) without needing to reopen the document (#441) -- thanks @gregwillits!
 - Fix blank preview when opening saved or externally-originated documents: the real document file is no longer used as the preview's base resource, which WebKit on macOS 26 can silently refuse to load (e.g. files with the execute bit set by sync clients like OneDrive, or stale TCC/provenance state) (#431, #405) -- thanks @maskedspitz, @songjianbupt, and @craigrodger for the diagnosis!
 - Improve render-path responsiveness: single-pass word/character counting, cached body-extraction regex, and bounded renderer polling with cancellation (#388)
 - Restrict auto-created link targets to the current document's folder scope (#388)

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -236,6 +236,11 @@ typedef NS_ENUM(NSUInteger, MPScrollOwner) {
 @property (strong) NSArray<NSNumber *> *webViewHeaderLocations;
 @property (strong) NSArray<NSNumber *> *editorHeaderLocations;
 @property (nonatomic) MPScrollOwner scrollOwner;  // Issue #342: Scroll ownership model
+// Issue #441: Last observed value of editorSyncScrolling, used purely for edge
+// detection in userDefaultsDidChange: so we can settle/re-sync the panes the
+// moment the user toggles Sync Panes mid-session. Never used for gating — gating
+// always reads self.preferences.editorSyncScrolling live.
+@property (nonatomic) BOOL lastKnownSyncScrolling;
 @property (nonatomic) NSTimeInterval lastWordCountUpdate;  // Issue #294: Throttle timestamp
 @property (nonatomic) BOOL showingSelectionCount;  // Issue #452: Widget showing selection counts
 
@@ -268,6 +273,9 @@ typedef NS_ENUM(NSUInteger, MPScrollOwner) {
 - (void)windowDidEndLiveResize:(NSNotification *)notification;
 - (void)windowDidChangeFullScreen:(NSNotification *)notification;
 - (void)applyEditorStartInPreviewModePreference;
+// Issue #441: Settle / re-sync the panes when Sync Panes is toggled mid-session.
+- (void)handleSyncScrollingEnabled;
+- (void)handleSyncScrollingDisabled;
 // Commit 8 (gap 9): MathJax generation counter accessor (used by tests via category)
 - (NSUInteger)mathJaxRenderGeneration;
 
@@ -467,7 +475,11 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     _scrollOwner = MPScrollOwnerNeither;
     self.previousSplitRatio = -1.0;
     self.lastNonCollapsedRatio = -1.0;
-    
+    // Issue #441: Seed the cached Sync Panes value from the live preference so the
+    // first NSUserDefaultsDidChangeNotification (which fires for any default) is not
+    // misread as a transition.
+    _lastKnownSyncScrolling = [MPPreferences sharedInstance].editorSyncScrolling;
+
     return self;
 }
 
@@ -1562,6 +1574,15 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         }
     }
 
+    // Issue #441: The full-reload completion handler unconditionally restores the
+    // preview to lastPreviewScrollTop to avoid a flash-to-top. When sync is OFF the
+    // preview scrolls independently, so capture its actual position here — before the
+    // load blanks the view — so the restore preserves where the user is rather than
+    // an editor-derived position left over from when sync was ON.
+    if (!self.preferences.editorSyncScrolling && self.preview.enclosingScrollView)
+        self.lastPreviewScrollTop =
+            NSMinY(self.preview.enclosingScrollView.contentView.bounds);
+
     // Fall back to full reload
     [self.preview.mainFrame loadHTMLString:html baseURL:baseUrl];
     self.currentBaseUrl = baseUrl;
@@ -1700,6 +1721,21 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 - (void)userDefaultsDidChange:(NSNotification *)notification
 {
+    // Issue #441: NSUserDefaultsDidChangeNotification fires for every defaults
+    // change, so detect a genuine Sync Panes transition by comparing against the
+    // last observed value. On a real toggle, settle the panes (disable) or re-sync
+    // them immediately (enable) so the new mode takes effect without requiring a
+    // document reopen. Always refresh the cached value, even for unrelated changes.
+    BOOL nowSync = self.preferences.editorSyncScrolling;
+    if (nowSync != self.lastKnownSyncScrolling)
+    {
+        self.lastKnownSyncScrolling = nowSync;
+        if (nowSync)
+            [self handleSyncScrollingEnabled];
+        else
+            [self handleSyncScrollingDisabled];
+    }
+
     MPRenderer *renderer = self.renderer;
 
     // Force update if we're switching from manual to auto, or renderer settings
@@ -1716,6 +1752,44 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         [renderer parseIfPreferencesChanged];
         [renderer renderIfPreferencesChanged];
     }
+}
+
+// Issue #441: The user turned Sync Panes ON mid-session. Re-sync immediately,
+// Editor-authoritative (the Preview moves to match the editor's current position),
+// then return to the quiescent state so subsequent scrolls sync in either direction.
+// Mirrors the editor-reveal sync in setSplitViewDividerLocation:, but forward.
+- (void)handleSyncScrollingEnabled
+{
+    if (!self.renderer)
+        return;                              // Headless / nib not yet loaded.
+    if (_scrollOwner != MPScrollOwnerNeither)
+        return;                              // Don't fight an in-progress live scroll.
+
+    // Claiming editor ownership suppresses the synchronous previewBoundsDidChange:
+    // fired by the bounds write inside syncScrollers (it is gated on == Preview).
+    _scrollOwner = MPScrollOwnerEditor;
+    [self updateHeaderLocations];
+    [self syncScrollers];
+    _scrollOwner = MPScrollOwnerNeither;
+}
+
+// Issue #441: The user turned Sync Panes OFF mid-session. Make the panes fully
+// independent immediately, preserving their current positions (no jump). The bug
+// was that a stale, editor-derived lastPreviewScrollTop — last written while sync
+// was ON — kept getting restored on the full-reload completion path, yanking the
+// Preview toward the editor each time the user typed. Resetting ownership prevents
+// any lingering Editor ownership from suppressing the user's own preview scrolls,
+// and recapturing the Preview's actual position makes the restore a visual no-op.
+- (void)handleSyncScrollingDisabled
+{
+    // Unlike handleSyncScrollingEnabled, which defers when a live scroll owns the
+    // panes, disabling resets ownership unconditionally: the goal is immediate
+    // independence. If a preview drag is somehow in flight, didEndPreviewLiveScroll:
+    // re-checks the (now false) preference before reverse-syncing, so this is safe.
+    _scrollOwner = MPScrollOwnerNeither;
+    if (self.preview.enclosingScrollView)
+        self.lastPreviewScrollTop =
+            NSMinY(self.preview.enclosingScrollView.contentView.bounds);
 }
 
 - (void)editorFrameDidChange:(NSNotification *)notification

--- a/MacDownTests/MPScrollSyncTests.m
+++ b/MacDownTests/MPScrollSyncTests.m
@@ -51,6 +51,11 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 - (void)setSplitViewDividerLocation:(CGFloat)ratio;
 // Commit 8 (gap 9): MathJax render generation counter getter
 - (NSUInteger)mathJaxRenderGeneration;
+// Issue #441: mid-session Sync Panes toggle handling
+@property (nonatomic) BOOL lastKnownSyncScrolling;
+- (void)userDefaultsDidChange:(NSNotification *)notification;
+- (void)handleSyncScrollingEnabled;
+- (void)handleSyncScrollingDisabled;
 @end
 
 @interface MPScrollSyncTests : XCTestCase
@@ -2022,6 +2027,157 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
     XCTAssertEqual([doc mathJaxRenderGeneration], (NSUInteger)0,
                    @"N1: _mathJaxRenderGeneration should be 0 on a fresh document");
+}
+
+#pragma mark - Group O — Issue #441: Sync Panes mid-session toggle
+
+/**
+ * O1 — Disabling Sync Panes mid-session resets scroll ownership to Neither.
+ *
+ * Issue #441: while sync was ON, typing sets scrollOwner = Editor. If that
+ * ownership lingers after the user disables Sync Panes, the panes are not truly
+ * independent. handleSyncScrollingDisabled must clear it back to Neither.
+ */
+- (void)testDisableSyncResetsOwnershipToNeither
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.scrollOwner = MPScrollOwnerEditor;
+
+    [doc handleSyncScrollingDisabled];
+
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerNeither,
+                   @"O1: disabling Sync Panes should reset scrollOwner to Neither");
+}
+
+/**
+ * O2 — Disabling Sync Panes is safe (and a no-op on lastPreviewScrollTop) when
+ * there is no preview scroll view, as in a headless document.
+ *
+ * Issue #441: the position recapture is guarded on the preview's scroll view, so
+ * a headless document must not crash and must leave the stored value untouched.
+ */
+- (void)testDisableSyncWithNilPreviewDoesNotCrash
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.lastPreviewScrollTop = 123.0;
+
+    XCTAssertNoThrow([doc handleSyncScrollingDisabled],
+                     @"O2: disabling Sync Panes must not crash without a preview");
+    XCTAssertEqualWithAccuracy(doc.lastPreviewScrollTop, 123.0, 0.01,
+                               @"O2: lastPreviewScrollTop unchanged when preview is nil");
+}
+
+/**
+ * O3 — Enabling Sync Panes is a no-op (and safe) when the renderer is nil.
+ *
+ * Issue #441: handleSyncScrollingEnabled must bail out early on a not-yet-loaded
+ * document rather than attempting to sync against absent views.
+ */
+- (void)testEnableSyncWithNilRendererIsNoOp
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.scrollOwner = MPScrollOwnerNeither;
+
+    XCTAssertNoThrow([doc handleSyncScrollingEnabled],
+                     @"O3: enabling Sync Panes must not crash without a renderer");
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerNeither,
+                   @"O3: ownership stays Neither when there is nothing to sync");
+}
+
+/**
+ * O4 — Enabling Sync Panes does not steal ownership during an active preview drag.
+ *
+ * Issue #441: if the user is live-scrolling the preview (scrollOwner == Preview)
+ * when sync is toggled on, the re-sync must defer rather than fight the drag.
+ */
+- (void)testEnableSyncDoesNotStealActivePreviewOwnership
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.renderer = [[MPRenderer alloc] init];
+    doc.scrollOwner = MPScrollOwnerPreview;
+
+    [doc handleSyncScrollingEnabled];
+
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerPreview,
+                   @"O4: enabling sync must not seize ownership during a preview drag");
+}
+
+/**
+ * O5 — Enabling Sync Panes from the quiescent state brackets the re-sync in
+ * Editor ownership and returns to Neither.
+ *
+ * Issue #441: with a renderer present and empty header arrays, the forward
+ * re-sync runs and leaves the document quiescent so both directions resume.
+ */
+- (void)testEnableSyncReturnsToNeitherAfterResync
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.renderer = [[MPRenderer alloc] init];
+    doc.editorHeaderLocations = @[];
+    doc.webViewHeaderLocations = @[];
+    doc.scrollOwner = MPScrollOwnerNeither;
+
+    XCTAssertNoThrow([doc handleSyncScrollingEnabled],
+                     @"O5: enabling sync should re-sync without crashing");
+    XCTAssertEqual(doc.scrollOwner, MPScrollOwnerNeither,
+                   @"O5: ownership returns to Neither after the re-sync");
+}
+
+/**
+ * O6 — A fresh document seeds lastKnownSyncScrolling from the live preference so
+ * the first defaults-change notification is not misread as a transition.
+ *
+ * Issue #441: prevents a spurious settle/re-sync on the first unrelated defaults
+ * change of the session.
+ */
+- (void)testLastKnownSyncScrollingSeededFromPreference
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+
+    XCTAssertEqual(doc.lastKnownSyncScrolling,
+                   [MPPreferences sharedInstance].editorSyncScrolling,
+                   @"O6: lastKnownSyncScrolling should match the live preference at init");
+}
+
+/**
+ * O7 — userDefaultsDidChange: only reacts to a genuine Sync Panes transition.
+ *
+ * Issue #441: edge detection must compare against the cached value. Here we
+ * simulate "sync was ON, now OFF": prime the cached value to YES, force the live
+ * preference OFF, and verify the disable path ran (ownership reset to Neither).
+ * A second call with no further change must not re-trigger. The preference is
+ * saved and restored so the test does not leak state to other tests.
+ */
+- (void)testUserDefaultsChangeReactsOnlyToSyncTransition
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    BOOL savedSync = prefs.editorSyncScrolling;
+
+    @try
+    {
+        // Simulate the mid-session disable: cache says ON, live preference is OFF.
+        prefs.editorSyncScrolling = NO;
+        doc.lastKnownSyncScrolling = YES;
+        doc.scrollOwner = MPScrollOwnerEditor;
+
+        [doc userDefaultsDidChange:nil];
+
+        XCTAssertFalse(doc.lastKnownSyncScrolling,
+                       @"O7: cached value should update to the new (OFF) state");
+        XCTAssertEqual(doc.scrollOwner, MPScrollOwnerNeither,
+                       @"O7: the disable transition should have settled ownership");
+
+        // No further change: a second call must be a no-op for the transition.
+        doc.scrollOwner = MPScrollOwnerEditor;
+        [doc userDefaultsDidChange:nil];
+        XCTAssertEqual(doc.scrollOwner, MPScrollOwnerEditor,
+                       @"O7: no transition means handleSyncScrollingDisabled is not re-run");
+    }
+    @finally
+    {
+        prefs.editorSyncScrolling = savedSync;
+    }
 }
 
 @end


### PR DESCRIPTION
## Summary

Fixes the reported bug where, after turning **Sync Panes** off while a document is open, **typing in the editor still auto-scrolled the Preview** toward the editor. Restarting with sync already off avoided it — the tell-tale sign that this was a mid-session **state** problem, not an initialization one.

### Root cause
While sync was ON, every forward sync wrote an editor-derived value into `lastPreviewScrollTop` (`syncScrollers`). The full-reload completion handler (`MPGetPreviewLoadingCompletionHandler`) restores the preview to `lastPreviewScrollTop` **unconditionally**, regardless of the sync preference. After disabling sync, that stale editor-derived position kept getting restored, plus scroll **ownership** could linger as `Editor` — so the panes were never truly independent until the document was reopened.

### Fix
Detect the `editorSyncScrolling` transition in `userDefaultsDidChange:` (the only native hook that fires for the XIB-bound checkbox) and react immediately:

- **On disable** (`handleSyncScrollingDisabled`): reset scroll ownership to `Neither` and recapture the Preview's *actual* current position into `lastPreviewScrollTop`, so the panes become fully independent with no jump. The full-reload path also keeps `lastPreviewScrollTop` aligned with the Preview's real position whenever sync is off, covering the "scroll the Preview independently, then type" case.
- **On enable** (`handleSyncScrollingEnabled`): re-sync immediately, editor-authoritative (Preview moves to match the editor), bracketed in `Editor` ownership and returned to `Neither` — mirroring the existing editor-reveal sync in `setSplitViewDividerLocation:`.

A cached `lastKnownSyncScrolling` (seeded in `init` from the live preference) drives edge detection only; **gating still always reads the live preference**, so no preference value is ever cached for decision-making.

### Audit
Confirmed every `syncScrollers` / `syncScrollersReverse` call site reads the live `editorSyncScrolling` value; the only non-sync preview-moving write was the unconditional `lastPreviewScrollTop` restore, which this change neutralizes when sync is off.

## Files Changed

- `MacDown/Code/Document/MPDocument.m` — transition detection + `handleSyncScrollingEnabled`/`handleSyncScrollingDisabled`; full-reload position capture when sync is off; cached value seeded in `init`.
- `MacDownTests/MPScrollSyncTests.m` — new **Group O** regression tests.
- `CHANGELOG.md` — user-facing entry.

## Related Issue

Related to #441

## Manual Testing Plan

1. Launch with **Sync Panes ON**. Open a longer document (e.g. the bundled help). Scroll/edit so the panes are synced.
2. Open Settings → uncheck **Sync Panes**.
3. Scroll each pane independently — they stay independent (already worked).
4. **Type in the editor** — the Preview must now stay put (this was the bug; it previously jumped toward the editor).
5. Scroll the Preview to a new position, type again — Preview stays where you left it.
6. Re-check **Sync Panes** — the Preview should immediately jump to match the editor's current position, and continue syncing on subsequent edits/scrolls.
7. Repeat 1–6 having launched with **Sync Panes OFF** — behavior should be identical to the post-fix mid-session case.
8. Edge check: toggle the checkbox rapidly a few times — no crashes, panes settle correctly.

## Review Notes

Automated review found **no critical issues**. The unit tests lock the fix at the state level (ownership reset, position recapture, edge detection, nil-safety); the rendered end-to-end jump requires a live WebView and isn't headless-testable, which is consistent with the existing scroll-sync test suite's approach.
