### PR TITLE
Address issue #436: keep editor and preview panes in sync on large files

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2826,8 +2826,10 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     static NSRegularExpression *hrRegex = nil;     // thematic break (-, *, _)
     static dispatch_once_t regexOnceToken;
     dispatch_once(&regexOnceToken, ^{
-        dashRegex = [NSRegularExpression regularExpressionWithPattern:@"^([-]+)$" options:0 error:NULL];
-        eqRegex = [NSRegularExpression regularExpressionWithPattern:@"^([=]+)$" options:0 error:NULL];
+        // Setext underlines: 0-3 leading spaces and trailing whitespace are allowed
+        // (CommonMark), matching how the preview DOM renders e.g. "Text\n   ---".
+        dashRegex = [NSRegularExpression regularExpressionWithPattern:@"^[ ]{0,3}([-]+)[ \\t]*$" options:0 error:NULL];
+        eqRegex = [NSRegularExpression regularExpressionWithPattern:@"^[ ]{0,3}([=]+)[ \\t]*$" options:0 error:NULL];
         // Capture the leading hashes (0-3 leading spaces allowed); a space must follow.
         atxRegex = [NSRegularExpression regularExpressionWithPattern:@"^[ ]{0,3}(#+)\\s" options:0 error:NULL];
         imgRegex = [NSRegularExpression regularExpressionWithPattern:@"^!\\[[^\\]]*\\]\\([^)]*\\)$" options:0 error:NULL];

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -203,6 +203,22 @@ typedef NS_ENUM(NSUInteger, MPScrollOwner) {
     MPScrollOwnerNeither = 2,  // Quiescent; sync in either direction is valid
 };
 
+// Issue #436: Reference-point kind tag. The editor (regex over markdown) and the
+// preview (DOM query in updateHeaderLocations.js) detect reference points by
+// independent mechanisms that can disagree mid-document. Tagging each point with its
+// kind lets validateHeaderLocationAlignment align the two sequences instead of blindly
+// assuming they correspond 1:1 by index. Header values equal the header level, matching
+// the kind codes emitted by updateHeaderLocations.js.
+typedef NS_ENUM(NSInteger, MPReferenceKind) {
+    MPReferenceKindImage = 0,
+    MPReferenceKindH1    = 1,
+    MPReferenceKindH2    = 2,
+    MPReferenceKindH3    = 3,
+    MPReferenceKindH4    = 4,
+    MPReferenceKindH5    = 5,
+    MPReferenceKindH6    = 6,
+};
+
 @property (weak) IBOutlet NSToolbar *toolbar;
 @property (weak) IBOutlet MPDocumentSplitView *splitView;
 @property (weak) IBOutlet NSView *editorContainer;
@@ -235,6 +251,10 @@ typedef NS_ENUM(NSUInteger, MPScrollOwner) {
 @property (nonatomic) BOOL renderToWebPending;
 @property (strong) NSArray<NSNumber *> *webViewHeaderLocations;
 @property (strong) NSArray<NSNumber *> *editorHeaderLocations;
+// Issue #436: Kind tags running parallel to the *HeaderLocations arrays. Kept private;
+// the public Y-coordinate arrays stay NSNumber arrays so existing consumers are unaffected.
+@property (strong) NSArray<NSNumber *> *webViewHeaderTypes;
+@property (strong) NSArray<NSNumber *> *editorHeaderTypes;
 @property (nonatomic) MPScrollOwner scrollOwner;  // Issue #342: Scroll ownership model
 // Issue #441: Last observed value of editorSyncScrolling, used purely for edge
 // detection in userDefaultsDidChange: so we can settle/re-sync the panes the
@@ -265,6 +285,15 @@ typedef NS_ENUM(NSUInteger, MPScrollOwner) {
 - (void)syncScrollersReverse;
 - (void)updateHeaderLocations;
 - (void)validateHeaderLocationAlignment;
+// Issue #436: Pure helpers — no view/DOM dependencies, so they are unit-testable headless.
++ (NSArray<NSNumber *> *)editorReferenceKindsForMarkdown:(NSString *)markdown
+                                          outLineNumbers:(NSArray<NSNumber *> **)outLineNumbers;
++ (void)alignEditorYs:(NSArray<NSNumber *> *)editorYs
+          editorTypes:(NSArray<NSNumber *> *)editorTypes
+            previewYs:(NSArray<NSNumber *> *)previewYs
+         previewTypes:(NSArray<NSNumber *> *)previewTypes
+      alignedEditorYs:(NSArray<NSNumber *> **)outEditorYs
+     alignedPreviewYs:(NSArray<NSNumber *> **)outPreviewYs;
 - (void)invokeRenderCompletionHandlers;
 - (void)willStartPreviewLiveScroll:(NSNotification *)notification;
 - (void)didEndPreviewLiveScroll:(NSNotification *)notification;
@@ -343,6 +372,51 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         // (This is called for MathJax rendering completion path)
         [strongObj invokeRenderCompletionHandlers];
     };
+}
+
+
+/**
+ * Issue #436: Scans a single line for a fenced-code-block marker (a run of 3+ backticks or
+ * tildes, allowing 0-3 leading spaces). Returns YES and reports the marker character, its
+ * length, and whether any non-whitespace follows the run. A backtick run whose info string
+ * contains a backtick is not a valid fence marker (per CommonMark), so it returns NO.
+ * The caller decides whether the marker opens or closes a fence.
+ */
+static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outLength,
+                              BOOL *outHasTrailingContent)
+{
+    NSUInteger length = line.length;
+    NSUInteger i = 0;
+    NSUInteger leadingSpaces = 0;
+    while (i < length && [line characterAtIndex:i] == ' ') { i++; leadingSpaces++; }
+    if (leadingSpaces > 3 || i >= length)
+        return NO;  // 4+ leading spaces is indented code, not a fence.
+
+    unichar marker = [line characterAtIndex:i];
+    if (marker != '`' && marker != '~')
+        return NO;
+
+    NSUInteger runStart = i;
+    while (i < length && [line characterAtIndex:i] == marker) i++;
+    NSUInteger runLength = i - runStart;
+    if (runLength < 3)
+        return NO;
+
+    BOOL hasTrailing = NO;
+    BOOL hasBacktickAfter = NO;
+    for (NSUInteger j = i; j < length; j++) {
+        unichar c = [line characterAtIndex:j];
+        if (c != ' ' && c != '\t') hasTrailing = YES;
+        if (c == '`') hasBacktickAfter = YES;
+    }
+    // A backtick fence's info string may not contain backticks.
+    if (marker == '`' && hasBacktickAfter)
+        return NO;
+
+    if (outChar) *outChar = marker;
+    if (outLength) *outLength = runLength;
+    if (outHasTrailingContent) *outHasTrailingContent = hasTrailing;
+    return YES;
 }
 
 
@@ -2649,8 +2723,6 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
  */
 -(void) updateHeaderLocations
 {
-    NSMutableArray<NSNumber *> *locations = [NSMutableArray array];
-
     // Load JavaScript from resource file for better maintainability
     static NSString *script = nil;
     static dispatch_once_t onceToken;
@@ -2661,150 +2733,320 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         }
     });
 
-    // Issue #342 (Bug B): JS now returns document-absolute coordinates via
-    // window.scrollY + rect.top. No ObjC-side offset correction is needed.
+    // Preview side. Issue #436: the JS now returns {ys, kinds} instead of a bare array.
+    // ys are document-absolute (window.scrollY + rect.top, Issue #342 Bug B); kinds tag
+    // each reference point (0 = image, 1-6 = header level) so the two sequences can be
+    // aligned rather than blindly cross-indexed by position.
     if (script) {
-        _webViewHeaderLocations = [[self.preview.mainFrame.javaScriptContext evaluateScript:script] toArray];
+        JSValue *result = [self.preview.mainFrame.javaScriptContext evaluateScript:script];
+        NSArray<NSNumber *> *ys = [result[@"ys"] toArray];
+        NSArray<NSNumber *> *kinds = [result[@"kinds"] toArray];
+        _webViewHeaderLocations = ys ?: @[];
+        _webViewHeaderTypes = kinds ?: @[];
     } else {
         _webViewHeaderLocations = @[];
+        _webViewHeaderTypes = @[];
     }
 
+    // Editor side. Issue #436: which lines are reference points (and their kinds) is now
+    // a pure function, +editorReferenceKindsForMarkdown:outLineNumbers:, so it can be unit
+    // tested headless. Here we only translate those line numbers into vertical positions
+    // via the layout manager. In headless tests self.editor is nil and the geometry
+    // collapses to 0 (harmless — the classifier is exercised directly in unit tests).
+    NSString *editorString = self.editor.string ?: @"";
+    NSArray<NSNumber *> *lineNumbers = nil;
+    _editorHeaderTypes = [MPDocument editorReferenceKindsForMarkdown:editorString
+                                                      outLineNumbers:&lineNumbers];
 
-
-    // Next, cache the locations of all of the reference nodes in the editor view.
-    NSInteger characterCount = 0;
+    NSArray<NSString *> *documentLines = [editorString componentsSeparatedByString:@"\n"];
+    NSUInteger lineCount = documentLines.count;
     NSLayoutManager *layoutManager = [self.editor layoutManager];
-    NSArray<NSString *> *documentLines = [self.editor.string componentsSeparatedByString:@"\n"];
-    [locations removeAllObjects];
+    NSTextContainer *textContainer = [self.editor textContainer];
 
-    // Cache regex patterns for markdown headers and images.
-    // Only handle images that are not inline with other text/images.
-    static NSRegularExpression *dashRegex = nil;
-    static NSRegularExpression *headerRegex = nil;
-    static NSRegularExpression *imgRegex = nil;
-    static NSRegularExpression *imgRefRegex = nil;
-    static NSRegularExpression *hrRegex = nil;
-    static dispatch_once_t regexOnceToken;
-    dispatch_once(&regexOnceToken, ^{
-        // Match setext-style headers (underlined with dashes).
-        // Matches one or more dashes on a line by itself.
-        // Used with previousLineHadContent to distinguish from horizontal rules.
-        dashRegex = [NSRegularExpression regularExpressionWithPattern:@"^([-]+)$" options:0 error:NULL];
+    // Precompute the character offset at the start of each line so a line number maps to
+    // its glyph range without rescanning the whole string.
+    NSMutableArray<NSNumber *> *lineStartOffsets = [NSMutableArray arrayWithCapacity:lineCount];
+    NSUInteger runningOffset = 0;
+    for (NSString *line in documentLines) {
+        [lineStartOffsets addObject:@(runningOffset)];
+        runningOffset += line.length + 1;  // +1 for the '\n' separator
+    }
 
-        // Match ATX-style headers (# Header, ## Header, etc.)
-        headerRegex = [NSRegularExpression regularExpressionWithPattern:@"^(#+)\\s" options:0 error:NULL];
-
-        // Match basic inline image syntax: ![alt](url)
-        imgRegex = [NSRegularExpression regularExpressionWithPattern:@"^!\\[[^\\]]*\\]\\([^)]*\\)$" options:0 error:NULL];
-
-        // Match reference-style image syntax: ![alt][ref]
-        imgRefRegex = [NSRegularExpression regularExpressionWithPattern:@"^!\\[[^\\]]*\\]\\[[^\\]]*\\]$" options:0 error:NULL];
-
-        // Match horizontal rules per CommonMark specification:
-        // - Requires 3+ matching characters: -, *, or _
-        // - Allows 0-3 leading spaces (4+ spaces = code block)
-        // - Allows optional spaces between characters
-        // - All non-whitespace characters must be identical
-        // Examples that match: ---, ***, ___, - - -, * * *, _ _ _,    ---
-        // Examples that don't: --, **, __, -*-,  ----a,     --- (4+ leading spaces)
-        hrRegex = [NSRegularExpression regularExpressionWithPattern:@"^[ ]{0,3}(([-][ ]*){3,}|([*][ ]*){3,}|([_][ ]*){3,})$" options:0 error:NULL];
-    });
-
-    // Track whether previous line had content (non-empty, non-dash-only).
-    // This flag is essential for distinguishing between:
-    //   - Setext headers (content line followed by dashes): Text\n---
-    //   - Horizontal rules (dashes without preceding content): \n---
-    //
-    // The distinction works as follows:
-    //   1. If previous line had content AND current line is dashes AND not an HR
-    //      → It's a setext header underline
-    //   2. If no previous content OR current line matches HR pattern
-    //      → It's a horizontal rule (or standalone dashes)
-    BOOL previousLineHadContent = NO;
-
-    // We start by splitting our document into lines, and then searching
-    // line by line for headers or images.
-    for (NSInteger lineNumber = 0; lineNumber < [documentLines count]; lineNumber++)
-    {
-        NSString *line = documentLines[lineNumber];
-
-        // Check if line is a horizontal rule (3+ matching characters).
-        // Per CommonMark: 0-3 leading spaces allowed, spaces between characters allowed.
-        BOOL isHorizontalRule = [hrRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])] > 0;
-
-        // Check if line is a setext-style header (dashes after content).
-        // A line of dashes is a setext header if:
-        //   1. Previous line had content (text, not dashes)
-        //   2. Current line is all consecutive dashes (matches dashRegex)
-        //
-        // Note: dashRegex pattern ^([-]+)$ only matches consecutive dashes (---, not - - -).
-        // Spaced patterns like "- - -" match hrRegex but not dashRegex, so they're HRs.
-        // This ensures "Text\n---" is a setext header but "\n---" and "- - -" are HRs.
-        BOOL isDashHeader = previousLineHadContent && [dashRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])];
-
-        BOOL isImage = ([imgRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])] > 0 ||
-                        [imgRefRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])] > 0);
-        BOOL isHeader = [headerRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])] > 0;
-
-        if (isDashHeader || isImage || isHeader)
-        {
-            // Calculate where this header/image appears vertically in the editor
-            NSRange glyphRange = [layoutManager glyphRangeForCharacterRange:NSMakeRange(characterCount, [line length]) actualCharacterRange:nil];
-            NSRect topRect = [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:[self.editor textContainer]];
-            CGFloat headerY = NSMidY(topRect);
-
-            // Issue #342 (Bug D): Add all headers unconditionally to keep
-            // _editorHeaderLocations and _webViewHeaderLocations aligned.
-            // The runtime filters in syncScrollers/syncScrollersReverse already
-            // handle end-of-document interpolation.
-            [locations addObject:@(headerY)];
-        }
-
-        // Update previousLineHadContent flag for next iteration.
-        // A line "has content" if:
-        //   1. It's non-empty (has length)
-        //   2. It's not just dashes (not a potential header underline)
-        //
-        // This allows the next line to determine if dashes should be interpreted
-        // as a setext header underline.
-        previousLineHadContent = [line length] && ![dashRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])];
-
-        characterCount += [line length] + 1;
+    NSMutableArray<NSNumber *> *locations = [NSMutableArray arrayWithCapacity:lineNumbers.count];
+    for (NSNumber *lineNumberObj in lineNumbers) {
+        NSUInteger lineNumber = lineNumberObj.unsignedIntegerValue;
+        if (lineNumber >= lineCount)
+            continue;
+        NSUInteger charLocation = lineStartOffsets[lineNumber].unsignedIntegerValue;
+        NSUInteger lineLength = documentLines[lineNumber].length;
+        NSRange glyphRange = [layoutManager glyphRangeForCharacterRange:NSMakeRange(charLocation, lineLength)
+                                                   actualCharacterRange:nil];
+        NSRect topRect = [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:textContainer];
+        [locations addObject:@(NSMidY(topRect))];
     }
 
     _editorHeaderLocations = [locations copy];
 
-    // Gap 5: Validate that editor and preview header arrays are aligned.
-    // Mismatches cause cross-indexing to wrong reference points.
+    // Issue #436 / Gap 5: Align the editor and preview reference-point sequences so
+    // syncScrollers/syncScrollersReverse always cross-index matching points.
     [self validateHeaderLocationAlignment];
 }
 
 /**
- * Validates that _editorHeaderLocations and _webViewHeaderLocations have the
- * same count. When they diverge (e.g. because the editor regex matches headers
- * inside fenced code blocks that the JS DOM query ignores), truncates both to
- * MIN(editorCount, previewCount) so syncScrollers/syncScrollersReverse always
- * cross-index aligned arrays. Trailing unmatched headers are dropped; the sync
- * algorithms interpolate to end-of-document for those sections.
+ * Issue #436: Classifies the reference points (ATX/setext headers and standalone images)
+ * in a markdown string, returning their kind codes (see MPReferenceKind) in document
+ * order, with the matching source line numbers via outLineNumbers. This mirrors the DOM
+ * detection in updateHeaderLocations.js so the editor and preview sequences agree:
  *
- * Gap 5: editor regex vs JS DOM divergence.
+ *   - Headers inside fenced code blocks (``` or ~~~) are skipped — the DOM renders them
+ *     as <pre><code>, not <hN>.
+ *   - Setext headers are detected for both '===' (level 1) and '---' (level 2).
+ *   - ATX headers with 7+ hashes are not headers (CommonMark §4.2; Hoedown emits no <hN>),
+ *     so they are treated as ordinary paragraph text.
+ *   - Standalone whole-line images (inline or reference syntax) are kind 0.
+ *
+ * Pure function: no view, layout, or DOM dependencies, so it is unit-testable headless.
+ */
++ (NSArray<NSNumber *> *)editorReferenceKindsForMarkdown:(NSString *)markdown
+                                          outLineNumbers:(NSArray<NSNumber *> **)outLineNumbers
+{
+    NSMutableArray<NSNumber *> *kinds = [NSMutableArray array];
+    NSMutableArray<NSNumber *> *lineNumbers = [NSMutableArray array];
+
+    if (markdown.length == 0) {
+        if (outLineNumbers) *outLineNumbers = lineNumbers;
+        return kinds;
+    }
+
+    static NSRegularExpression *dashRegex = nil;   // setext underline '---' (level 2)
+    static NSRegularExpression *eqRegex = nil;     // setext underline '===' (level 1)
+    static NSRegularExpression *atxRegex = nil;    // ATX header, 0-3 leading spaces
+    static NSRegularExpression *imgRegex = nil;    // ![alt](url)
+    static NSRegularExpression *imgRefRegex = nil; // ![alt][ref]
+    static NSRegularExpression *hrRegex = nil;     // thematic break (-, *, _)
+    static dispatch_once_t regexOnceToken;
+    dispatch_once(&regexOnceToken, ^{
+        dashRegex = [NSRegularExpression regularExpressionWithPattern:@"^([-]+)$" options:0 error:NULL];
+        eqRegex = [NSRegularExpression regularExpressionWithPattern:@"^([=]+)$" options:0 error:NULL];
+        // Capture the leading hashes (0-3 leading spaces allowed); a space must follow.
+        atxRegex = [NSRegularExpression regularExpressionWithPattern:@"^[ ]{0,3}(#+)\\s" options:0 error:NULL];
+        imgRegex = [NSRegularExpression regularExpressionWithPattern:@"^!\\[[^\\]]*\\]\\([^)]*\\)$" options:0 error:NULL];
+        imgRefRegex = [NSRegularExpression regularExpressionWithPattern:@"^!\\[[^\\]]*\\]\\[[^\\]]*\\]$" options:0 error:NULL];
+        hrRegex = [NSRegularExpression regularExpressionWithPattern:@"^[ ]{0,3}(([-][ ]*){3,}|([*][ ]*){3,}|([_][ ]*){3,})$" options:0 error:NULL];
+    });
+
+    NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
+
+    // Setext underlines attach to a *paragraph* line. previousLineHadContent is true only
+    // after ordinary text — not after blanks, headers, HRs, images, or fence lines —
+    // so e.g. "# H\n---" is an ATX header followed by an HR, not a setext header.
+    BOOL previousLineHadContent = NO;
+
+    // Fenced-code-block state. CommonMark: a fence opens with 3+ of ` or ~ (0-3 leading
+    // spaces) and closes with a run of the same character at least as long, with nothing
+    // but whitespace after it. A backtick fence's info string may not contain backticks.
+    BOOL insideFence = NO;
+    unichar fenceChar = 0;
+    NSUInteger fenceLength = 0;
+
+    for (NSUInteger lineNumber = 0; lineNumber < lines.count; lineNumber++) {
+        NSString *line = lines[lineNumber];
+        NSRange full = NSMakeRange(0, line.length);
+
+        unichar markerChar = 0;
+        NSUInteger markerLength = 0;
+        BOOL hasTrailingContent = NO;
+        BOOL isFenceMarker = MPScanFenceMarker(line, &markerChar, &markerLength, &hasTrailingContent);
+
+        if (insideFence) {
+            // Inside a fence: only a matching, long-enough, bare closing marker ends it.
+            // Everything here (including the fence lines) is code, never a reference point.
+            if (isFenceMarker && markerChar == fenceChar
+                    && markerLength >= fenceLength && !hasTrailingContent) {
+                insideFence = NO;
+            }
+            previousLineHadContent = NO;
+            continue;
+        }
+
+        if (isFenceMarker) {
+            // Opens a fence. The opening line itself is never a reference point.
+            insideFence = YES;
+            fenceChar = markerChar;
+            fenceLength = markerLength;
+            previousLineHadContent = NO;
+            continue;
+        }
+
+        // ATX header? Capture the hash run; 7+ hashes is not a header (paragraph text).
+        NSTextCheckingResult *atxMatch = [atxRegex firstMatchInString:line options:0 range:full];
+        if (atxMatch) {
+            NSUInteger hashCount = [atxMatch rangeAtIndex:1].length;
+            if (hashCount >= 1 && hashCount <= 6) {
+                [kinds addObject:@((NSInteger)hashCount)];
+                [lineNumbers addObject:@(lineNumber)];
+                previousLineHadContent = NO;
+                continue;
+            }
+            // 7+ hashes: ordinary paragraph text, which can still anchor a setext header.
+            previousLineHadContent = YES;
+            continue;
+        }
+
+        // Setext underline (only valid directly under a paragraph line).
+        if (previousLineHadContent
+                && [eqRegex numberOfMatchesInString:line options:0 range:full] > 0) {
+            [kinds addObject:@(MPReferenceKindH1)];
+            [lineNumbers addObject:@(lineNumber)];
+            previousLineHadContent = NO;
+            continue;
+        }
+        if (previousLineHadContent
+                && [dashRegex numberOfMatchesInString:line options:0 range:full] > 0) {
+            [kinds addObject:@(MPReferenceKindH2)];
+            [lineNumbers addObject:@(lineNumber)];
+            previousLineHadContent = NO;
+            continue;
+        }
+
+        // Standalone whole-line image.
+        if ([imgRegex numberOfMatchesInString:line options:0 range:full] > 0
+                || [imgRefRegex numberOfMatchesInString:line options:0 range:full] > 0) {
+            [kinds addObject:@(MPReferenceKindImage)];
+            [lineNumbers addObject:@(lineNumber)];
+            previousLineHadContent = NO;
+            continue;
+        }
+
+        // Thematic break: not a reference point, and not paragraph text either.
+        if ([hrRegex numberOfMatchesInString:line options:0 range:full] > 0) {
+            previousLineHadContent = NO;
+            continue;
+        }
+
+        // Blank line breaks any setext context.
+        if ([[line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] length] == 0) {
+            previousLineHadContent = NO;
+            continue;
+        }
+
+        // Anything else is ordinary paragraph text that can anchor a setext underline.
+        previousLineHadContent = YES;
+    }
+
+    if (outLineNumbers) *outLineNumbers = lineNumbers;
+    return kinds;
+}
+
+/**
+ * Issue #436: Aligns the editor and preview reference-point sequences so they correspond
+ * 1:1 by index, which is the invariant syncScrollers/syncScrollersReverse rely on.
+ *
+ * The two detectors (editor regex vs preview DOM) can disagree mid-document; a single
+ * extra point on one side shifts every later index, which is the "synced only at the
+ * start and end" bug. This computes the longest common subsequence of the two *kind*
+ * sequences (matching on the coarse image-vs-header class, since the two sides legitimately
+ * disagree on exact header level) and keeps only the matched points on each side. An
+ * unmatched point is dropped from whichever side it appears on, so the remaining points
+ * stay aligned regardless of where the divergence occurs.
+ *
+ * Fallback: if the type information is missing or inconsistent with the coordinate arrays
+ * (e.g. callers/tests that set only the Y arrays), it degrades to the original behavior of
+ * truncating both arrays to MIN count.
+ *
+ * Pure function: no view dependencies, so it is unit-testable headless.
+ */
++ (void)alignEditorYs:(NSArray<NSNumber *> *)editorYs
+          editorTypes:(NSArray<NSNumber *> *)editorTypes
+            previewYs:(NSArray<NSNumber *> *)previewYs
+         previewTypes:(NSArray<NSNumber *> *)previewTypes
+      alignedEditorYs:(NSArray<NSNumber *> **)outEditorYs
+     alignedPreviewYs:(NSArray<NSNumber *> **)outPreviewYs
+{
+    NSUInteger editorCount = editorYs.count;
+    NSUInteger previewCount = previewYs.count;
+
+    // Fallback to MIN-count truncation when type tags are absent or inconsistent.
+    if (editorTypes.count != editorCount || previewTypes.count != previewCount) {
+        NSUInteger minCount = MIN(editorCount, previewCount);
+        if (outEditorYs)
+            *outEditorYs = [editorYs subarrayWithRange:NSMakeRange(0, minCount)];
+        if (outPreviewYs)
+            *outPreviewYs = [previewYs subarrayWithRange:NSMakeRange(0, minCount)];
+        return;
+    }
+
+    // Coarse class for matching: images match images, any header matches any header.
+    NSInteger (^classOf)(NSNumber *) = ^NSInteger(NSNumber *kind) {
+        return kind.integerValue == MPReferenceKindImage ? 0 : 1;
+    };
+
+    // LCS over the coarse class sequences. dp[i][j] = LCS length of editor[i..] / preview[j..].
+    NSUInteger m = editorCount, n = previewCount;
+    NSUInteger **dp = calloc(m + 1, sizeof(NSUInteger *));
+    for (NSUInteger i = 0; i <= m; i++)
+        dp[i] = calloc(n + 1, sizeof(NSUInteger));
+
+    for (NSInteger i = (NSInteger)m - 1; i >= 0; i--) {
+        for (NSInteger j = (NSInteger)n - 1; j >= 0; j--) {
+            if (classOf(editorTypes[i]) == classOf(previewTypes[j]))
+                dp[i][j] = dp[i + 1][j + 1] + 1;
+            else
+                dp[i][j] = MAX(dp[i + 1][j], dp[i][j + 1]);
+        }
+    }
+
+    NSMutableArray<NSNumber *> *alignedEditor = [NSMutableArray array];
+    NSMutableArray<NSNumber *> *alignedPreview = [NSMutableArray array];
+    NSUInteger i = 0, j = 0;
+    while (i < m && j < n) {
+        if (classOf(editorTypes[i]) == classOf(previewTypes[j])) {
+            [alignedEditor addObject:editorYs[i]];
+            [alignedPreview addObject:previewYs[j]];
+            i++; j++;
+        } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+            // Drop the editor point (no preview counterpart).
+            i++;
+        } else {
+            // Drop the preview point (no editor counterpart).
+            j++;
+        }
+    }
+
+    for (NSUInteger k = 0; k <= m; k++)
+        free(dp[k]);
+    free(dp);
+
+    if (outEditorYs) *outEditorYs = alignedEditor;
+    if (outPreviewYs) *outPreviewYs = alignedPreview;
+}
+
+/**
+ * Issue #436: Realigns _editorHeaderLocations and _webViewHeaderLocations using the kind
+ * tags so syncScrollers/syncScrollersReverse cross-index matching reference points. See
+ * +alignEditorYs:... for the algorithm; this just wires the instance state through it and
+ * stores the aligned results back.
  */
 - (void)validateHeaderLocationAlignment
 {
-    NSUInteger editorCount = _editorHeaderLocations.count;
-    NSUInteger previewCount = _webViewHeaderLocations.count;
-    if (editorCount != previewCount)
-    {
-        NSUInteger minCount = MIN(editorCount, previewCount);
+    NSArray<NSNumber *> *alignedEditor = nil;
+    NSArray<NSNumber *> *alignedPreview = nil;
+    [MPDocument alignEditorYs:_editorHeaderLocations
+                  editorTypes:_editorHeaderTypes
+                    previewYs:_webViewHeaderLocations
+                 previewTypes:_webViewHeaderTypes
+              alignedEditorYs:&alignedEditor
+             alignedPreviewYs:&alignedPreview];
 #ifdef DEBUG
-        NSLog(@"[ScrollSync] Header location count mismatch: editor=%lu preview=%lu, truncating to %lu",
-              (unsigned long)editorCount, (unsigned long)previewCount, (unsigned long)minCount);
-#endif
-        if (editorCount > minCount)
-            _editorHeaderLocations = [_editorHeaderLocations subarrayWithRange:NSMakeRange(0, minCount)];
-        if (previewCount > minCount)
-            _webViewHeaderLocations = [_webViewHeaderLocations subarrayWithRange:NSMakeRange(0, minCount)];
+    if (alignedEditor.count != _editorHeaderLocations.count
+            || alignedPreview.count != _webViewHeaderLocations.count) {
+        NSLog(@"[ScrollSync] Realigned reference points: editor %lu->%lu, preview %lu->%lu",
+              (unsigned long)_editorHeaderLocations.count, (unsigned long)alignedEditor.count,
+              (unsigned long)_webViewHeaderLocations.count, (unsigned long)alignedPreview.count);
     }
+#endif
+    _editorHeaderLocations = alignedEditor;
+    _webViewHeaderLocations = alignedPreview;
 }
 
 /**

--- a/MacDown/Resources/updateHeaderLocations.js
+++ b/MacDown/Resources/updateHeaderLocations.js
@@ -1,17 +1,26 @@
 /**
  * Detects reference points (headers and standalone images) in the preview document.
- * Returns an array of y-coordinates (relative to document top) for scroll synchronization.
+ * Returns parallel arrays of y-coordinates and kind codes (in document order) for
+ * scroll synchronization.
  *
  * Standalone images are defined as:
  * - An image alone in a paragraph
  * - An image wrapped in a link that's alone in a paragraph
  * - An image that's the only child of its parent element
  *
- * @returns {Array<number>} Array of y-coordinates for reference points, in document order
+ * Issue #436: The y-coordinates alone are not enough to keep the editor and preview
+ * in sync, because the editor (regex over markdown) and the preview (this DOM query)
+ * can disagree about which reference points exist mid-document. Each reference point is
+ * therefore tagged with a "kind" code so the ObjC side can align the two sequences:
+ *   - image  -> 0
+ *   - header -> header level (h1 -> 1, h2 -> 2, ... h6 -> 6)
+ *
+ * @returns {{ys: Array<number>, kinds: Array<number>}} Parallel arrays of y-coordinates
+ *          and kind codes for reference points, in document order.
  */
 (function() {
     try {
-        if (!document.body) return [];
+        if (!document.body) return {ys: [], kinds: []};
 
         var headers = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
         var images = document.querySelectorAll('img');
@@ -72,14 +81,25 @@
             return 0;  // Same node or disconnected
         });
 
-        // Return y-coordinates (document-absolute) for all reference points.
+        // Return y-coordinates (document-absolute) and kind codes for all reference points.
         // Uses window.scrollY + rect.top so the result is independent of current scroll position.
         // No pre-filtering - the syncScrollers algorithm handles end-of-document cases.
-        return result.map(function(item) {
+        var ys = [];
+        var kinds = [];
+        for (var k = 0; k < result.length; k++) {
+            var item = result[k];
             var rect = item.node.getBoundingClientRect();
-            return window.scrollY + rect.top;
-        });
+            ys.push(window.scrollY + rect.top);
+            if (item.type === 'image') {
+                kinds.push(0);
+            } else {
+                // tagName is like 'H3'; the second character is the header level.
+                var level = parseInt(String(item.node.tagName).charAt(1), 10);
+                kinds.push((level >= 1 && level <= 6) ? level : 1);
+            }
+        }
+        return {ys: ys, kinds: kinds};
     } catch (e) {
-        return [];
+        return {ys: [], kinds: []};
     }
 })()

--- a/MacDownTests/MPScrollSyncTests.m
+++ b/MacDownTests/MPScrollSyncTests.m
@@ -2301,6 +2301,14 @@ static const NSUInteger MPScrollOwnerNeither = 2;
                           @"B8: setext header then HR yields just the header (Issue #436)");
 }
 
+- (void)testClassifierSetextWithLeadingAndTrailingSpaces
+{
+    XCTAssertEqualObjects([self kindsFor:@"Title\n   --- "], (@[@2]),
+                          @"B9: setext underline allows 0-3 leading spaces and trailing whitespace (Issue #436)");
+    XCTAssertEqualObjects([self kindsFor:@"Title\n  ==="], (@[@1]),
+                          @"B9: '===' underline allows leading spaces too (Issue #436)");
+}
+
 // --- HR vs setext (no reference points) ---
 
 - (void)testClassifierStandaloneDashHR

--- a/MacDownTests/MPScrollSyncTests.m
+++ b/MacDownTests/MPScrollSyncTests.m
@@ -29,6 +29,17 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 @property (unsafe_unretained) MPEditorView *editor;
 @property (nonatomic) NSUInteger scrollOwner;  // Issue #342: MPScrollOwner enum
 - (void)updateHeaderLocations;
+// Issue #436: pure helpers for reference-point classification and sequence alignment
++ (NSArray<NSNumber *> *)editorReferenceKindsForMarkdown:(NSString *)markdown
+                                          outLineNumbers:(NSArray<NSNumber *> **)outLineNumbers;
++ (void)alignEditorYs:(NSArray<NSNumber *> *)editorYs
+          editorTypes:(NSArray<NSNumber *> *)editorTypes
+            previewYs:(NSArray<NSNumber *> *)previewYs
+         previewTypes:(NSArray<NSNumber *> *)previewTypes
+      alignedEditorYs:(NSArray<NSNumber *> **)outEditorYs
+     alignedPreviewYs:(NSArray<NSNumber *> **)outPreviewYs;
+@property (strong) NSArray<NSNumber *> *webViewHeaderTypes;
+@property (strong) NSArray<NSNumber *> *editorHeaderTypes;
 - (void)syncScrollers;
 - (void)syncScrollersReverse;
 - (void)editorTextDidChange:(NSNotification *)notification;
@@ -1499,7 +1510,7 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
     JSContext *context = [self jsContextWithScrollY:200 headerTops:@[@100]];
     JSValue *result = [context evaluateScript:script];
-    NSArray *locations = [result toArray];
+    NSArray *locations = [result[@"ys"] toArray];  // Issue #436: result is now {ys, kinds}
 
     XCTAssertEqual(locations.count, 1U, @"Should return one location");
     XCTAssertEqualWithAccuracy([[locations firstObject] floatValue], 300.0, 0.5,
@@ -1520,7 +1531,7 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
     JSContext *context = [self jsContextWithScrollY:0 headerTops:@[@150]];
     JSValue *result = [context evaluateScript:script];
-    NSArray *locations = [result toArray];
+    NSArray *locations = [result[@"ys"] toArray];  // Issue #436: result is now {ys, kinds}
 
     XCTAssertEqual(locations.count, 1U, @"Should return one location");
     XCTAssertEqualWithAccuracy([[locations firstObject] floatValue], 150.0, 0.5,
@@ -1560,7 +1571,8 @@ static const NSUInteger MPScrollOwnerNeither = 2;
         @"};\n"];
 
     JSValue *result = [context evaluateScript:script];
-    NSArray *locations = [result toArray];
+    NSArray *locations = [result[@"ys"] toArray];  // Issue #436: result is now {ys, kinds}
+    NSArray *kinds = [result[@"kinds"] toArray];
 
     XCTAssertEqual(locations.count, 3U, @"Should return three locations");
     XCTAssertEqualWithAccuracy([locations[0] floatValue], 550.0, 0.5,
@@ -1569,6 +1581,9 @@ static const NSUInteger MPScrollOwnerNeither = 2;
                                @"Second header: 500+100=600");
     XCTAssertEqualWithAccuracy([locations[2] floatValue], 800.0, 0.5,
                                @"Third header: 500+300=800");
+    // Issue #436: kinds carry the header level parsed from tagName (H1/H2/H3).
+    XCTAssertEqualObjects(kinds, (@[@1, @2, @3]),
+                          @"kinds should be the header levels [1,2,3] in document order");
 }
 
 /**
@@ -1595,7 +1610,7 @@ static const NSUInteger MPScrollOwnerNeither = 2;
         @"};\n"];
 
     JSValue *result = [context evaluateScript:script];
-    NSArray *locations = [result toArray];
+    NSArray *locations = [result[@"ys"] toArray];  // Issue #436: result is now {ys, kinds}
 
     XCTAssertNotNil(locations, @"Result should not be nil for empty body");
     XCTAssertEqual(locations.count, 0U, @"Empty body should return empty array");
@@ -1622,9 +1637,9 @@ static const NSUInteger MPScrollOwnerNeither = 2;
         @"var document = {body: null, querySelectorAll: function(s){return [];}};\n"];
 
     JSValue *result = [context evaluateScript:script];
-    XCTAssertNoThrow((void)[result toArray],
+    XCTAssertNoThrow((void)[result[@"ys"] toArray],
                      @"Script with null document.body should not throw");
-    NSArray *locations = [result toArray];
+    NSArray *locations = [result[@"ys"] toArray];  // Issue #436: result is now {ys, kinds}
     XCTAssertEqual(locations.count, 0U, @"Null body should return empty array");
 }
 
@@ -2178,6 +2193,396 @@ static const NSUInteger MPScrollOwnerNeither = 2;
     {
         prefs.editorSyncScrolling = savedSync;
     }
+}
+
+#pragma mark - Issue #436: Group P — Editor reference classifier (pure)
+
+/**
+ * Helper: classify markdown into reference-point kind codes via the pure classifier.
+ */
+- (NSArray<NSNumber *> *)kindsFor:(NSString *)markdown
+{
+    NSArray<NSNumber *> *lines = nil;
+    return [MPDocument editorReferenceKindsForMarkdown:markdown outLineNumbers:&lines];
+}
+
+// --- ATX headers and clamping ---
+
+- (void)testClassifierATXLevels
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n## B\n### C\n#### D\n##### E\n###### F"],
+                          (@[@1, @2, @3, @4, @5, @6]),
+                          @"A1: ATX header kind equals the hash count (Issue #436)");
+}
+
+- (void)testClassifierSevenHashesNotHeader
+{
+    XCTAssertEqualObjects([self kindsFor:@"####### G"], @[],
+                          @"A2: 7 hashes is not a header in CommonMark/Hoedown (Issue #436)");
+}
+
+- (void)testClassifierEightHashesNotHeader
+{
+    XCTAssertEqualObjects([self kindsFor:@"######## H"], @[],
+                          @"A3: 8 hashes is not a header (Issue #436)");
+}
+
+- (void)testClassifierATXRequiresSpace
+{
+    XCTAssertEqualObjects([self kindsFor:@"#NoSpace"], @[],
+                          @"A4: ATX header requires a space after the hashes (Issue #436)");
+}
+
+- (void)testClassifierBareHashNotHeader
+{
+    XCTAssertEqualObjects([self kindsFor:@"#"], @[],
+                          @"A5: a bare '#' with no following space/text is not a header (Issue #436)");
+}
+
+- (void)testClassifierATXLeadingSpacesAllowed
+{
+    XCTAssertEqualObjects([self kindsFor:@"   ### C"], (@[@3]),
+                          @"A7: 0-3 leading spaces are allowed before ATX hashes (Issue #436)");
+}
+
+- (void)testClassifierATXFourLeadingSpacesNotHeader
+{
+    XCTAssertEqualObjects([self kindsFor:@"    # C"], @[],
+                          @"A8: 4 leading spaces is indented code, not a header (Issue #436)");
+}
+
+// --- Setext headers ---
+
+- (void)testClassifierSetextEqualsIsH1
+{
+    XCTAssertEqualObjects([self kindsFor:@"Title\n==="], (@[@1]),
+                          @"B1: '===' under a paragraph line is a level-1 setext header (Issue #436)");
+}
+
+- (void)testClassifierSetextDashIsH2
+{
+    XCTAssertEqualObjects([self kindsFor:@"Title\n---"], (@[@2]),
+                          @"B2: '---' under a paragraph line is a level-2 setext header (Issue #436)");
+}
+
+- (void)testClassifierSetextRequiresPrevContent
+{
+    XCTAssertEqualObjects([self kindsFor:@"\n---"], @[],
+                          @"B3: '---' with no preceding content is an HR, not a setext header (Issue #436)");
+}
+
+- (void)testClassifierSetextAfterBlankLineIsNotHeader
+{
+    XCTAssertEqualObjects([self kindsFor:@"Text\n\n---"], @[],
+                          @"B4: a blank line breaks setext context, so '---' is an HR (Issue #436)");
+}
+
+- (void)testClassifierEqualsAfterBlankIsNotHeader
+{
+    XCTAssertEqualObjects([self kindsFor:@"Text\n\n==="], @[],
+                          @"B5: '===' not directly under content is not a setext header (Issue #436)");
+}
+
+- (void)testClassifierTwoDashesSetext
+{
+    XCTAssertEqualObjects([self kindsFor:@"Text\n--"], (@[@2]),
+                          @"B6: two dashes under content is a setext header, not an HR (Issue #436)");
+}
+
+- (void)testClassifierMultipleSetext
+{
+    XCTAssertEqualObjects([self kindsFor:@"H1\n===\n\nH2\n---"], (@[@1, @2]),
+                          @"B7: multiple setext headers detected with correct levels (Issue #436)");
+}
+
+- (void)testClassifierSetextThenHR
+{
+    XCTAssertEqualObjects([self kindsFor:@"H\n---\n\n***"], (@[@2]),
+                          @"B8: setext header then HR yields just the header (Issue #436)");
+}
+
+// --- HR vs setext (no reference points) ---
+
+- (void)testClassifierStandaloneDashHR
+{
+    XCTAssertEqualObjects([self kindsFor:@"---\n\ntext"], @[],
+                          @"C1: a leading '---' is an HR (Issue #436)");
+}
+
+- (void)testClassifierAsteriskHR
+{
+    XCTAssertEqualObjects([self kindsFor:@"***"], @[], @"C2: '***' is an HR (Issue #436)");
+}
+
+- (void)testClassifierSpacedDashHR
+{
+    XCTAssertEqualObjects([self kindsFor:@"- - -"], @[],
+                          @"C4: '- - -' is an HR, not a setext underline (Issue #436)");
+}
+
+- (void)testClassifierHRAfterATX
+{
+    XCTAssertEqualObjects([self kindsFor:@"# H\n\n---"], (@[@1]),
+                          @"C5: ATX header followed by an HR yields just the header (Issue #436)");
+}
+
+- (void)testClassifierHeadingThenDashesIsHR
+{
+    XCTAssertEqualObjects([self kindsFor:@"# H\n---"], (@[@1]),
+                          @"An ATX heading is not paragraph text, so a following '---' is an HR (Issue #436)");
+}
+
+// --- Fenced code blocks ---
+
+- (void)testClassifierBacktickFenceSkipsHeaders
+{
+    XCTAssertEqualObjects([self kindsFor:@"# Real\n\n```\n# Fake\n## Fake\n```\n\n## Real2"],
+                          (@[@1, @2]),
+                          @"D1: headers inside a backtick fence are skipped (Issue #436)");
+}
+
+- (void)testClassifierTildeFenceSkipsHeaders
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n\n~~~\n# Fake\n~~~\n\n## B"],
+                          (@[@1, @2]),
+                          @"D2: headers inside a tilde fence are skipped (Issue #436)");
+}
+
+- (void)testClassifierFenceWithInfoString
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n\n```objc\n# Fake\n```\n\n## B"],
+                          (@[@1, @2]),
+                          @"D3: a fence with an info string still skips its contents (Issue #436)");
+}
+
+- (void)testClassifierUnclosedFenceAtEOFSkipsRest
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n\n```\n# Fake\n## Fake"],
+                          (@[@1]),
+                          @"D4: an unclosed fence at EOF swallows the remaining headers (Issue #436)");
+}
+
+- (void)testClassifierBacktickDoesNotCloseTildeFence
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n\n~~~\n# Fake\n```\n## StillFake\n~~~\n\n## B"],
+                          (@[@1, @2]),
+                          @"D5: a backtick line does not close a tilde fence (Issue #436)");
+}
+
+- (void)testClassifierClosingFenceLengthRule
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n\n````\n# Fake\n```\n## StillFake\n````\n\n## B"],
+                          (@[@1, @2]),
+                          @"D6: a closing fence must be at least as long as the opening fence (Issue #436)");
+}
+
+- (void)testClassifierFourBacktickFence
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n\n````\n# Fake\n````\n\n## B"],
+                          (@[@1, @2]),
+                          @"D7: a 4-backtick fence opens and closes normally (Issue #436)");
+}
+
+- (void)testClassifierFenceThreeLeadingSpaces
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n\n   ```\n# Fake\n   ```\n\n## B"],
+                          (@[@1, @2]),
+                          @"D8: 0-3 leading spaces are allowed on a fence marker (Issue #436)");
+}
+
+- (void)testClassifierFourLeadingSpacesIsNotAFence
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n\n    ```\n# Fake\n\n## B"],
+                          (@[@1, @1, @2]),
+                          @"D9: a 4-space-indented marker is not a fence, so '# Fake' is a real header (Issue #436)");
+}
+
+- (void)testClassifierImageInsideFenceSkipped
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n\n```\n![x](y.png)\n```\n\n## B"],
+                          (@[@1, @2]),
+                          @"D11: a standalone image inside a fence is skipped (Issue #436)");
+}
+
+// --- Images ---
+
+- (void)testClassifierStandaloneInlineImage
+{
+    XCTAssertEqualObjects([self kindsFor:@"![alt](img.png)"], (@[@0]),
+                          @"E1: a whole-line inline image is a reference point (Issue #436)");
+}
+
+- (void)testClassifierStandaloneRefImage
+{
+    XCTAssertEqualObjects([self kindsFor:@"![alt][ref]"], (@[@0]),
+                          @"E2: a whole-line reference image is a reference point (Issue #436)");
+}
+
+- (void)testClassifierInlineImageInTextIgnored
+{
+    XCTAssertEqualObjects([self kindsFor:@"text ![x](y.png) more"], @[],
+                          @"E3: an image inline with text is not a reference point (Issue #436)");
+}
+
+- (void)testClassifierImageWithTrailingTextIgnored
+{
+    XCTAssertEqualObjects([self kindsFor:@"![x](y.png) caption"], @[],
+                          @"E5: an image with trailing text is not standalone (Issue #436)");
+}
+
+- (void)testClassifierHeaderThenImage
+{
+    XCTAssertEqualObjects([self kindsFor:@"# H\n\n![x](y.png)"], (@[@1, @0]),
+                          @"E6: header then standalone image yields [H1, image] (Issue #436)");
+}
+
+// --- Mixed / integration ---
+
+- (void)testClassifierComplexDocument
+{
+    NSString *md = @"# Main\n\nintro\n\n## Sec\n\n![Fig](f.png)\n\n"
+                   @"text ![inline](s.png) text\n\n---\n\n### Sub\n\n![Fig2][f2]\n\n[f2]: f2.png";
+    NSArray<NSNumber *> *lines = nil;
+    NSArray<NSNumber *> *kinds = [MPDocument editorReferenceKindsForMarkdown:md outLineNumbers:&lines];
+
+    XCTAssertEqualObjects(kinds, (@[@1, @2, @0, @3, @0]),
+                          @"F1: mixed document yields headers and standalone images only (Issue #436)");
+    XCTAssertEqual(lines.count, kinds.count,
+                   @"F1: line numbers must run parallel to kinds (Issue #436)");
+    for (NSUInteger i = 1; i < lines.count; i++) {
+        XCTAssertGreaterThan(lines[i].unsignedIntegerValue, lines[i - 1].unsignedIntegerValue,
+                             @"F1: reference-point line numbers must be strictly increasing (Issue #436)");
+    }
+}
+
+- (void)testClassifierHeadersInsideAndOutsideFences
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n```\n## skip\n```\n### B\n\n~~~\n#### skip\n~~~\n##### C"],
+                          (@[@1, @3, @5]),
+                          @"F4: only headers outside fences are detected (Issue #436)");
+}
+
+- (void)testClassifierEmptyDocument
+{
+    XCTAssertEqualObjects([self kindsFor:@""], @[], @"F2: empty document has no reference points (Issue #436)");
+}
+
+- (void)testClassifierWhitespaceOnlyDocument
+{
+    XCTAssertEqualObjects([self kindsFor:@"\n\n\n"], @[],
+                          @"F3: whitespace-only document has no reference points (Issue #436)");
+}
+
+- (void)testClassifierTrailingNewlineNoExtraReference
+{
+    XCTAssertEqualObjects([self kindsFor:@"# A\n"], (@[@1]),
+                          @"A trailing newline must not add a spurious reference point (Issue #436)");
+}
+
+#pragma mark - Issue #436: Group Q — Reference-point aligner (LCS)
+
+/**
+ * Helper: run the pure aligner and assert both aligned outputs.
+ */
+- (void)assertAlignEditorYs:(NSArray *)eY types:(NSArray *)eT
+                  previewYs:(NSArray *)pY types:(NSArray *)pT
+              expectEditor:(NSArray *)wantE expectPreview:(NSArray *)wantP
+                    message:(NSString *)msg
+{
+    NSArray<NSNumber *> *outE = nil, *outP = nil;
+    [MPDocument alignEditorYs:eY editorTypes:eT previewYs:pY previewTypes:pT
+              alignedEditorYs:&outE alignedPreviewYs:&outP];
+    XCTAssertEqualObjects(outE, wantE, @"%@ (editor)", msg);
+    XCTAssertEqualObjects(outP, wantP, @"%@ (preview)", msg);
+    XCTAssertEqual(outE.count, outP.count, @"%@ (outputs must be equal length)", msg);
+}
+
+- (void)testAlignIdenticalIsNoOp
+{
+    [self assertAlignEditorYs:@[@10, @20, @30] types:@[@1, @1, @1]
+                    previewYs:@[@11, @21, @31] types:@[@1, @1, @1]
+                 expectEditor:@[@10, @20, @30] expectPreview:@[@11, @21, @31]
+                      message:@"G1: identical kind sequences align fully (Issue #436)"];
+}
+
+- (void)testAlignLevelMismatchStillMatches
+{
+    [self assertAlignEditorYs:@[@10, @20] types:@[@1, @2]
+                    previewYs:@[@11, @21] types:@[@2, @3]
+                 expectEditor:@[@10, @20] expectPreview:@[@11, @21]
+                      message:@"G2: headers match on coarse class regardless of level (Issue #436)"];
+}
+
+- (void)testAlignExtraImageOnEditorMid
+{
+    [self assertAlignEditorYs:@[@10, @20, @30] types:@[@1, @0, @1]
+                    previewYs:@[@11, @31] types:@[@1, @1]
+                 expectEditor:@[@10, @30] expectPreview:@[@11, @31]
+                      message:@"G3: an unmatched mid-document editor point is dropped from both (Issue #436)"];
+}
+
+- (void)testAlignExtraImageOnPreviewMid
+{
+    [self assertAlignEditorYs:@[@10, @30] types:@[@1, @1]
+                    previewYs:@[@11, @21, @31] types:@[@1, @0, @1]
+                 expectEditor:@[@10, @30] expectPreview:@[@11, @31]
+                      message:@"G4: an unmatched mid-document preview point is dropped from both (Issue #436)"];
+}
+
+- (void)testAlignMultipleDivergences
+{
+    [self assertAlignEditorYs:@[@10, @20, @30, @40] types:@[@1, @1, @0, @1]
+                    previewYs:@[@11, @31, @41] types:@[@1, @0, @1]
+                 expectEditor:@[@10, @30, @40] expectPreview:@[@11, @31, @41]
+                      message:@"G5: alignment realigns around multiple divergences (Issue #436)"];
+}
+
+- (void)testAlignTotalMismatchEmpty
+{
+    [self assertAlignEditorYs:@[@10] types:@[@0]
+                    previewYs:@[@11] types:@[@1]
+                 expectEditor:@[] expectPreview:@[]
+                      message:@"G6: image-vs-header with no common class yields empty alignment (Issue #436)"];
+}
+
+- (void)testAlignEmptyInputs
+{
+    [self assertAlignEditorYs:@[] types:@[]
+                    previewYs:@[] types:@[]
+                 expectEditor:@[] expectPreview:@[]
+                      message:@"G7: empty inputs yield empty outputs (Issue #436)"];
+}
+
+- (void)testAlignSingleMatch
+{
+    [self assertAlignEditorYs:@[@10] types:@[@1]
+                    previewYs:@[@11] types:@[@1]
+                 expectEditor:@[@10] expectPreview:@[@11]
+                      message:@"G8: a single matching pair aligns (Issue #436)"];
+}
+
+- (void)testAlignOneSideEmpty
+{
+    [self assertAlignEditorYs:@[@10, @20] types:@[@1, @1]
+                    previewYs:@[] types:@[]
+                 expectEditor:@[] expectPreview:@[]
+                      message:@"G9: when one side is empty the alignment is empty (Issue #436)"];
+}
+
+- (void)testAlignTypesAbsentFallsBackToTruncation
+{
+    [self assertAlignEditorYs:@[@10, @20, @30] types:nil
+                    previewYs:@[@11, @21] types:nil
+                 expectEditor:@[@10, @20] expectPreview:@[@11, @21]
+                      message:@"G10: missing types fall back to MIN-count truncation (Issue #436)"];
+}
+
+- (void)testAlignTypesCountMismatchFallsBackToTruncation
+{
+    [self assertAlignEditorYs:@[@10, @20, @30] types:@[@1, @1]
+                    previewYs:@[@11, @21, @31] types:@[@1, @1, @1]
+                 expectEditor:@[@10, @20, @30] expectPreview:@[@11, @21, @31]
+                      message:@"G11: inconsistent type counts fall back to MIN-count truncation (Issue #436)"];
 }
 
 @end

--- a/plans/scroll-sync-fix-analysis.md
+++ b/plans/scroll-sync-fix-analysis.md
@@ -193,7 +193,7 @@ No timers anywhere in the sync path.
 
 ### Step 4 — Fix asymmetric header filtering (Bug D)
 
-Remove the `editorContentHeight - editorVisibleHeight` filter from `_editorHeaderLocations` in `updateHeaderLocations`. Both arrays should contain all headers in document order. The `interpolateToEndOfDocument` logic in `syncScrollers` and `syncScrollersReverse` already handles the end-of-document case correctly; no pre-filtering is needed. This ensures `_editorHeaderLocations[n]` and `_webViewHeaderLocations[n]` always refer to the same heading.
+Remove the `editorContentHeight - editorVisibleHeight` filter from `_editorHeaderLocations` in `updateHeaderLocations`. Both arrays should contain all headers in document order. The `interpolateToEndOfDocument` logic in `syncScrollers` and `syncScrollersReverse` already handles the end-of-document case correctly; no pre-filtering is needed. (Filter removal alone does not guarantee `_editorHeaderLocations[n]` and `_webViewHeaderLocations[n]` refer to the same heading — the detectors can still disagree mid-document. Issue #436 later added a kind-tagged LCS alignment pass, `validateHeaderLocationAlignment`, that restores the 1:1 index invariant before `syncScrollers`/`syncScrollersReverse` run.)
 
 ### Step 5 — Fix `lastPreviewScrollTop` (Bug E)
 
@@ -264,7 +264,7 @@ Conducted after multi-agent codebase review. All line numbers are from `MPDocume
 
 ### `updateHeaderLocations.js` confirmed
 
-Currently returns `rect.top` (viewport-relative). The Step 1 fix (`window.scrollY + rect.top`) is confirmed necessary.
+The Step 1 fix landed: the script returns document-absolute coordinates (`window.scrollY + rect.top`). It has since (#436) been changed to return `{ys, kinds}` — parallel arrays of y-coordinates and kind codes (0 = image, 1-6 = header level) — rather than a bare array of y-coordinates.
 
 ### `syncScrollers` and `syncScrollersReverse` have their own runtime filters
 
@@ -407,7 +407,9 @@ All tests live in `MacDownTests/MPScrollSyncTests.m`. No new test file is needed
 
 Mock DOM in JSContext: inject `window = {scrollY: N}`, `document = {body: ..., querySelectorAll: fn}`, `Node = {DOCUMENT_POSITION_FOLLOWING: 4, ...}`. Load and evaluate `updateHeaderLocations.js`.
 
-| Test | scrollY | header rect.top(s) | Expected result |
+(Since #436 the script returns `{ys, kinds}`; the expected `ys` values are below.)
+
+| Test | scrollY | header rect.top(s) | Expected `ys` |
 |------|---------|-------------------|-----------------|
 | C1 — scrolled page | 200 | [100] | [300] |
 | C2 — unscrolled page | 0 | [150] | [150] |

--- a/plans/scroll-sync.md
+++ b/plans/scroll-sync.md
@@ -41,9 +41,9 @@ Both panes detect the same set of structural elements: ATX headers (`# Heading`)
 
 **Editor side.** `updateHeaderLocations` (a single method that populates both arrays) runs a regex over the raw Markdown text and uses `NSLayoutManager` to convert character offsets to Y-coordinates in the text view's coordinate system.
 
-**Preview side.** The same `updateHeaderLocations` method evaluates `updateHeaderLocations.js` synchronously via the WebView's `JavaScriptContext`. The script runs `document.querySelectorAll('h1, h2, h3, h4, h5, h6')` and a standalone image query, returning document-absolute Y-coordinates computed as `window.scrollY + getBoundingClientRect().top` for each matched element. The result crosses the JavaScript-to-Objective-C boundary via `JSValue`'s `-toArray` method.
+**Preview side.** The same `updateHeaderLocations` method evaluates `updateHeaderLocations.js` synchronously via the WebView's `JavaScriptContext`. The script runs `document.querySelectorAll('h1, h2, h3, h4, h5, h6')` and a standalone image query, returning an object `{ys, kinds}` where `ys` holds document-absolute Y-coordinates computed as `window.scrollY + getBoundingClientRect().top` for each matched element and `kinds` holds the parallel kind codes (0 = image, 1-6 = header level). The result crosses the JavaScript-to-Objective-C boundary as a `JSValue`.
 
-The two arrays must stay parallel — the Nth entry in `_editorHeaderLocations` must correspond to the Nth entry in `_webViewHeaderLocations`. In practice they can diverge because the editor regex matches headers inside code blocks while the JS query does not (issue #375 tracks AST-based detection as a fix). A runtime validation step, `validateHeaderLocationAlignment`, detects count mismatches and truncates both arrays to the shorter length. This prevents index-out-of-bounds errors but discards trailing reference points.
+The two arrays must stay parallel — the Nth entry in `_editorHeaderLocations` must correspond to the Nth entry in `_webViewHeaderLocations`. In practice they can diverge because the editor and preview detectors disagree mid-document (headers inside fenced code blocks, `===` setext headers, 7+ hash lines), which would shift every subsequent index. To keep the arrays aligned, each reference point is tagged with a kind code. `updateHeaderLocations.js` returns `{ys, kinds}` (kind 0 = image, 1-6 = header level), and the editor side computes parallel kind codes via the pure class method `+editorReferenceKindsForMarkdown:outLineNumbers:`, which skips headers inside ``` / ~~~ fences, detects `===`/`---` setext headers, treats 7+ hashes as non-headers (CommonMark/Hoedown), allows 0-3 leading spaces on ATX, and detects standalone images. The kinds are stored in the private parallel arrays `_editorHeaderTypes` / `_webViewHeaderTypes`. A runtime validation step, `validateHeaderLocationAlignment`, calls `+alignEditorYs:editorTypes:previewYs:previewTypes:alignedEditorYs:alignedPreviewYs:`, which runs an LCS over the coarse kind class (image vs header) and keeps only matched points, dropping unmatched points on the correct side (issue #436). It falls back to truncating both arrays to the shorter length when the kind tags are absent or inconsistent.
 
 ---
 
@@ -148,7 +148,7 @@ This prevents state corruption but does not eliminate the brief visual flash whe
 
 **MathJax visual jump.** The generation counter prevents incorrect state transitions but cannot prevent the un-typeset DOM from being briefly visible between DOM replacement and MathJax completion.
 
-**Header array alignment divergence.** The editor regex detects headers inside fenced code blocks; the JS query does not. This causes the two arrays to have different lengths on documents with headers in code blocks. The truncation fix loses trailing reference points, reducing sync accuracy at the bottom of the document (#375).
+**Header array alignment divergence.** The editor detector and the JS query can disagree mid-document (e.g. headers inside fenced code blocks). Issue #436 addresses this by tagging each reference point with a kind code and aligning the two sequences with an LCS over the coarse kind class (image vs header), keeping only matched points rather than truncating from the tail. AST-based editor-side detection (#375) would further reduce divergence at the source.
 
 **Checkbox toggle and syntax highlighting.** Checkbox toggles modify `NSTextStorage` directly, which fires `NSTextStorageDidProcessEditingNotification` but not `NSTextDidChangeNotification`. The syntax highlighter observes the latter, so it does not re-highlight after a checkbox toggle.
 
@@ -158,7 +158,7 @@ This prevents state corruption but does not eliminate the brief visual flash whe
 
 ## Future Work
 
-- **AST-based header detection** (#375): Replace the editor-side regex with an AST walk that is aware of code block boundaries. This would eliminate the primary cause of array alignment divergence.
+- **AST-based header detection** (#375): Replace the editor-side detector with an AST walk that is aware of code block boundaries. The kind-tagged LCS alignment (#436) already keeps the two arrays parallel when the detectors disagree; an AST walk would reduce divergence at the source.
 
 - **WKWebView migration** (#111): The `WebView` class is deprecated. Migrating to `WKWebView` will require reworking the JavaScript bridge used by `updateHeaderLocations.js` and the DOM replacement path.
 

--- a/plans/test_coverage_improvement_plan.md
+++ b/plans/test_coverage_improvement_plan.md
@@ -30,7 +30,7 @@ MacDown currently has minimal test coverage (~7% test-to-code ratio) focused pri
 | MPColorTests.m | Color parsing | Good | ~39 |
 | MPAssetTests.m | Asset handling | Good | ~122 |
 | MPDocumentIOTests.m | File I/O, document state | Good | ~340 |
-| MPScrollSyncTests.m | Scroll sync, JavaScript sort, horizontal rule/setext header detection, bidirectional scroll sync | Excellent | ~1201 |
+| MPScrollSyncTests.m | Scroll sync, JavaScript sort, horizontal rule/setext header detection, bidirectional scroll sync, reference-kind classifier and kind-tagged alignment (Issue #436) | Excellent | ~1201 |
 | MPDocumentLifecycleTests.m | Document lifecycle, dirty flags, encoding | Good | (Issue #234) |
 | MPNotificationTests.m | Notification observers, preference changes | Good | (Issue #234) |
 | MPRendererEdgeCaseTests.m | Renderer edge cases, nil handling | Good | (Issue #234) |
@@ -58,7 +58,7 @@ MacDown currently has minimal test coverage (~7% test-to-code ratio) focused pri
 **Partial Coverage:**
 - Markdown rendering engine (MPRenderer.m) - 18 golden file tests + 3 regression tests added (Issue #89, Issue #81)
 - Document management (MPDocument.m) - File I/O and state management covered (Issue #90)
-- Scroll synchronization (MPDocument.m) - 78 regression tests covering header detection, scroll position preservation, JavaScript sort logic, horizontal rule regex edge cases, setext header detection, bidirectional scroll sync, and editing-state-aware sync (Issue #39, Issue #143, Issue #144, Issue #258, Issue #282)
+- Scroll synchronization (MPDocument.m) - 78 regression tests covering header detection, scroll position preservation, JavaScript sort logic, horizontal rule regex edge cases, setext header detection, bidirectional scroll sync, and editing-state-aware sync (Issue #39, Issue #143, Issue #144, Issue #258, Issue #282); plus pure-function tests for the reference-kind classifier (`+editorReferenceKindsForMarkdown:outLineNumbers:`) and kind-tagged LCS alignment (`+alignEditorYs:...`) that keep the editor/preview reference arrays parallel when the detectors disagree mid-document (Issue #436)
 - Preferences UI localization - Validation tests for complete translations added (Issue #40)
 - Style change detection (MPDocument.m) - Tests for CSS style and syntax highlighting theme change detection added (Issue #219); style reload cache invalidation tests added (Issue #318)
 - Security policy (MPURLSecurityPolicy.m) - 16 tests covering executable/bundle detection and directory scope enforcement for CVE-2019-12138 and CVE-2019-12173 (Issue #351)


### PR DESCRIPTION
## Summary

Editor↔preview scroll sync built two parallel arrays of reference-point Y-coordinates — the editor side via regex over the raw markdown (`MPDocument.m` `updateHeaderLocations`), the preview side via a DOM query (`updateHeaderLocations.js`) — and assumed they corresponded **1:1 by index**. The two detectors disagree mid-document, and a single extra point on one side shifts every later index, so the panes ended up **synced only at the very start and end** of a large document (issue #436).

Three detector divergences caused this on real files:
- ATX/setext headers **inside fenced code blocks** were counted by the editor regex but render as `<pre><code>` (no header) in the preview.
- **`===` setext headers** were never detected by the editor (only `---` was).
- **7+ hash lines** matched the editor's `^#+\s` but are not headers in CommonMark/Hoedown.

### Fix
- **Tag every reference point with a kind** on both sides. `updateHeaderLocations.js` now returns `{ys, kinds}` (0 = image, 1–6 = header level); the editor scan records parallel type arrays. The public `editorHeaderLocations` / `webViewHeaderLocations` stay `NSArray<NSNumber*>` so existing consumers are untouched.
- **Make the editor scan agree with the rendered DOM** via a new pure classifier `+editorReferenceKindsForMarkdown:outLineNumbers:`: skips headers inside ` ``` ` / `~~~` fences, detects `===` (level 1) and `---` (level 2, allowing 0–3 leading spaces and trailing whitespace), treats 7+ hashes as paragraph text, allows 0–3 leading spaces on ATX. Fence detection lives in a small static helper `MPScanFenceMarker`.
- **Replace tail-truncation** in `validateHeaderLocationAlignment` with a new pure aligner `+alignEditorYs:editorTypes:previewYs:previewTypes:…` that runs an **LCS over the coarse kind class (image vs header)** and keeps only matched points, dropping unmatched ones on the correct side regardless of position. Falls back to MIN-count truncation when type tags are absent (preserves existing callers/tests).
- `syncScrollers` / `syncScrollersReverse` and the issue #342 scroll-ownership machinery are **unchanged** — the alignment pass restores the 1:1 index invariant they already assume.

The classifier and aligner are pure class methods, so they are unit-tested headless with **real assertions** (counts, kinds, alignment) rather than no-crash checks — including the mid-document-divergence case that reproduces this bug.

## Related Issue

Related to #436

## Manual Testing Plan

1. **Repro the original bug:** open the large markdown file attached to issue #436 (or any long doc that mixes headings, fenced code blocks containing `#` lines, and `===`/`---` setext titles). Drag the editor scrollbar to the middle. **Expected:** the preview tracks the same section, not just at the top/bottom.
2. **Fenced code with `#` lines:** a document with a code block full of shell comments (`# ...`) between two real headings should keep sync through and past the block.
3. **`===` titles:** a doc using `Title\n===` setext headings should sync at those headings.
4. **Reverse sync:** drag the *preview* scrollbar on the same file; the editor should follow to the matching section.
5. **Edge content:** documents with many standalone images, deeply nested headings, 7+ `#` lines, and HRs should scroll without the editor and preview drifting apart.
6. **No regression:** short documents, empty documents, and live typing should still sync as before.

## Review Notes

- Architecture and test design were developed with the project's agent workflow; code review found no merge blockers.
- Two minor residual detector divergences (the editor's whole-line image rule is narrower than the DOM's standalone-image heuristics) are now **absorbed gracefully** by the LCS aligner — an unmatched point is dropped rather than cascading — instead of misaligning the rest of the document.
- Tests run on macOS CI only; correctness was verified statically (CI is running on the branch).
- `plans/scroll-sync.md`, `plans/scroll-sync-fix-analysis.md`, and `plans/test_coverage_improvement_plan.md` were updated to reflect the new `{ys, kinds}` shape and the kind-tagged LCS alignment.

