### PR TITLE
Add GitHub Dark Default editor theme

### DIFF
--- a/MacDown/Resources/Themes/GitHub Dark Default+.style
+++ b/MacDown/Resources/Themes/GitHub Dark Default+.style
@@ -1,0 +1,93 @@
+editor
+foreground: e6edf3
+background: 0d1117
+caret: e6edf3
+
+editor-selection
+foreground: e6edf3
+background: 264f78
+
+H1
+foreground: 79c0ff
+font-style: bold
+font-size: 24px
+
+H2
+foreground: 79c0ff
+font-style: bold
+font-size: 20px
+
+H3
+foreground: 79c0ff
+font-style: bold
+font-size: 17px
+
+H4
+foreground: 79c0ff
+font-style: bold
+font-size: 15px
+
+H5
+foreground: 79c0ff
+font-style: bold
+font-size: 13px
+
+H6
+foreground: 79c0ff
+font-style: bold
+font-size: 11px
+
+EMPH
+foreground: e6edf3
+font-style: italic
+
+STRONG
+foreground: e6edf3
+font-style: bold
+
+HRULE
+foreground: 7d8590
+
+LIST_BULLET
+foreground: ffa657
+
+LIST_ENUMERATOR
+foreground: ffa657
+
+LINK
+foreground: 2f81f7
+
+AUTO_LINK_URL
+foreground: 2f81f7
+
+AUTO_LINK_EMAIL
+foreground: 2f81f7
+
+REFERENCE
+foreground: 58a6ff
+
+IMAGE
+foreground: 7ee787
+
+CODE
+foreground: 79c0ff
+background: 161b22
+
+VERBATIM
+foreground: 79c0ff
+background: 161b22
+
+HTML
+foreground: 8b949e
+
+HTMLBLOCK
+foreground: 8b949e
+
+HTML_ENTITY
+foreground: 8b949e
+
+COMMENT
+foreground: 8b949e
+
+BLOCKQUOTE
+foreground: 7ee787

--- a/MacDown/Resources/Themes/GitHub Dark Default.style
+++ b/MacDown/Resources/Themes/GitHub Dark Default.style
@@ -1,0 +1,87 @@
+editor
+foreground: e6edf3
+background: 0d1117
+caret: e6edf3
+
+editor-selection
+foreground: e6edf3
+background: 264f78
+
+H1
+foreground: 79c0ff
+font-style: bold
+
+H2
+foreground: 79c0ff
+font-style: bold
+
+H3
+foreground: 79c0ff
+font-style: bold
+
+H4
+foreground: 79c0ff
+font-style: bold
+
+H5
+foreground: 79c0ff
+font-style: bold
+
+H6
+foreground: 79c0ff
+font-style: bold
+
+EMPH
+foreground: e6edf3
+font-style: italic
+
+STRONG
+foreground: e6edf3
+font-style: bold
+
+HRULE
+foreground: 7d8590
+
+LIST_BULLET
+foreground: ffa657
+
+LIST_ENUMERATOR
+foreground: ffa657
+
+LINK
+foreground: 2f81f7
+
+AUTO_LINK_URL
+foreground: 2f81f7
+
+AUTO_LINK_EMAIL
+foreground: 2f81f7
+
+REFERENCE
+foreground: 58a6ff
+
+IMAGE
+foreground: 7ee787
+
+CODE
+foreground: 79c0ff
+background: 161b22
+
+VERBATIM
+foreground: 79c0ff
+background: 161b22
+
+HTML
+foreground: 8b949e
+
+HTMLBLOCK
+foreground: 8b949e
+
+HTML_ENTITY
+foreground: 8b949e
+
+COMMENT
+foreground: 8b949e
+
+BLOCKQUOTE
+foreground: 7ee787


### PR DESCRIPTION
## Summary

Adds GitHub Dark Default color scheme as an editor theme for MacDown 3000.

The colors are ported from the official [GitHub VS Code extension](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) ([primer/github-vscode-theme](https://github.com/primer/github-vscode-theme)), using Primer primitives for the `dark` variant.

## Color mapping

| Token | Color | Source |
|-------|-------|--------|
| Background | `#0d1117` | `scale.gray[9]` |
| Foreground | `#e6edf3` | `fg.default` |
| Headings (H1–H6) | `#79c0ff` | `scale.blue[2]` |
| Links | `#2f81f7` | `accent.fg` |
| Code / Verbatim | `#79c0ff` on `#161b22` | `scale.blue[2]` |
| Blockquote | `#7ee787` | `scale.green[1]` |
| Comments / HTML | `#8b949e` | `fg.muted` |
| List bullets | `#ffa657` | `scale.orange[3]` |
| Images | `#7ee787` | `scale.green[1]` |
| Selection | `#264f78` | VS Code selection blue |

## Files added

- `MacDown/Resources/Themes/GitHub Dark Default.style` — standard (no font sizes)
- `MacDown/Resources/Themes/GitHub Dark Default+.style` — with font sizes (H1: 24px → H6: 11px)