### PR TITLE
Widen HTML preferences pane to fit theme controls

### DIFF
--- a/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
@@ -18,7 +18,7 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="430" height="367"/>
+            <rect key="frame" x="0.0" y="0.0" width="482" height="367"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0ez-nk-c3q">
@@ -30,7 +30,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wgm-Sy-7mr">
-                    <rect key="frame" x="105" y="323" width="161" height="26"/>
+                    <rect key="frame" x="105" y="323" width="231" height="26"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="9Mg-zg-Kvi">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -41,7 +41,7 @@
                     </connections>
                 </popUpButton>
                 <segmentedControl horizontalHuggingPriority="300" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IJe-cc-YKn">
-                    <rect key="frame" x="269" y="324" width="118" height="24"/>
+                    <rect key="frame" x="344" y="324" width="118" height="24"/>
                     <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="momentary" id="0rH-I9-Dxr">
                         <font key="font" metaFont="smallSystem"/>
                         <segments>
@@ -54,7 +54,7 @@
                     </connections>
                 </segmentedControl>
                 <pathControl verticalHuggingPriority="750" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bih-Hu-dSj">
-                    <rect key="frame" x="104" y="16" width="284" height="22"/>
+                    <rect key="frame" x="104" y="16" width="358" height="22"/>
                     <pathCell key="cell" controlSize="small" selectable="YES" editable="YES" alignment="left" pathStyle="popUp" id="eXH-Mm-BJH">
                         <font key="font" metaFont="smallSystem"/>
                         <url key="url" string="file:///Applications/"/>
@@ -75,7 +75,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="Zna-RM-nBO">
-                    <rect key="frame" x="106" y="295" width="281" height="18"/>
+                    <rect key="frame" x="106" y="295" width="356" height="18"/>
                     <buttonCell key="cell" type="check" title="Syntax highlighted code block" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="BuQ-02-oQB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -85,7 +85,7 @@
                     </connections>
                 </button>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2I4-c8-jan">
-                    <rect key="frame" x="202" y="268" width="110" height="22"/>
+                    <rect key="frame" x="202" y="268" width="132" height="22"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="dvX-w7-kuE">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystem"/>
@@ -97,7 +97,7 @@
                     </connections>
                 </popUpButton>
                 <segmentedControl horizontalHuggingPriority="300" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="311-HC-seg">
-                    <rect key="frame" x="320" y="269" width="67" height="20"/>
+                    <rect key="frame" x="342" y="267" width="118" height="24"/>
                     <segmentedCell key="cell" borderStyle="border" alignment="left" controlSize="small" style="rounded" trackingMode="momentary" id="311-HC-cel">
                         <font key="font" metaFont="smallSystem"/>
                         <segments>

--- a/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
+++ b/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
@@ -312,6 +312,32 @@ static NSArray<NSButton *> *MPCheckboxes(NSView *content)
     }];
 }
 
+// The HTML pane's CSS theme popup and its Reveal/Reload controls were clipped
+// at the original 430pt design width, most visibly with long theme names such
+// as the bundled "GitHub Dark Default". loadView pins each pane to its XIB
+// design width (it never widens, only grows height), so the design width itself
+// must stay wide enough. This guards against the pane being narrowed back to the
+// cramped value. (Issue #419.)
+- (void)testHtmlPaneIsWideEnoughForThemeControls
+{
+    MPHtmlPreferencesViewController *vc = [[MPHtmlPreferencesViewController alloc] init];
+    NSView *content = MPContentView(vc);
+
+    NSLayoutConstraint *widthPin = nil;
+    for (NSLayoutConstraint *c in content.constraints)
+    {
+        if (c.firstItem == content && c.secondItem == nil
+            && c.relation == NSLayoutRelationEqual
+            && c.firstAttribute == NSLayoutAttributeWidth)
+            widthPin = c;
+    }
+    XCTAssertNotNil(widthPin, @"Html pane: loadView should pin the content width");
+    XCTAssertGreaterThanOrEqual(widthPin.constant, 482,
+        @"Html pane must stay wide enough for the CSS theme popup and its "
+        @"Reveal/Reload controls; long theme names like \"GitHub Dark Default\" "
+        @"clip at the old 430pt width");
+}
+
 // loadView must size each pane to fit its content for the active locale rather
 // than the static English design frame, so localized text is never clipped.
 - (void)testContentIsSizedToFitItsContent


### PR DESCRIPTION
## Summary

Widens the HTML preferences pane from 430pt to 482pt so the CSS theme popup and its Reveal/Reload controls stop clipping — most visible now that the bundled **"GitHub Dark Default"** theme (#465) ships a long name. The pane is fully constraint-driven and `loadView` pins each pane to its XIB design width, so widening the content view is what actually buys the theme controls room; the inner controls reflow automatically.

Adds `testHtmlPaneIsWideEnoughForThemeControls` to guard the design width against being narrowed back to the cramped value.

## Credit / relationship to #419

This reproduces the HTML-pane fix from **@yusufm's #419** on top of the recently-merged #461 ("Fix preference pane layout for localized text wrapping"). We merged #461 on top of #419, which created the conflict, so rather than ask the author to untangle our merge we've rebased the fix forward and credited him as co-author. **Closes #419 in favor of this PR.**

Two deliberate differences from #419:
- **#461's checkbox `lineBreakMode="wordWrap"` is preserved** (the merge resolution on the `Syntax highlighted code block` checkbox).
- **#419's editor-pane `<rect>` nudges are omitted.** They were 1–2px design-time-only values that are inert under Auto Layout (that pane is constraint-driven) and overlap #461's rework of the editor pane.

## Validation
- New + existing locale/layout regression tests in `MPPreferencesViewControllerResizabilityTests` (`testPanesHaveNoAmbiguousLayout`, `testContentIsSizedToFitItsContent`, `testCheckboxTitlesWrap`) exercise the widened pane.
- XIB validated as well-formed; reviewed for ambiguous layout.

Related to #419.

https://claude.ai/code/session_0193hY9AbWhec8BuUHCJvHgv

---
_Generated by [Claude Code](https://claude.ai/code/session_0193hY9AbWhec8BuUHCJvHgv)_