### PR TITLE
Extend wide-table horizontal scrolling to all themes (screen only)

### DIFF
--- a/MacDown/Resources/Extensions/export.css
+++ b/MacDown/Resources/Extensions/export.css
@@ -28,6 +28,30 @@ td, th {
     overflow-wrap: break-word;
 }
 
+/* Wide tables - give every theme a horizontal scroll container so columns keep
+ * their natural width instead of compressing to the pane width (Issue #432).
+ *
+ * Scoped to screen media on purpose: this stylesheet is also present when the
+ * preview is printed to PDF, where WebKit switches to print media. A scroll
+ * container would clip wide tables on paper instead of scrolling them, so PDF
+ * table layout is left entirely to print.css.
+ *
+ * The non-default themes declare bare `table { ... }` rules with no overflow
+ * handling. Those have the SAME specificity as this rule, so it wins purely
+ * because export.css is appended LAST in the cascade (see MPRenderer.m) -- keep
+ * export.css last or this tie-break breaks. The default GitHub-2020.css theme
+ * is intentionally left alone: its `body table` rule has higher specificity and
+ * retains the behavior from PR #440. `max-width: 100%` keeps the scrollbar on
+ * the table itself rather than relying on document-level horizontal scrolling. */
+@media screen {
+    table {
+        display: block;
+        width: max-content;
+        max-width: 100%;
+        overflow-x: auto;
+    }
+}
+
 /* Blockquotes - ensure quoted content wraps */
 blockquote {
     word-break: break-word;


### PR DESCRIPTION
## Summary

Follow-up to #440. That PR restored natural table width and horizontal scrolling for the **default GitHub-2020 theme** (via its own `body table` rule) and removed the column-collapsing `word-break: break-word` from `export.css` for all themes.

The other ten themes, however, declare bare `table { ... }` rules with **no overflow handling**, so a wide table under those themes still has no scroll container — it overflows the pane and relies on document-level scrolling that may not be available. This PR closes that gap.

## Change

A single rule added to `MacDown/Resources/Extensions/export.css` (which is appended last in the cascade):

```css
@media screen {
    table {
        display: block;
        width: max-content;
        max-width: 100%;
        overflow-x: auto;
    }
}
```

Design notes:

- **Cascade, not specificity.** The non-default themes use bare `table` selectors of *equal* specificity; this rule wins because `export.css` loads last (see `MPRenderer.m`). The default GitHub-2020 theme uses a higher-specificity `body table` rule and is intentionally left untouched, keeping #440's behavior.
- **`@media screen` is deliberate.** `export.css` is also present when the preview is printed to PDF, where WebKit switches to print media. An unscoped scroll container would *clip* wide tables on paper; the screen scope confines this to the live preview and browser-viewed HTML and leaves PDF layout to `print.css` (whose `overflow: visible` reset only covers `pre`, not tables).
- **`max-width: 100%`** keeps the scrollbar attached to the table itself rather than relying on document-level horizontal scrolling.

## Testing

Tables are rendered via CSS in the preview WebView, so the existing fixture tests (which only cover the markdown→HTML step) do not exercise this behavior. Verify manually on macOS:

1. Open a document containing a wide table (≥10 columns) — the `## Wide Table` block in `MacDownTests/Fixtures/tables.md` works well.
2. **Default theme (GitHub-2020):** confirm the table keeps its natural width and scrolls horizontally — i.e. no regression from #440.
3. **Each non-default theme** (Preferences → Rendering → Style): GitHub, GitHub2, GitHub Tomorrow, Github2 (dark), Google Docs, Gmail, Clearness, Clearness Dark, Solarized (Light), Solarized (Dark). For each, confirm the wide table now scrolls horizontally instead of compressing columns. This is the core thing the PR fixes.
4. **Narrow tables:** confirm small tables still render normally (they shrink-wrap to content width under this rule, which is expected).
5. **PDF export (regression guard):** with a wide table, File → Export → PDF under both a default and a non-default theme, and confirm the table is **not** clipped on the page (the `@media screen` scope should keep `print.css` in charge). 
6. Long-URL cell content still wraps rather than expanding the table indefinitely (preserved via `overflow-wrap` from #440).

Related to #432

