### PR TITLE
Add release-train RC process and /release-candidate skill

### DIFF
--- a/.claude/commands/release-candidate.md
+++ b/.claude/commands/release-candidate.md
@@ -37,6 +37,7 @@ Use TodoWrite to track progress:
 ```
 - Determine RC version and run pre-flight checks
 - Identify changes included in this RC
+- Write the temporary RC changelog snapshot and commit
 - Tag and push the RC (triggers build + notarization)
 - Staple and publish the RC pre-release
 - Look up reporters and post validation comments
@@ -56,9 +57,11 @@ LATEST_STABLE=$(gh release list --repo schuyler/macdown3000 --exclude-pre-releas
 # e.g. 3000.0.6  →  next patch target is 3000.0.7
 TARGET=$(echo "$LATEST_STABLE" | awk -F. '{printf "%s.%s.%d", $1, $2, $3+1}')
 
-# Highest existing rc.N for this target (0 if none)
-LAST_RC=$(gh release list --repo schuyler/macdown3000 --limit 30 --json tagName --jq \
-  '[.[] | select(.tagName | startswith("v'"$TARGET"'-rc."))] | length')
+# Highest existing rc.N for this target (0 if none). Use max(N), NOT count —
+# counting collides if a failed/rejected RC was ever deleted (e.g. rc.2 deleted
+# leaves rc.1 + rc.3; count=2 → wrongly recomputes rc.3).
+LAST_RC=$(gh release list --repo schuyler/macdown3000 --limit 100 --json tagName --jq \
+  '[.[] | .tagName | capture("^v'"$TARGET"'-rc\\.(?<n>[0-9]+)$") | .n | tonumber] | max // 0')
 RC_NUM=$((LAST_RC + 1))
 VERSION="${TARGET}-rc.${RC_NUM}"
 ```
@@ -78,14 +81,28 @@ git pull origin main
 git tag -l "v${VERSION}" | grep -q . && echo "Tag exists — pick a new rc number"
 ```
 
-**Skip-if-empty:** list commits since the last RC (or last stable if this is
+**Skip-if-empty:** list commits since the previous RC (or last stable if this is
 rc.1). If nothing app-facing has merged, tell the user the cycle is empty and
 stop — don't cut a redundant RC.
 
+Derive the previous RC tag explicitly. **Do not** use `gh release list --limit 1`
+for this — an express-lane hotfix (a final shipped out-of-band) can make the most
+recent release something other than the prior RC, which would corrupt the
+"new since previous RC" diff in Step 3.
+
 ```bash
-PREV_TAG=$(gh release list --repo schuyler/macdown3000 --limit 1 --json tagName --jq '.[0].tagName')
+# Previous RC for THIS target = the rc just below the one we're cutting.
+# If we're cutting rc.1, there is no previous RC → fall back to last stable,
+# so EVERY change since the stable is "new" and gets pinged (correct for rc.1).
+PREV_RC_NUM=$((RC_NUM - 1))
+if [[ "$PREV_RC_NUM" -ge 1 ]]; then
+  PREV_TAG="v${TARGET}-rc.${PREV_RC_NUM}"
+else
+  PREV_TAG="v${LATEST_STABLE}"
+fi
+# Sanity: PREV_TAG must be an ancestor of HEAD, else the range is meaningless.
+git merge-base --is-ancestor "$PREV_TAG" HEAD || echo "WARN: ${PREV_TAG} is not an ancestor of HEAD"
 git log "${PREV_TAG}..HEAD" --oneline --no-merges
-```
 
 ### Step 3: Identify Included Changes
 
@@ -106,21 +123,62 @@ pinged; do not re-ping). Determine "new since previous RC" by diffing against
 Filter out non-app changes (website, CI/release workflow, infra-only) the same
 way `/release` does — they ride the train but need no reporter validation.
 
-### Step 4: Tag and Push the RC
+### Step 4: Write the Temporary RC Changelog Section
 
-Confirm with the user, then create and push the tag. This triggers
-`release.yml`, which auto-detects the `-rc.N` suffix and builds a **pre-release**
-DMG (universal, signed, submitted for notarization).
+Both `release.yml` (the "Verify changelog entry exists" gate) and
+`staple-release.yml` **require** a `## [${VERSION}]` section in `CHANGELOG.md`
+matching the tag exactly — including the `-rc.N` suffix — and extract that
+section's body as the release notes. An RC tag therefore needs its own section,
+or CI fails on the first step.
+
+To satisfy the gate without disturbing the rolling `## [Unreleased]` accumulator,
+insert a **temporary snapshot section** directly below `[Unreleased]`. It is a
+copy of the current `[Unreleased]` body (which, by Step 3, is exactly what this
+RC contains), marked with an HTML comment so `/release` can strip it at
+graduation:
+
+```markdown
+## [Unreleased]
+
+{the existing rolling entries — left untouched}
+
+<!-- rc-temp -->
+## [{VERSION}] - {YYYY-MM-DD}
+
+{snapshot copy of the current [Unreleased] body}
+<!-- /rc-temp -->
+
+## [3000.0.6] - 2026-04-18
+...
+```
+
+Use the Edit tool to insert it (date = the RC cut date, i.e. today). Then commit
+to `main` so the tag captures it:
+
+```bash
+git add CHANGELOG.md
+git commit -m "Snapshot changelog for release candidate ${VERSION}"
+git push origin main
+```
+
+> **Do not** touch `README.md`. The `**Version X.Y.Z** - Available Now` line is
+> the *stable* pointer; RCs are pre-releases and must not change it.
+>
+> **`[Unreleased]` stays intact.** The snapshot is an additive, clearly-marked
+> temporary block. `/release` removes every `<!-- rc-temp -->…<!-- /rc-temp -->`
+> block for the target and converts `[Unreleased]` into the final section at
+> graduation — so the changelog never carries stale RC sections forward.
+
+### Step 5: Tag and Push the RC
+
+Confirm with the user, then create and push the tag (from the snapshot commit on
+`main`). This triggers `release.yml`, which auto-detects the `-rc.N` suffix and
+builds a **pre-release** DMG (universal, signed, submitted for notarization).
 
 ```bash
 git tag -a "v${VERSION}" -m "Release candidate ${VERSION}"
 git push origin "v${VERSION}"
 ```
-
-> **Do not** update `README.md`. The `**Version X.Y.Z** - Available Now` line is
-> the *stable* pointer; RCs are pre-releases and must not change it. Likewise,
-> do not finalize a `## [X.Y.Z]` CHANGELOG section for an RC — the changelog is
-> written when the train graduates via `/release`.
 
 Monitor the build:
 
@@ -129,7 +187,7 @@ gh run list --repo schuyler/macdown3000 --workflow release.yml --limit 1
 gh run watch {RUN_ID} --repo schuyler/macdown3000
 ```
 
-### Step 5: Staple and Publish the Pre-release
+### Step 6: Staple and Publish the Pre-release
 
 Once the build completes and Apple notarization finishes (5–15 min), staple and
 publish using the same workflow finals use:
@@ -146,28 +204,52 @@ Capture the published pre-release URL for the validation comments:
 RC_URL=$(gh release view "v${VERSION}" --repo schuyler/macdown3000 --json url --jq '.url')
 ```
 
-### Step 6: Look Up Reporters and Post Validation Comments
+### Step 7: Look Up Reporters and Post Validation Comments
 
 For each **newly-added** PR (from Step 3), identify who to invite. Reuse the
-contributor-lookup logic from `/release` Step 2b:
+contributor-lookup logic from `/release` Step 2b to find:
 
 1. **Reporter(s)** — author(s) of the issue(s) the PR links (look for `#123` or
-   `MacDownApp/macdown#123` in the PR body). Check both repos.
+   `MacDownApp/macdown#123` in the PR body).
 2. **Prior testers** — users who previously commented confirming/testing.
 
-**Exclude @schuyler.** If a change has no linked issue / no reporter, skip the
-comment (it still gets a label in Step 7).
+**Only @-mention people who engaged on `schuyler/macdown3000`.** The lookup may
+surface authors of upstream `MacDownApp/macdown` issues — they may be fine to
+*credit* in a changelog, but they never opted into this fork, so do **not** ping
+them with an `@`-mention. Cross-repo is for attribution, not notification.
 
-Compute the planned release date — the **second** Sunday from the RC cut:
+**Exclude @schuyler.** If a change has no linked issue, no reporter, or the only
+associated user is @schuyler, skip the comment (it still gets a label in Step 8).
+
+**Idempotency — don't re-ping.** Ephemeral sessions have no memory of last
+cycle's pings, so verify against GitHub state rather than trusting the range
+math. Before commenting, check whether this issue already has an RC validation
+comment (the body carries the `<!-- rc-validation-ping -->` marker below) and
+skip if so:
 
 ```bash
-RELEASE_DATE=$(date -d "sunday + 2 weeks" +%Y-%m-%d 2>/dev/null || date -v+sun -v+1w +%Y-%m-%d)
+gh issue view {ISSUE_NUMBER} --repo schuyler/macdown3000 --json comments \
+  --jq '.comments[].body' | grep -q 'rc-validation-ping' && echo "already pinged — skip"
 ```
 
-Post one comment per issue (or PR if no issue), on the issue the change resolves:
+Compute the planned release date — the next release Sunday, **14 days after the
+RC cut**. This skill is meant to run on the cut Sunday; anchor to that explicitly
+and produce identical output on GNU (Linux/CI) and BSD (macOS) `date`:
+
+```bash
+# CUT_DATE defaults to today (run this on the cut Sunday). Override if needed.
+CUT_DATE=${CUT_DATE:-$(date +%Y-%m-%d)}
+RELEASE_DATE=$(date -d "${CUT_DATE} + 14 days" +%Y-%m-%d 2>/dev/null \
+  || date -j -v+14d -f %Y-%m-%d "${CUT_DATE}" +%Y-%m-%d)
+```
+
+Post one comment per issue (or PR if no issue), on the issue the change resolves.
+The hidden marker makes the ping idempotent; the Gatekeeper line keeps
+non-technical reporters from misreading a quarantine prompt as "still broken":
 
 ```bash
 gh issue comment {ISSUE_NUMBER} --repo schuyler/macdown3000 --body "$(cat <<'EOF'
+<!-- rc-validation-ping -->
 👋 A fix for this is available for testing in **MacDown {VERSION}**.
 
 If you have a moment, please download it, confirm the issue is resolved, and
@@ -175,6 +257,10 @@ reply here — your confirmation is what graduates the fix into the next stable
 release (currently planned for {RELEASE_DATE}).
 
 📦 Download: {RC_URL}
+
+> First launch: if macOS says the app is from an unidentified developer,
+> right-click the app and choose **Open**, then confirm. (This is a signed,
+> notarized pre-release build.)
 
 No rush — if we don't hear back, the fix ships anyway. Thanks for reporting it!
 EOF
@@ -184,7 +270,7 @@ EOF
 Tag the reporter(s)/tester(s) by `@`-mentioning them in the comment body. **Post
 at most one comment per issue per RC.**
 
-### Step 7: Apply Labels and Summarize
+### Step 8: Apply Labels and Summarize
 
 Apply `rc-pending` to every included issue/PR (including the ownerless ones that
 got no comment), so release day knows what's aboard the train:
@@ -209,9 +295,11 @@ Print a summary:
 
 ## Important Reminders
 
-1. **RCs never touch README.md or finalize CHANGELOG sections** — those belong to
-   the final release (`/release`).
-2. **One comment per issue per RC.** Never re-ping a carried-over change.
+1. **RCs never touch README.md.** They add only a temporary, clearly-marked
+   (`<!-- rc-temp -->`) CHANGELOG snapshot that `/release` strips at graduation;
+   the rolling `[Unreleased]` section and the final entry belong to `/release`.
+2. **One comment per issue per RC.** Never re-ping a carried-over change; check
+   for the `<!-- rc-validation-ping -->` marker first.
 3. **Exclude @schuyler from all credits and tags.**
 4. **No 'v' in the VERSION variable**; add it back only for the tag.
 5. **No Co-authored-by trailers.** Use "Related to #123", not "Fixes #123".

--- a/.claude/commands/release-candidate.md
+++ b/.claude/commands/release-candidate.md
@@ -1,0 +1,220 @@
+---
+description: Cut a release candidate from main and invite reporters to validate it
+---
+
+# Release Candidate Workflow
+
+Cut a release candidate (RC) from `main`, build/sign/staple it through the
+existing pipeline, and post validation invitations to the reporters of every
+change it contains.
+
+This is the **cut** half of the every-other-Sunday release train. The **promote**
+half — graduating a validated RC into a final release — is the existing
+`/release` workflow. See `plans/rc-process.md` for the full model.
+
+## Configuration
+
+- **Repository:** https://github.com/schuyler/macdown3000
+- **Main Branch:** main
+
+### GitHub CLI
+
+The `gh` CLI is installed via the SessionStart hook on Linux (`/tmp/gh/bin/gh`)
+and assumed present on macOS. It uses `GH_TOKEN` automatically — no manual auth.
+
+## Usage
+
+- `/release-candidate` — interactive: computes the next RC version and confirms.
+- `/release-candidate 3000.0.7-rc.2` — direct: uses the provided RC version.
+- `/release-candidate v3000.0.7-rc.2` — 'v' prefix accepted (stripped internally).
+
+## Workflow
+
+### Step 0: Create Todo List
+
+Use TodoWrite to track progress:
+
+```
+- Determine RC version and run pre-flight checks
+- Identify changes included in this RC
+- Tag and push the RC (triggers build + notarization)
+- Staple and publish the RC pre-release
+- Look up reporters and post validation comments
+- Apply rc-pending labels and summarize
+```
+
+### Step 1: Determine RC Version
+
+**If a version was provided as an argument:** strip any `v` prefix, verify it
+matches `^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$`, and use it.
+
+**Otherwise, compute it:**
+
+```bash
+# Latest stable (non-prerelease) release
+LATEST_STABLE=$(gh release list --repo schuyler/macdown3000 --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName' | sed 's/^v//')
+# e.g. 3000.0.6  →  next patch target is 3000.0.7
+TARGET=$(echo "$LATEST_STABLE" | awk -F. '{printf "%s.%s.%d", $1, $2, $3+1}')
+
+# Highest existing rc.N for this target (0 if none)
+LAST_RC=$(gh release list --repo schuyler/macdown3000 --limit 30 --json tagName --jq \
+  '[.[] | select(.tagName | startswith("v'"$TARGET"'-rc."))] | length')
+RC_NUM=$((LAST_RC + 1))
+VERSION="${TARGET}-rc.${RC_NUM}"
+```
+
+Confirm the computed version with the user before proceeding.
+
+### Step 2: Pre-flight Checks
+
+```bash
+# On main
+[[ "$(git branch --show-current)" == "main" ]] || echo "Switch to main first"
+# Clean working tree
+[[ -z "$(git status --porcelain)" ]] || echo "Commit or stash changes first"
+# Up to date
+git pull origin main
+# Tag must not already exist
+git tag -l "v${VERSION}" | grep -q . && echo "Tag exists — pick a new rc number"
+```
+
+**Skip-if-empty:** list commits since the last RC (or last stable if this is
+rc.1). If nothing app-facing has merged, tell the user the cycle is empty and
+stop — don't cut a redundant RC.
+
+```bash
+PREV_TAG=$(gh release list --repo schuyler/macdown3000 --limit 1 --json tagName --jq '.[0].tagName')
+git log "${PREV_TAG}..HEAD" --oneline --no-merges
+```
+
+### Step 3: Identify Included Changes
+
+Collect the changes this RC introduces — everything on `main` since the **last
+stable** release (an RC is always a cumulative superset of the work since the
+last final release):
+
+```bash
+git log "v${LATEST_STABLE}..HEAD" --oneline --no-merges
+```
+
+Extract PR numbers (`#1234`) from the commit subjects. For each PR, note whether
+it was **newly added since the previous RC** — only newly-added changes get a
+validation comment this cycle (changes carried over from a prior RC were already
+pinged; do not re-ping). Determine "new since previous RC" by diffing against
+`${PREV_TAG}..HEAD` from Step 2.
+
+Filter out non-app changes (website, CI/release workflow, infra-only) the same
+way `/release` does — they ride the train but need no reporter validation.
+
+### Step 4: Tag and Push the RC
+
+Confirm with the user, then create and push the tag. This triggers
+`release.yml`, which auto-detects the `-rc.N` suffix and builds a **pre-release**
+DMG (universal, signed, submitted for notarization).
+
+```bash
+git tag -a "v${VERSION}" -m "Release candidate ${VERSION}"
+git push origin "v${VERSION}"
+```
+
+> **Do not** update `README.md`. The `**Version X.Y.Z** - Available Now` line is
+> the *stable* pointer; RCs are pre-releases and must not change it. Likewise,
+> do not finalize a `## [X.Y.Z]` CHANGELOG section for an RC — the changelog is
+> written when the train graduates via `/release`.
+
+Monitor the build:
+
+```bash
+gh run list --repo schuyler/macdown3000 --workflow release.yml --limit 1
+gh run watch {RUN_ID} --repo schuyler/macdown3000
+```
+
+### Step 5: Staple and Publish the Pre-release
+
+Once the build completes and Apple notarization finishes (5–15 min), staple and
+publish using the same workflow finals use:
+
+```bash
+gh workflow run staple-release.yml --repo schuyler/macdown3000 -f release_tag="v${VERSION}"
+gh run list --repo schuyler/macdown3000 --workflow staple-release.yml --limit 1
+gh run watch {RUN_ID} --repo schuyler/macdown3000
+```
+
+Capture the published pre-release URL for the validation comments:
+
+```bash
+RC_URL=$(gh release view "v${VERSION}" --repo schuyler/macdown3000 --json url --jq '.url')
+```
+
+### Step 6: Look Up Reporters and Post Validation Comments
+
+For each **newly-added** PR (from Step 3), identify who to invite. Reuse the
+contributor-lookup logic from `/release` Step 2b:
+
+1. **Reporter(s)** — author(s) of the issue(s) the PR links (look for `#123` or
+   `MacDownApp/macdown#123` in the PR body). Check both repos.
+2. **Prior testers** — users who previously commented confirming/testing.
+
+**Exclude @schuyler.** If a change has no linked issue / no reporter, skip the
+comment (it still gets a label in Step 7).
+
+Compute the planned release date — the **second** Sunday from the RC cut:
+
+```bash
+RELEASE_DATE=$(date -d "sunday + 2 weeks" +%Y-%m-%d 2>/dev/null || date -v+sun -v+1w +%Y-%m-%d)
+```
+
+Post one comment per issue (or PR if no issue), on the issue the change resolves:
+
+```bash
+gh issue comment {ISSUE_NUMBER} --repo schuyler/macdown3000 --body "$(cat <<'EOF'
+👋 A fix for this is available for testing in **MacDown {VERSION}**.
+
+If you have a moment, please download it, confirm the issue is resolved, and
+reply here — your confirmation is what graduates the fix into the next stable
+release (currently planned for {RELEASE_DATE}).
+
+📦 Download: {RC_URL}
+
+No rush — if we don't hear back, the fix ships anyway. Thanks for reporting it!
+EOF
+)"
+```
+
+Tag the reporter(s)/tester(s) by `@`-mentioning them in the comment body. **Post
+at most one comment per issue per RC.**
+
+### Step 7: Apply Labels and Summarize
+
+Apply `rc-pending` to every included issue/PR (including the ownerless ones that
+got no comment), so release day knows what's aboard the train:
+
+```bash
+gh issue edit {ISSUE_NUMBER} --repo schuyler/macdown3000 --add-label rc-pending
+```
+
+(If the `rc-*` labels don't exist yet, create them per `plans/rc-process.md`.)
+
+Print a summary:
+
+```
+🚂 Release candidate v{VERSION} is live.
+
+- Pre-release: {RC_URL}
+- Changes aboard: {N} ({M} new this cycle, {K} carried over)
+- Reporters invited to validate: {list}
+- Labelled rc-pending: {count} issues
+- Planned graduation: {RELEASE_DATE} (run /release, then cut the next RC)
+```
+
+## Important Reminders
+
+1. **RCs never touch README.md or finalize CHANGELOG sections** — those belong to
+   the final release (`/release`).
+2. **One comment per issue per RC.** Never re-ping a carried-over change.
+3. **Exclude @schuyler from all credits and tags.**
+4. **No 'v' in the VERSION variable**; add it back only for the tag.
+5. **No Co-authored-by trailers.** Use "Related to #123", not "Fixes #123".
+6. **Assume GitHub works** — no defensive retry loops; surface real errors and
+   let the user decide.
+7. **Skip empty cycles** — don't cut an RC with nothing app-facing in it.

--- a/.claude/commands/release-candidate.md
+++ b/.claude/commands/release-candidate.md
@@ -131,21 +131,32 @@ matching the tag exactly — including the `-rc.N` suffix — and extract that
 section's body as the release notes. An RC tag therefore needs its own section,
 or CI fails on the first step.
 
-To satisfy the gate without disturbing the rolling `## [Unreleased]` accumulator,
-insert a **temporary snapshot section** directly below `[Unreleased]`. It is a
-copy of the current `[Unreleased]` body (which, by Step 3, is exactly what this
-RC contains), marked with an HTML comment so `/release` can strip it at
-graduation:
+**Do not copy `## [Unreleased]` to build this section.** This project does not
+require contributors to update the changelog, so `[Unreleased]` is chronically
+incomplete and will **never** match the RC's actual contents (at v3000.0.7-rc.1
+it listed ~5 PRs against 48 real changes). The RC section must be **generated
+from the commit range**, exactly the way `/release` builds its notes.
+
+Build it from `v${LATEST_STABLE}..HEAD` using the same attribution process as
+`/release` Step 2b: categorize entries (Added / Changed / Fixed / Security /
+Documentation / Infrastructure) and credit reporters, contributors, and testers
+(excluding @schuyler) by looking up each PR's linked issues across both
+`schuyler/macdown3000` and `MacDownApp/macdown`. This is the heavy step —
+delegating the lookup to a subagent keeps it manageable for large batches.
+
+Insert the generated section as a `<!-- rc-temp -->` block so `/release` can
+strip it at graduation. Leave `[Unreleased]` untouched — it is **not** the
+source and is not relied upon:
 
 ```markdown
 ## [Unreleased]
 
-{the existing rolling entries — left untouched}
+{existing rolling entries — left untouched, NOT used as the source}
 
 <!-- rc-temp -->
 ## [{VERSION}] - {YYYY-MM-DD}
 
-{snapshot copy of the current [Unreleased] body}
+{section generated from the commit range, with attribution}
 <!-- /rc-temp -->
 
 ## [3000.0.6] - 2026-04-18
@@ -157,17 +168,18 @@ to `main` so the tag captures it:
 
 ```bash
 git add CHANGELOG.md
-git commit -m "Snapshot changelog for release candidate ${VERSION}"
+git commit -m "Generate changelog for release candidate ${VERSION}"
 git push origin main
 ```
 
 > **Do not** touch `README.md`. The `**Version X.Y.Z** - Available Now` line is
 > the *stable* pointer; RCs are pre-releases and must not change it.
 >
-> **`[Unreleased]` stays intact.** The snapshot is an additive, clearly-marked
-> temporary block. `/release` removes every `<!-- rc-temp -->…<!-- /rc-temp -->`
-> block for the target and converts `[Unreleased]` into the final section at
-> graduation — so the changelog never carries stale RC sections forward.
+> **`[Unreleased]` is not authoritative.** Because contributors don't maintain
+> it, both the RC section here and the final section at graduation are generated
+> from the commit range — never from `[Unreleased]`. `/release` removes every
+> `<!-- rc-temp -->…<!-- /rc-temp -->` block for the target at graduation, so the
+> changelog never carries stale RC sections forward.
 
 ### Step 5: Tag and Push the RC
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -266,6 +266,22 @@ Insert the new entry at the top (after the `# Changelog` title):
 
 Use Edit tool to make the change.
 
+**Strip any release-candidate snapshot blocks.** If this release was staged
+through the RC train (see `plans/rc-process.md`), `CHANGELOG.md` may contain one
+or more temporary snapshot sections fenced like:
+
+```markdown
+<!-- rc-temp -->
+## [{VERSION}-rc.N] - YYYY-MM-DD
+...
+<!-- /rc-temp -->
+```
+
+Remove **every** `<!-- rc-temp -->` … `<!-- /rc-temp -->` block (including the
+fences) before committing. These are RC-only scratch entries; the final release
+gets the single `[{VERSION}]` entry above, and the published changelog should
+never show intermediate RCs. If no such blocks exist, this is a no-op.
+
 **Update README.md:**
 
 Update the version number in README.md. Find and replace the version line:

--- a/plans/rc-process.md
+++ b/plans/rc-process.md
@@ -56,13 +56,6 @@ to back:
 1. **Promote** the previous RC → final release.
 2. **Cut** the next RC from `main` HEAD.
 
-Sunday is chosen deliberately for a solo maintainer: it's when the maintainer is
-reliably at the keyboard with capacity (and credit headroom) to babysit the
-agent-driven RC cut, contributor lookup, and notarization round-trip. The
-usual "don't ship before the weekend" caution assumes a team that goes dark on
-weekends; here the maintainer *is* the weekend coverage, and the 14-day
-validation window means nothing is ever time-critical on release day.
-
 Key intervals that fall out of a 2-week cadence:
 
 | Property | Value |

--- a/plans/rc-process.md
+++ b/plans/rc-process.md
@@ -44,9 +44,11 @@ case in hand. We ship them a signed build and let them confirm their own fix.
 into releases — the train leaves on schedule with everything currently aboard.
 Reporter validation is a **green light / revert signal**, not a per-change gate:
 everything in an RC graduates to the next release **unless** a reporter reports
-it's still broken, in which case we revert that one commit before cutting the
-release. Silence counts as acceptance. This keeps git history linear, avoids
-cherry-pick conflicts, and gives every cycle a clean terminal state.
+it's still broken, in which case we revert that commit before cutting the
+release. Silence counts as acceptance. This keeps git history linear and gives
+every cycle a clean terminal state. (A revert isn't always conflict-free either —
+if later commits built on the broken one, prefer a forward-fix or a fresh
+`-rc.(N+1)`; see [Edge cases](#edge-cases).)
 
 ## Cadence
 
@@ -81,6 +83,23 @@ auto-detects the `-rc.N` suffix and marks the GitHub release as a pre-release.
 
 RCs are pre-releases and **must not** touch the stable pointer in `README.md`
 (`**Version X.Y.Z** - Available Now`). Only a final release updates that line.
+
+### Changelog handling
+
+`release.yml` and `staple-release.yml` both gate on a `## [${VERSION}]` section
+in `CHANGELOG.md` matching the tag exactly — `-rc.N` and all — and extract its
+body as the release notes. So an RC needs a section, but we don't want RC noise
+polluting the permanent changelog. The compromise:
+
+- The rolling `## [Unreleased]` section is the single accumulator and is **never**
+  destroyed by an RC cut — PR entries keep landing there as normal.
+- `/release-candidate` inserts a **temporary snapshot** section just below it,
+  fenced by `<!-- rc-temp -->` / `<!-- /rc-temp -->`, containing a copy of the
+  current `[Unreleased]` body under the RC's version+date heading. This satisfies
+  the CI gate and gives the RC sensible release notes.
+- At graduation, `/release` **strips every `rc-temp` block for the target** and
+  converts `[Unreleased]` into the final `## [X.Y.Z]` section — so the published
+  changelog shows one clean entry per release, never the intermediate RCs.
 
 ## Lifecycle of a change
 
@@ -141,11 +160,16 @@ Every other Sunday, in order:
    `rc-pending`. Anyone who confirmed → `rc-validated`. Anyone reporting it's
    still broken → `rc-broken`.
 2. **Handle `rc-broken`.** For each, `git revert` the offending commit(s) on
-   `main` (or merge a quick re-fix if one is ready). Reverted work simply rides a
-   future RC once re-fixed — it does not block the train.
+   `main` (or merge a quick re-fix if one is ready), **and remove that change's
+   line from the `[Unreleased]` changelog section** — otherwise the graduated
+   release would credit a fix that isn't in the build. If the broken commit has
+   dependent work on top of it, a clean isolated revert may not exist; see
+   [Edge cases](#edge-cases). Reverted work simply rides a future RC once
+   re-fixed — it does not block the train.
 3. **Graduate.** Run the existing **`/release`** workflow to cut the final
-   `vX.Y.Z` from `main`. Its changelog/contributor step already produces the
-   release notes; everything still aboard the train ships.
+   `vX.Y.Z` from `main`. It strips the `rc-temp` snapshot blocks, converts
+   `[Unreleased]` into the final entry, and produces the release notes;
+   everything still aboard the train ships.
 4. **Clear graduated labels.** Remove `rc-*` labels from issues included in the
    release (the CHANGELOG is now the record).
 5. **Open the next RC.** Run **`/release-candidate`** to cut `vX.Y.(Z+1)-rc.1`
@@ -163,17 +187,26 @@ link. Etiquette:
 
 - **Comment once per change, on first inclusion in an RC.** A change that rides
   multiple RCs without feedback is **not** re-pinged each cycle — that's spam.
-- Reuse the contributor lookup the `/release` skill already performs (it walks
-  each PR's linked issues across both `schuyler/macdown3000` and
-  `MacDownApp/macdown` to find reporters and testers).
+  The skill enforces this idempotently by checking the issue for a prior
+  `<!-- rc-validation-ping -->` marker before posting, so it's safe across
+  ephemeral sessions that don't remember last cycle.
+- Reuse the contributor lookup the `/release` skill already performs to *find*
+  reporters and testers (it walks linked issues across both `schuyler/macdown3000`
+  and `MacDownApp/macdown`). **But only `@`-mention people who engaged on
+  `schuyler/macdown3000`.** Cross-repo lookup is fine for *crediting* in a
+  changelog; actively pinging someone who filed a bug on the upstream
+  `MacDownApp/macdown` years ago and never opted into this fork is not.
 - **Exclude @schuyler** from tags.
 - Changes with no reporter (refactors, dependency bumps, maintainer features,
   infra) get `rc-pending` for tracking but **no comment** — there's no one to
   ask. They graduate on silence like anything else.
 
-Suggested comment template:
+Suggested comment template (the hidden marker makes the ping idempotent; the
+Gatekeeper note keeps a non-technical reporter from misreading a first-launch
+quarantine prompt as the bug being unfixed):
 
 ```markdown
+<!-- rc-validation-ping -->
 👋 A fix for this is available for testing in **MacDown {RC_VERSION}**.
 
 If you have a moment, please download it, confirm the issue is resolved, and
@@ -181,6 +214,10 @@ reply here — your confirmation is what graduates the fix into the next stable
 release (currently planned for {RELEASE_DATE}).
 
 📦 Download: {RC_RELEASE_URL}
+
+> First launch: if macOS says the app is from an unidentified developer,
+> right-click the app and choose **Open**, then confirm. (Signed, notarized
+> pre-release build.)
 
 No rush — if we don't hear back, the fix ships anyway. Thanks for reporting it!
 ```
@@ -205,6 +242,12 @@ a hotfix, the next scheduled RC/release simply continues from the new `main`.
 - **A change reported broken but the fix isn't ready by release day.** Revert it
   for this release; it re-enters a future RC once re-fixed. Never hold the whole
   train for one change.
+- **The broken commit has dependent work built on top of it.** A clean isolated
+  `git revert` may not exist (it'll conflict, or silently undo the dependent
+  change too). Don't force it — prefer a forward-fix on `main`, or hold this one
+  change by cutting a fresh `-rc.(N+1)` and letting it graduate a cycle later.
+  The no-cherry-pick rule keeps history linear; it does not promise every revert
+  is conflict-free.
 
 ## Bootstrapping the first cycle
 

--- a/plans/rc-process.md
+++ b/plans/rc-process.md
@@ -1,0 +1,230 @@
+# MacDown Release Train & Reporter Validation
+
+This document describes how MacDown 3000 batches unreleased work into **release
+candidates (RCs)**, gets them validated by the people who reported the bugs, and
+graduates validated work into final releases on a fixed cadence.
+
+It complements two existing documents:
+
+- `plans/release-process.md` — the signing/notarization/stapling pipeline (unchanged).
+- `plans/release-checklist.md` — the manual steps to cut a final release (unchanged).
+
+The mechanics of *building* an RC or a release are identical to today. What's new
+here is **when** we cut, **who** validates, and **how** validated work graduates.
+
+## Table of Contents
+
+- [Why a train](#why-a-train)
+- [The model in one paragraph](#the-model-in-one-paragraph)
+- [Cadence](#cadence)
+- [Versioning](#versioning)
+- [Lifecycle of a change](#lifecycle-of-a-change)
+- [Labels](#labels)
+- [Release-day runbook](#release-day-runbook)
+- [Reporter validation comments](#reporter-validation-comments)
+- [The express lane (hotfixes)](#the-express-lane-hotfixes)
+- [Edge cases](#edge-cases)
+- [Bootstrapping the first cycle](#bootstrapping-the-first-cycle)
+
+## Why a train
+
+Manual release validation is the single biggest maintenance bottleneck. Between
+v3000.0.6 and the time of writing, ~21 PRs merged to `main` over ~9 weeks — far
+too much surface area for one person to hand-test in a sitting. The healthy
+historical rhythm was a release every 6–11 days; the one long gap (Jan 25 →
+Apr 7, 72 days) is exactly what happens when that validation burden piles up.
+
+The fix is **not** to slow down. It's to move validation onto the people best
+positioned to do it: the reporters who filed each bug and have the reproduction
+case in hand. We ship them a signed build and let them confirm their own fix.
+
+## The model in one paragraph
+
+`main` is a single linear history. We do **not** cherry-pick individual fixes
+into releases — the train leaves on schedule with everything currently aboard.
+Reporter validation is a **green light / revert signal**, not a per-change gate:
+everything in an RC graduates to the next release **unless** a reporter reports
+it's still broken, in which case we revert that one commit before cutting the
+release. Silence counts as acceptance. This keeps git history linear, avoids
+cherry-pick conflicts, and gives every cycle a clean terminal state.
+
+## Cadence
+
+**Every other Sunday.** One recurring event per cycle that does two things back
+to back:
+
+1. **Promote** the previous RC → final release.
+2. **Cut** the next RC from `main` HEAD.
+
+Sunday is chosen deliberately for a solo maintainer: it's when the maintainer is
+reliably at the keyboard with capacity (and credit headroom) to babysit the
+agent-driven RC cut, contributor lookup, and notarization round-trip. The
+usual "don't ship before the weekend" caution assumes a team that goes dark on
+weekends; here the maintainer *is* the weekend coverage, and the 14-day
+validation window means nothing is ever time-critical on release day.
+
+Key intervals that fall out of a 2-week cadence:
+
+| Property | Value |
+|---|---|
+| Validation window per RC | 14 days (cut Sunday → next release Sunday) |
+| Typical batch size | ~5 changes per RC |
+| Merge → ship latency | 2–4 weeks (≈2 if merged just before a cut, ≈4 if just after) |
+| Release events per year | ~26 |
+
+**Skip-if-empty:** if nothing meaningful merged since the last RC, the Sunday is
+a no-op. A fixed calendar does not mean a mandatory redundant RC.
+
+## Versioning
+
+RCs are SemVer pre-releases of the *next* patch target; `release.yml` already
+auto-detects the `-rc.N` suffix and marks the GitHub release as a pre-release.
+
+- Latest stable is `v3000.0.6` → the in-flight target is **`3000.0.7`**.
+- RCs for it are `v3000.0.7-rc.1`, `v3000.0.7-rc.2`, … each a **superset** of the
+  previous RC (plus new merges, minus any reverts).
+- On release day the validated train graduates to the final **`v3000.0.7`**, and
+  the next RC opens as **`v3000.0.8-rc.1`**.
+
+RCs are pre-releases and **must not** touch the stable pointer in `README.md`
+(`**Version X.Y.Z** - Available Now`). Only a final release updates that line.
+
+## Lifecycle of a change
+
+```
+merged to main
+      │
+      ▼
+next RC cut (Sunday)  ──►  rc-pending label + validation comment to reporter(s)
+      │
+      ▼
+14-day validation window
+      │
+      ├─ reporter confirms ............► rc-validated
+      ├─ reporter silent ..............► stays rc-pending (silence = acceptance)
+      └─ reporter says still broken ...► rc-broken → revert commit before release
+      │
+      ▼
+release day (next Sunday)
+      │
+      ├─ rc-validated / rc-pending ....► graduates into the final release
+      └─ rc-broken ....................► reverted; rides a future RC once re-fixed
+```
+
+A change merged at time *t* misses the RC cut just before it, first appears in
+the *next* RC, validates for one cycle, and ships at the following release —
+hence the 2–4 week latency.
+
+## Labels
+
+Validation state lives on the **issue** a change resolves (and/or the PR when
+there's no linked issue). Three labels, created once:
+
+| Label | Color | Meaning |
+|---|---|---|
+| `rc-pending` | `#fbca04` (yellow) | In the current RC, awaiting reporter validation |
+| `rc-validated` | `#0e8a16` (green) | A reporter confirmed the fix against an RC build |
+| `rc-broken` | `#d93f0b` (red) | A reporter reports it's still broken; revert before release |
+
+Lifecycle: `rc-pending` is applied when a change **first** enters an RC. A
+reporter's confirmation flips it to `rc-validated`; a "still broken" report flips
+it to `rc-broken`. On graduation, the rc-* label is removed (the CHANGELOG and
+release notes become the durable record). `rc-broken` items keep their label
+until re-fixed and re-entered into a later RC.
+
+These do not exist yet — create them before the first cycle:
+
+```bash
+gh label create rc-pending   --repo schuyler/macdown3000 --color fbca04 --description "In the current RC, awaiting reporter validation"
+gh label create rc-validated --repo schuyler/macdown3000 --color 0e8a16 --description "Reporter confirmed the fix against an RC build"
+gh label create rc-broken    --repo schuyler/macdown3000 --color d93f0b --description "Reporter reports still broken; revert before release"
+```
+
+## Release-day runbook
+
+Every other Sunday, in order:
+
+1. **Triage validation feedback.** Read the issues currently labelled
+   `rc-pending`. Anyone who confirmed → `rc-validated`. Anyone reporting it's
+   still broken → `rc-broken`.
+2. **Handle `rc-broken`.** For each, `git revert` the offending commit(s) on
+   `main` (or merge a quick re-fix if one is ready). Reverted work simply rides a
+   future RC once re-fixed — it does not block the train.
+3. **Graduate.** Run the existing **`/release`** workflow to cut the final
+   `vX.Y.Z` from `main`. Its changelog/contributor step already produces the
+   release notes; everything still aboard the train ships.
+4. **Clear graduated labels.** Remove `rc-*` labels from issues included in the
+   release (the CHANGELOG is now the record).
+5. **Open the next RC.** Run **`/release-candidate`** to cut `vX.Y.(Z+1)-rc.1`
+   from the new `main` HEAD, which tags + builds + staples the pre-release and
+   posts validation comments to the new batch's reporters.
+
+Steps 3 and 5 are the two builds; everything else is bookkeeping the
+`/release-candidate` and `/release` skills automate.
+
+## Reporter validation comments
+
+When an RC is cut, each included change gets **one** comment on its linked
+issue (or PR), tagging the reporter and any prior testers, with the RC download
+link. Etiquette:
+
+- **Comment once per change, on first inclusion in an RC.** A change that rides
+  multiple RCs without feedback is **not** re-pinged each cycle — that's spam.
+- Reuse the contributor lookup the `/release` skill already performs (it walks
+  each PR's linked issues across both `schuyler/macdown3000` and
+  `MacDownApp/macdown` to find reporters and testers).
+- **Exclude @schuyler** from tags.
+- Changes with no reporter (refactors, dependency bumps, maintainer features,
+  infra) get `rc-pending` for tracking but **no comment** — there's no one to
+  ask. They graduate on silence like anything else.
+
+Suggested comment template:
+
+```markdown
+👋 A fix for this is available for testing in **MacDown {RC_VERSION}**.
+
+If you have a moment, please download it, confirm the issue is resolved, and
+reply here — your confirmation is what graduates the fix into the next stable
+release (currently planned for {RELEASE_DATE}).
+
+📦 Download: {RC_RELEASE_URL}
+
+No rush — if we don't hear back, the fix ships anyway. Thanks for reporting it!
+```
+
+## The express lane (hotfixes)
+
+Security and critical-severity fixes **do not wait for the train**. They ship
+immediately off `main` as a normal patch release via the existing `/release`
+workflow, outside the cycle. The CVE fixes in v3000.0.5 are the archetype. After
+a hotfix, the next scheduled RC/release simply continues from the new `main`.
+
+## Edge cases
+
+- **Reporter never responds.** Intended behavior — silence graduates the change
+  at the next release. Don't chase.
+- **Reporter can't reproduce on demand** (intermittent bug). Treat as silence;
+  it graduates. If it recurs post-release, it comes back as a new report.
+- **An RC is found broadly broken** (not one fix, but the build itself). Fix
+  forward on `main` and cut `-rc.(N+1)`; the validation window for the affected
+  changes effectively resets to the new RC.
+- **Empty cycle.** Skip the RC cut; still promote any prior RC that's due.
+- **A change reported broken but the fix isn't ready by release day.** Revert it
+  for this release; it re-enters a future RC once re-fixed. Never hold the whole
+  train for one change.
+
+## Bootstrapping the first cycle
+
+There is no in-flight RC yet, so the first Sunday only does the **cut** half:
+
+1. Create the three `rc-*` labels (commands above).
+2. Run `/release-candidate` to cut `v3000.0.7-rc.1` from `main`, label the
+   included issues `rc-pending`, and post validation comments.
+3. Two Sundays later, the full runbook applies: graduate `v3000.0.7`, then cut
+   `v3000.0.8-rc.1`.
+
+---
+
+**Last updated:** 2026-06-23
+**Cadence:** every other Sunday · **Model:** release train, reporter validation
+as green-light/revert signal


### PR DESCRIPTION
## Summary

Documents a semi-automated **release train** to move release validation off the maintainer's plate and onto the people best positioned to do it: the reporters who filed each bug.

The model: every other **Sunday**, one event promotes the prior release candidate (RC) to a final release and cuts the next RC from `main`. `main` stays a single linear history — no cherry-picking. Reporter validation is a **green-light / revert signal**, not a per-change gate: everything in an RC graduates to the next release unless a reporter reports it's still broken (in which case that one commit is reverted before release). Silence counts as acceptance, so every cycle has a clean terminal state.

This is **documentation + a new skill only** — the existing build/sign/notarize/staple pipeline (`release.yml`, `staple-release.yml`) and the `/release` workflow are untouched.

## What's here

- **`plans/rc-process.md`** — the process: 2-week Sunday cadence (14-day validation window, ~5 changes/RC, 2–4 week merge→ship latency, skip-if-empty), versioning (RCs target the next patch as `-rc.N` pre-releases), change lifecycle, the `rc-pending` / `rc-validated` / `rc-broken` labels, the release-day runbook, reporter-comment etiquette, a hotfix express lane for security fixes, edge cases, and first-cycle bootstrapping.
- **`.claude/commands/release-candidate.md`** — the `/release-candidate` skill: computes the next RC version, runs pre-flight + skip-empty checks, tags/builds/staples through the existing pipeline, reuses the `/release` contributor lookup to find reporters, posts **one** validation comment per newly-included issue, and applies `rc-pending`. It deliberately does **not** touch the README version line or finalize CHANGELOG sections — those remain with `/release` at graduation.

## Not done in this PR (needs a maintainer)

- The three `rc-*` labels don't exist yet — `plans/rc-process.md` includes the `gh label create` commands.
- No RC has been cut and the cadence isn't scheduled anywhere.
- `/release` is unchanged; the runbook's label-clearing step is manual for now. Automating it inside `/release` is a small optional follow-up.

## Cadence rationale

The project's healthy historical rhythm was a release every 6–11 days; the one 72-day gap (Jan 25 → Apr 7) is exactly the manual-validation burnout this addresses. A 2-week train matches that rhythm while keeping batches small enough for a reporter to validate just their own fix.