### PR TITLE
Fix entitlements loss during app re-signing (issue #302)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,12 +304,18 @@ jobs:
 
           echo "✅ CLI binary signed successfully"
 
-          # Re-sign the app bundle to update the seal after modifying nested component
+          # Re-sign the app bundle to update the seal after modifying nested component.
+          # --entitlements MUST be re-applied here: the Xcode build signs the app with
+          # CODE_SIGN_ENTITLEMENTS, but this re-sign replaces that signature. Without
+          # --entitlements the app ships with NO entitlements, breaking NSSavePanel
+          # (Move To / Save As…) with ViewBridge error 14 on macOS Sequoia and later.
+          # See issue #302.
           echo "🔐 Re-signing app bundle to update code signature seal..."
           codesign --sign "$IDENTITY" \
             --force \
             --deep \
             --options runtime \
+            --entitlements "MacDown/MacDown.entitlements" \
             --timestamp \
             "build/MacDown 3000.app"
 
@@ -355,6 +361,21 @@ jobs:
           # Show CLI binary signature details
           echo "📋 CLI binary signature details:"
           codesign -dvv "$CLI_BINARY" 2>&1 | head -20
+
+          # Verify the app bundle still carries the file-access entitlement.
+          # The post-build re-sign previously stripped entitlements, shipping builds
+          # that hit ViewBridge error 14 on Move To / Save As… (issue #302). This gate
+          # ensures a build can NEVER ship without it.
+          echo "🔍 Verifying app entitlements..."
+          APP_ENTITLEMENTS=$(codesign -d --entitlements :- "build/MacDown 3000.app" 2>/dev/null || true)
+          if [[ "$APP_ENTITLEMENTS" != *"com.apple.security.files.user-selected.read-write"* ]]; then
+            echo "::error::App bundle is missing com.apple.security.files.user-selected.read-write entitlement"
+            echo "::error::This breaks NSSavePanel (Move To / Save As…) on macOS Sequoia and later. See issue #302."
+            echo "Entitlements found:"
+            echo "$APP_ENTITLEMENTS"
+            exit 1
+          fi
+          echo "✅ App bundle has the user-selected.read-write entitlement"
 
           echo "✅ Application bundle ready"
 
@@ -409,6 +430,19 @@ jobs:
           fi
 
           echo "✅ App bundle inside DMG is properly signed: $SIGNING_IDENTITY"
+
+          # Verify the packaged app still carries the file-access entitlement (issue #302)
+          echo "🔍 Verifying app entitlements inside DMG..."
+          DMG_APP_ENTITLEMENTS=$(codesign -d --entitlements :- "/tmp/dmg-verify/MacDown 3000.app" 2>/dev/null || true)
+          if [[ "$DMG_APP_ENTITLEMENTS" != *"com.apple.security.files.user-selected.read-write"* ]]; then
+            echo "::error::App inside DMG is missing com.apple.security.files.user-selected.read-write entitlement"
+            echo "::error::This breaks NSSavePanel (Move To / Save As…) on macOS Sequoia and later. See issue #302."
+            echo "Entitlements found:"
+            echo "$DMG_APP_ENTITLEMENTS"
+            hdiutil detach /tmp/dmg-verify
+            exit 1
+          fi
+          echo "✅ App inside DMG has the user-selected.read-write entitlement"
 
           # Verify CLI binary inside DMG
           echo "🔍 Verifying CLI binary inside DMG..."

--- a/.github/workflows/staple-release.yml
+++ b/.github/workflows/staple-release.yml
@@ -263,6 +263,21 @@ jobs:
           hdiutil attach "$DMG_PATH" -mountpoint /tmp/final-verify -nobrowse -readonly
           codesign -vvv --deep --strict "/tmp/final-verify/MacDown 3000.app"
 
+          # Final gate: the published app MUST carry the file-access entitlement, or
+          # Move To / Save As… break with ViewBridge error 14 on macOS Sequoia and
+          # later (issue #302). Refuse to publish a build that lost it.
+          echo "  ✓ Checking app entitlements..."
+          FINAL_ENTITLEMENTS=$(codesign -d --entitlements :- "/tmp/final-verify/MacDown 3000.app" 2>/dev/null || true)
+          if [[ "$FINAL_ENTITLEMENTS" != *"com.apple.security.files.user-selected.read-write"* ]]; then
+            echo "::error::Published app is missing com.apple.security.files.user-selected.read-write entitlement"
+            echo "::error::This breaks NSSavePanel (Move To / Save As…) on macOS Sequoia and later. See issue #302."
+            echo "Entitlements found:"
+            echo "$FINAL_ENTITLEMENTS"
+            hdiutil detach /tmp/final-verify
+            exit 1
+          fi
+          echo "    Entitlement present: com.apple.security.files.user-selected.read-write"
+
           # Get app version for logging
           APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" \
                         "/tmp/final-verify/MacDown 3000.app/Contents/Info.plist" 2>/dev/null || echo "unknown")

--- a/plans/release-process.md
+++ b/plans/release-process.md
@@ -52,6 +52,8 @@ MacDown uses an entitlements file at `MacDown/MacDown.entitlements` with the fol
 
 The entitlements file is wired into the Xcode project via `CODE_SIGN_ENTITLEMENTS` for both Debug and Release configurations, and is also passed during signed CI builds in `.github/actions/build-macdown/action.yml`.
 
+**Re-signing must re-apply entitlements.** After the Xcode build, the release workflow re-signs the app bundle (with `codesign --force --deep`) to re-seal it after signing the bundled `macdown` CLI binary. A `codesign` re-sign *replaces* the existing signature, so it must pass `--entitlements MacDown/MacDown.entitlements` — otherwise the shipped app loses its entitlements entirely and `NSSavePanel` (Move To / Save As…) fails with ViewBridge error 14 on macOS Sequoia and later. To prevent this regression from shipping silently, the pipeline asserts the `com.apple.security.files.user-selected.read-write` entitlement is present at three gates: after the re-sign and on the app inside the DMG (`release.yml`), and at the final pre-publish verification (`staple-release.yml`).
+
 **If additional entitlements are needed** (e.g., for JIT compilation or unsigned code execution), add them to `MacDown/MacDown.entitlements`:
 
    ```xml
@@ -446,6 +448,30 @@ CloudKit query for MacDown-1.0.0.dmg (2/....) failed due to "Ticket not found"
 - Ensure DMG is both **notarized** and **stapled**
 - Test on a clean Mac before releasing
 - Provide instructions for users with strict security settings
+
+### "Move To" / "Save As…" Fails with ViewBridge Error 14
+
+**Symptom:** On macOS Sequoia (15.x) and later, "Move To" or "Save As…" shows
+`com.apple.ViewBridge error 14`, or nothing happens at all.
+
+**Cause:** The shipped app lost its `com.apple.security.files.user-selected.read-write`
+entitlement. Under Hardened Runtime, `NSSavePanel` requires this entitlement. A common
+way to lose it is a post-build `codesign` re-sign that does **not** pass
+`--entitlements` — the re-sign replaces the Xcode-applied signature and drops the
+entitlements (see issue #302).
+
+**How to diagnose:** Inspect the installed app's entitlements:
+```bash
+codesign -d --entitlements :- "/Applications/MacDown 3000.app"
+```
+The output must include `com.apple.security.files.user-selected.read-write`.
+
+**Solution:**
+- Ensure every `codesign` re-sign of the app bundle passes
+  `--entitlements MacDown/MacDown.entitlements`.
+- The pipeline verifies this entitlement at three gates (after the re-sign and on the
+  app inside the DMG in `release.yml`, and at final verification in `staple-release.yml`),
+  so a build that lost it will fail CI rather than ship.
 
 ### Build Fails: CocoaPods Error
 


### PR DESCRIPTION
## Summary

Fixes a critical bug where the app bundle lost its `com.apple.security.files.user-selected.read-write` entitlement during the post-build re-signing step in the release workflow. This entitlement is required for `NSSavePanel` (Move To / Save As…) to function on macOS Sequoia and later; without it, users encounter ViewBridge error 14.

## Root Cause

The release workflow re-signs the app bundle after signing the bundled CLI binary to update the code signature seal. However, `codesign --force --deep` *replaces* the existing signature entirely. If `--entitlements` is not passed, the re-signed app loses all entitlements that were applied by the Xcode build.

## Changes

### `.github/workflows/release.yml`
- **Re-signing step:** Added `--entitlements "MacDown/MacDown.entitlements"` to the `codesign` command to preserve entitlements during the post-build re-sign
- **Verification gates:** Added two new entitlement verification checks:
  - After the app bundle re-sign (before DMG creation)
  - After packaging the app inside the DMG
- Both gates assert the presence of `com.apple.security.files.user-selected.read-write` and fail the build if missing
- Updated comment to explain why `--entitlements` is mandatory

### `.github/workflows/staple-release.yml`
- **Final verification gate:** Added entitlement check before publishing the release to ensure the shipped app carries the required entitlement
- Prevents a build that lost entitlements from being published

### `plans/release-process.md`
- Documented the entitlements re-signing requirement and the three verification gates
- Added troubleshooting section for "Move To / Save As… fails with ViewBridge error 14" with diagnosis and solution steps

## Implementation Details

- Entitlement verification uses `codesign -d --entitlements :-` to extract and inspect the app's entitlements
- Three defensive gates ensure the entitlement cannot be lost silently: after re-sign, in the DMG, and at final pre-publish verification
- All verification failures include clear error messages referencing issue #302 for user context

https://claude.ai/code/session_014YWsBJ616nvkLYKKe1NhkW