### PR TITLE
Address issue #313: make toolbar fully delegate-driven so Flexible Space can be dropped

### DIFF
--- a/MacDown/Localization/Base.lproj/MPDocument.xib
+++ b/MacDown/Localization/Base.lproj/MPDocument.xib
@@ -454,12 +454,7 @@
                     <constraint firstItem="0kv-p9-H4b" firstAttribute="top" secondItem="gIp-Ho-8D9" secondAttribute="top" id="yHd-Qc-mhZ"/>
                 </constraints>
             </view>
-            <toolbar key="toolbar" implicitIdentifier="E416A0C4-CA17-4923-8651-5CFF69659C83" displayMode="iconOnly" sizeMode="regular" id="owf-WR-5UO">
-                <allowedToolbarItems>
-                    <toolbarItem implicitItemIdentifier="NSToolbarSpaceItem" id="bzN-vA-6Vq"/>
-                    <toolbarItem implicitItemIdentifier="NSToolbarFlexibleSpaceItem" id="mwe-fC-9du"/>
-                </allowedToolbarItems>
-                <defaultToolbarItems/>
+            <toolbar key="toolbar" identifier="MPDocumentToolbar" allowsUserCustomization="YES" autosavesConfiguration="YES" displayMode="iconOnly" sizeMode="regular" id="owf-WR-5UO">
                 <connections>
                     <outlet property="delegate" destination="3i0-CY-DlB" id="4m3-HV-5dD"/>
                 </connections>


### PR DESCRIPTION
## Summary

Fixes the long-standing inability to drop a **Flexible Space** into the document toolbar via Customize Toolbar (issue #313). Regular Space dropped fine; Flexible Space showed the green (+) on hover but was rejected mid-drag — still broken as of v3000.0.6.

**Root cause.** The toolbar was configured in *two* places at once: `MPToolbarController` (the delegate) already advertised Flexible Space, Space, and Separator in `toolbarAllowedItemIdentifiers:` (the #322 work), **and** `MPDocument.xib` separately archived nib instances of Space and Flexible Space inside `<allowedToolbarItems>`. In that hybrid IB-configured + delegate-driven state, AppKit reuses the single archived Flexible Space instance instead of vending a fresh one per drop, so the drop is rejected. The earlier fix was only delegate-unit-tested, which couldn't catch a defect that lives in the nib/AppKit layer.

**The change** (a single XIB edit, `MacDown/Localization/Base.lproj/MPDocument.xib`):
- Remove `<allowedToolbarItems>` (the archived Space + Flexible Space nib instances) and the empty `<defaultToolbarItems/>`, so allowed/default/selectable items come entirely from the delegate.
- Replace the auto-generated `implicitIdentifier` with a stable `identifier="MPDocumentToolbar"`.
- Set `allowsUserCustomization="YES"` and `autosavesConfiguration="YES"` so customizations persist across launches.

The delegate behavior is unchanged and remains covered by the existing `MPToolbarControllerTests` (~40 tests).

## Related Issue

Related to #313

## Testing

- **Automated:** existing `MPToolbarControllerTests` continue to lock down the delegate's allowed/default/selectable identifiers (including Flexible Space, Space, Separator). The delegate is unchanged, so no test changes were needed. The actual drag-drop fix is in the nib/AppKit layer and cannot be exercised by the macOS unit-test target.
- **Independent review:** the change was reviewed by a second agent — verdict approve-with-nits, no blocking issues. Confirmed the removed nib ids are referenced nowhere, the toolbar outlet still resolves, `identifier` is the correct persistence key, and there is no stale-config risk (nothing was ever persisted before).

### Manual Testing Plan (verify on a real macOS build)

1. **Core repro:** Customize Toolbar → drag **Flexible Space** onto the toolbar → release → confirm it actually lands (not just the green +) and pushes items left. Repeat for Space and Separator.
2. **Multiple flexible spaces:** drop two or three — confirm each is an independent instance and they don't collapse/replace one another (the exact "single reused archived instance" failure mode).
3. **Default layout, fresh launch** (no saved config): confirm the toolbar shows the delegate default — 11 custom items with 5 flexible spaces, in the order asserted by `testDefaultIdentifiersExactOrder`.
4. **Autosave round-trip:** customize the toolbar, quit, relaunch → confirm the customization persists (validates the new `MPDocumentToolbar` identifier + `autosavesConfiguration`).
5. **Existing-user upgrade:** because the persistence key is brand new, existing users get the default layout on first launch after upgrade — confirm that's acceptable (no empty/garbled toolbar).

## Review Notes

- Non-blocking nit from review: there is no automated regression test for the fix itself — inherent to a nib/AppKit drag-drop change; manual verification covers it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EonLgNyfrSR9iai8bgkDd5)_