### PR TITLE
Address issue #318: cache-bust style/theme CSS on preview reload

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2339,6 +2339,24 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     // re-read from disk instead of served from the in-memory cache.
     [[NSURLCache sharedURLCache] removeAllCachedResponses];
 
+    // Issue #318: Bump a cache-busting version stamp on the active style and
+    // highlighting-theme CSS files. The legacy WebView serves CSS from its own
+    // by-URL resource cache, which removeAllCachedResponses does not clear, so
+    // a full reload of the same file:// URL still yields stale CSS. Stamping
+    // the file paths gives the <link> tags a fresh "?t=" query (applied in
+    // MPRenderer.render), which the WebView has not cached. This is the same
+    // trick used for edited local images (issue #110), and it also forces a
+    // refresh even when no file-watcher change event preceded the reload.
+    NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+    NSString *stylePath = MPStylePathForName(self.preferences.htmlStyleName);
+    if (stylePath)
+        [self.renderer setTimestamp:now forResourcePath:stylePath];
+    NSString *themePath =
+        MPHighlightingThemeURLForName(
+            self.preferences.htmlHighlightingThemeName).path;
+    if (themePath)
+        [self.renderer setTimestamp:now forResourcePath:themePath];
+
     // Issue #318: Reset cached names so renderer:didProduceHTMLOutput:
     // sees a "change" (nil != currentPref) and takes the full HTML reload
     // path instead of body-only DOM replacement.

--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -821,14 +821,6 @@ NS_INLINE NSString *MPPreviewHeadTags(NSString *checkboxBridgeToken)
     id<MPRendererDelegate> delegate = self.delegate;
 
     NSString *body = self.currentHtml;
-    if (self.resourceTimestamps.count > 0)
-    {
-        NSURL *baseURL = nil;
-        if ([delegate respondsToSelector:@selector(rendererBaseURL:)])
-            baseURL = [delegate rendererBaseURL:self];
-        if (baseURL)
-            body = MPApplyCacheBusting(body, self.resourceTimestamps, baseURL);
-    }
 
     NSString *title = [self.dataSource rendererHTMLTitle:self];
     if (!self.checkboxBridgeToken.length)
@@ -837,6 +829,22 @@ NS_INLINE NSString *MPPreviewHeadTags(NSString *checkboxBridgeToken)
     NSString *html = MPGetHTML(
         title, headTags, body, self.stylesheets, MPAssetFullLink,
         self.scripts, MPAssetFullLink);
+
+    // Issue #110 / #318: Apply cache-busting version stamps to local resource
+    // URLs. Run this over the full document — not just the <body> — so that
+    // edited style/theme CSS <link> tags in <head> also get a fresh URL that
+    // the legacy WebView cannot serve from its by-URL resource cache. Only
+    // paths with a recorded timestamp are stamped; bundled CSS and other
+    // untracked resources pass through unchanged.
+    if (self.resourceTimestamps.count > 0)
+    {
+        NSURL *baseURL = nil;
+        if ([delegate respondsToSelector:@selector(rendererBaseURL:)])
+            baseURL = [delegate rendererBaseURL:self];
+        if (baseURL)
+            html = MPApplyCacheBusting(html, self.resourceTimestamps, baseURL);
+    }
+
     [delegate renderer:self didProduceHTMLOutput:html];
 
     self.styleName = [delegate rendererStyleName:self];

--- a/MacDownTests/MPDocumentStyleUpdateTests.m
+++ b/MacDownTests/MPDocumentStyleUpdateTests.m
@@ -9,6 +9,9 @@
 
 #import <XCTest/XCTest.h>
 #import "MPPreferences.h"
+#import "MPRenderer.h"
+#import "MPRendererTestHelpers.h"
+#import "MPUtilities.h"
 
 // Forward declare the helper function we're testing
 NS_INLINE BOOL MPAreNilableStringsEqual(NSString *s1, NSString *s2)
@@ -440,6 +443,113 @@ NS_INLINE BOOL MPAreNilableStringsEqual(NSString *s1, NSString *s2)
         XCTAssertFalse(stylesChanged,
                        @"If both preferences are nil, no change detected");
     }
+}
+
+@end
+
+
+#pragma mark - Style Reload Cache-Busting Integration (Issue #318)
+
+// These tests drive MPRenderer end to end and assert that a version stamp on a
+// style/theme CSS file reaches the <head> <link> in the rendered preview HTML.
+// This is the missing piece that left "Reload" broken: the cache-busting trick
+// (issue #110) was only applied to the <body>, so the legacy WebView kept
+// serving the cached CSS by its unchanged file:// URL.
+@interface MPStyleReloadCacheBustTests : XCTestCase
+@property (nonatomic, strong) MPRenderer *renderer;
+@property (nonatomic, strong) MPMockRendererDataSource *dataSource;
+@property (nonatomic, strong) MPMockRendererDelegate *delegate;
+@end
+
+@implementation MPStyleReloadCacheBustTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.dataSource = [[MPMockRendererDataSource alloc] init];
+    self.delegate = [[MPMockRendererDelegate alloc] init];
+    // A non-nil file base URL enables the cache-busting path in MPRenderer.
+    self.delegate.baseURL =
+        [NSURL fileURLWithPath:@"/Users/test/docs/readme.md"];
+    self.delegate.styleName = @"GitHub2";
+
+    self.renderer = [[MPRenderer alloc] init];
+    self.renderer.dataSource = self.dataSource;
+    self.renderer.delegate = self.delegate;
+}
+
+- (void)tearDown
+{
+    self.renderer = nil;
+    self.dataSource = nil;
+    self.delegate = nil;
+    [super tearDown];
+}
+
+- (NSString *)renderMarkdown:(NSString *)markdown
+{
+    self.dataSource.markdown = markdown;
+    [self.renderer parseMarkdown:markdown];
+    [self.renderer render];
+    return self.delegate.lastHTML;
+}
+
+- (void)testStyleLinkHasNoStampWithoutTimestamp
+{
+    NSString *html = [self renderMarkdown:@"# Hello"];
+    XCTAssertNotNil(html, @"Render should produce HTML");
+    XCTAssertTrue([html containsString:@"GitHub2.css"],
+                  @"Preview head should link the active style");
+    XCTAssertFalse([html containsString:@"GitHub2.css?t="],
+                   @"Without a recorded timestamp, the style link is unstamped");
+}
+
+- (void)testStyleLinkInHeadIsCacheBustedWhenTimestamped
+{
+    NSString *stylePath = MPStylePathForName(self.delegate.styleName);
+    XCTAssertNotNil(stylePath, @"Active style should resolve to a path");
+
+    [self.renderer setTimestamp:1750000000 forResourcePath:stylePath];
+    NSString *html = [self renderMarkdown:@"# Hello"];
+
+    XCTAssertTrue([html containsString:@"GitHub2.css?t=1750000000"],
+                  @"A timestamped style file must produce a cache-busted "
+                  @"<link> in the preview <head> (issue #318)");
+}
+
+- (void)testHighlightingThemeLinkInHeadIsCacheBusted
+{
+    self.delegate.syntaxHighlighting = YES;
+    self.delegate.highlightingThemeName = @"tomorrow";
+
+    NSURL *themeURL =
+        MPHighlightingThemeURLForName(self.delegate.highlightingThemeName);
+    if (!themeURL)
+        return;     // Theme unavailable in this environment; nothing to assert.
+
+    NSString *themeFile = themeURL.lastPathComponent;
+    [self.renderer setTimestamp:1750000001 forResourcePath:themeURL.path];
+    NSString *html = [self renderMarkdown:@"```c\nint x;\n```"];
+
+    NSString *expected =
+        [NSString stringWithFormat:@"%@?t=1750000001", themeFile];
+    XCTAssertTrue([html containsString:expected],
+                  @"A timestamped highlighting theme must be cache-busted in "
+                  @"the preview <head> (issue #318)");
+}
+
+- (void)testUntrackedBundledStylesheetsAreNotStamped
+{
+    // Stamping only the active style must not stamp print.css/export.css.
+    NSString *stylePath = MPStylePathForName(self.delegate.styleName);
+    [self.renderer setTimestamp:1750000000 forResourcePath:stylePath];
+    NSString *html = [self renderMarkdown:@"# Hello"];
+
+    XCTAssertTrue([html containsString:@"GitHub2.css?t=1750000000"]);
+    XCTAssertTrue([html containsString:@"print.css"],
+                  @"Bundled print.css should still be linked");
+    XCTAssertFalse([html containsString:@"print.css?t="],
+                   @"Untracked bundled CSS must not be cache-busted");
 }
 
 @end

--- a/MacDownTests/MPHTMLResourceURLsTests.m
+++ b/MacDownTests/MPHTMLResourceURLsTests.m
@@ -226,4 +226,51 @@
     XCTAssertTrue([result containsString:@"images/photo.png?t=2000"]);
 }
 
+#pragma mark - MPApplyCacheBusting on stylesheet <link> (Issue #318)
+
+- (void)testCacheBustStampsRelativeStylesheetLink
+{
+    // The legacy WebView serves CSS from its cache keyed by file URL; a version
+    // stamp on the <link> href is what forces a fresh load after an edit.
+    NSString *html = @"<link rel=\"stylesheet\" href=\"style.css\">";
+    NSDictionary *timestamps = @{@"/Users/test/docs/style.css": @(1000.0)};
+    NSString *result = MPApplyCacheBusting(html, timestamps, self.baseURL);
+    XCTAssertTrue([result containsString:@"style.css?t=1000"],
+                  @"Stylesheet <link> href should receive a cache-busting stamp");
+}
+
+- (void)testCacheBustStampsAbsoluteFileURLStylesheetLink
+{
+    // The preview emits style/theme links as absolute file:// URLs.
+    NSString *html =
+        @"<link rel=\"stylesheet\" href=\"file:///Users/test/docs/GitHub2.css\">";
+    NSDictionary *timestamps =
+        @{@"/Users/test/docs/GitHub2.css": @(1750000000.0)};
+    NSString *result = MPApplyCacheBusting(html, timestamps, self.baseURL);
+    XCTAssertTrue([result containsString:@"GitHub2.css?t=1750000000"],
+                  @"Absolute file:// stylesheet link should be cache-busted");
+}
+
+- (void)testCacheBustReplacesExistingStylesheetTimestamp
+{
+    NSString *html = @"<link rel=\"stylesheet\" href=\"theme.css?t=500\">";
+    NSDictionary *timestamps = @{@"/Users/test/docs/theme.css": @(1000.0)};
+    NSString *result = MPApplyCacheBusting(html, timestamps, self.baseURL);
+    XCTAssertTrue([result containsString:@"theme.css?t=1000"]);
+    XCTAssertFalse([result containsString:@"t=500"],
+                   @"Stale stylesheet timestamp should be replaced, not appended");
+}
+
+- (void)testCacheBustOnlyStampsTrackedStylesheet
+{
+    // Only the edited style is tracked; bundled CSS (no timestamp) is left alone.
+    NSString *html = @"<link rel=\"stylesheet\" href=\"GitHub2.css\">"
+                     @"<link rel=\"stylesheet\" href=\"print.css\">";
+    NSDictionary *timestamps = @{@"/Users/test/docs/GitHub2.css": @(1000.0)};
+    NSString *result = MPApplyCacheBusting(html, timestamps, self.baseURL);
+    XCTAssertTrue([result containsString:@"GitHub2.css?t=1000"]);
+    XCTAssertTrue([result containsString:@"href=\"print.css\""],
+                  @"Untracked stylesheets must remain unchanged");
+}
+
 @end

--- a/MacDownTests/MPRendererTestHelpers.h
+++ b/MacDownTests/MPRendererTestHelpers.h
@@ -40,4 +40,8 @@
 @property (nonatomic, copy) NSString *styleName;
 @property (nonatomic, copy) NSString *highlightingThemeName;
 @property (nonatomic, copy) NSString *lastHTML;
+// Optional base URL for the cache-busting path (issue #110 / #318). When set,
+// MPRenderer applies MPApplyCacheBusting to the rendered HTML; leave nil to
+// exercise the no-base-URL fallback.
+@property (nonatomic, copy) NSURL *baseURL;
 @end

--- a/MacDownTests/MPRendererTestHelpers.m
+++ b/MacDownTests/MPRendererTestHelpers.m
@@ -115,6 +115,11 @@
     return self.highlightingThemeName;
 }
 
+- (NSURL *)rendererBaseURL:(MPRenderer *)renderer
+{
+    return self.baseURL;
+}
+
 - (void)renderer:(MPRenderer *)renderer didProduceHTMLOutput:(NSString *)html
 {
     self.lastHTML = html;


### PR DESCRIPTION
## Summary

Editing a CSS style or syntax-highlighting theme file and then choosing **Reload** (Preview context menu or Settings → Rendering) never updated the preview — only quitting and relaunching worked.

**Root cause:** The preview uses the legacy WebKit `WebView`, which caches CSS in its own resource cache keyed by the `file://` URL. `[[NSURLCache sharedURLCache] removeAllCachedResponses]` (from the earlier fix) does **not** clear that cache, so a full reload re-requests the same URL and the WebView serves the stale copy — the markup reloads but the CSS doesn't. This is why the reporter's "switch to another style and switch back" workaround worked: it changes the CSS *filename*, a URL the WebView hasn't cached.

**Fix:** Reuse the Issue #110 cache-busting machinery (`MPApplyCacheBusting` + `resourceTimestamps`). Its regex already matches `<link href>`, but the stamp was only applied to the `<body>`, so `<head>` CSS links never changed.

## Changes

- **`MPRenderer.render`** — apply `MPApplyCacheBusting` to the **full** assembled HTML (head + body) instead of body-only. Timestamped style/theme `<link>` tags now get a fresh `?t=` query the WebView can't serve from cache. Only tracked paths are stamped; bundled CSS and other resources pass through unchanged.
- **`MPDocument.invalidateStyleCaches`** — stamp the active style (`MPStylePathForName`) and theme (`MPHighlightingThemeURLForName`) CSS paths on explicit Reload, forcing a fresh URL even when no file-watcher event preceded the reload. All three Reload entry points (Preview context menu, Settings → Style Reload, Settings → Theme Reload) route here.

### Bonus: live auto-refresh
The active style/theme files are *already* watched — `MPLocalFilePathsInHTML` extracts their `<link>` paths on every render and the resource watcher stamps a timestamp on change. With cache-busting now reaching the head links, **editing and saving a style/theme refreshes the preview live**, no Reload needed.

## Tests

- `MPApplyCacheBusting` cache-busts `<link>` stylesheet URLs: relative, absolute `file://`, replacing a stale stamp, and leaving untracked CSS untouched (`MPHTMLResourceURLsTests`).
- Renderer-level integration (`MPDocumentStyleUpdateTests`): a timestamped style/theme produces a cache-busted `<link>` in the preview `<head>`; an unstamped render has no `?t=`; bundled CSS is never stamped. These would fail before the fix (body-only busting never touched the head) and pass after.

All new tests live in existing test files already in the Xcode target, so no `project.pbxproj` change is required.

## Related Issue

Related to #318

## Manual Testing Plan

1. Open a document; ensure a code block is present and syntax highlighting is on.
2. Settings → Rendering: note the active Style (e.g. GitHub2) and Highlighting theme.
3. Reveal the style folder (Settings → Style → Reveal), open the active `.css` in an external editor, change something obvious (e.g. body background color), and save.
4. **Preview context menu → Reload** → preview reflects the change immediately. ✅ (previously required quit + relaunch)
5. Make another edit to the style file and save → preview **auto-refreshes** without Reload. ✅
6. Repeat 3–5 for the highlighting theme (Settings → Highlighting → Reveal/Reload); code-block colors update.
7. Use **Settings → Style → Reload** and **Settings → Highlighting → Reload** buttons → both apply the latest CSS.
8. Regression checks: normal text editing still preserves scroll position (DOM-replacement path); switching styles/themes from the popups still works; local images still render and update.

## Review Notes

A code-review pass found no critical or blocking issues. Confirmed: head `<link>` path keys match the stamped paths exactly; no regression to image cache-busting from moving the call after `MPGetHTML`; `invalidateStyleCaches` is crash-safe when the theme is nil/"None" (falls back to the bundled default, harmless); cache-busting is idempotent (stale `?t=` stripped before re-stamping).

https://claude.ai/code/session_014inRvh6Ne1dLpTJsR7pmFd

---
_Generated by [Claude Code](https://claude.ai/code/session_014inRvh6Ne1dLpTJsR7pmFd)_