### PR TITLE
Re-highlight editor after preview checkbox toggle (#376)

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -3593,6 +3593,24 @@ to link outside that scope.", \
                                                withString:newMarkdown];
         [self.editor.textStorage endEditing];
 
+        // Issue #376: replaceCharactersInRange:withString: leaves the inserted
+        // text carrying character 0's attributes (e.g. a leading heading's font
+        // and color smeared across the whole document). The highlighter only
+        // re-parses on NSTextDidChangeNotification, which this direct textStorage
+        // edit deliberately does not fire ("Gap 10" below) — so re-highlight
+        // explicitly, following -reloadFromLoadedString's programmatic-swap recipe.
+        // (We intentionally skip that path's -readClearTextStylesFromTextView: a
+        // checkbox toggle leaves the font, theme, and default color unchanged, so
+        // the highlighter's clear baselines are still valid.)
+        //
+        // The full-range -clearHighlighting is load-bearing: -parseAndHighlightNow
+        // ultimately calls -applyVisibleRangeHighlighting, which clears and restyles
+        // only the on-screen range. Without a full-document clear first, the heading
+        // smear would persist on any content scrolled off-screen until it next
+        // re-entered the viewport.
+        [self.highlighter clearHighlighting];
+        [self.highlighter parseAndHighlightNow];
+
         // Gap 10: textStorage editing doesn't fire NSTextDidChangeNotification.
         // Mirror editorTextDidChange: — trigger render and claim ownership.
         if (self.needsHtml)

--- a/MacDownTests/HGMarkdownHighlighterTests.m
+++ b/MacDownTests/HGMarkdownHighlighterTests.m
@@ -9,6 +9,7 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <Cocoa/Cocoa.h>
 #import "HGMarkdownHighlighter.h"
 #import "HGMarkdownHighlightingStyle.h"
 #import "pmh_definitions.h"
@@ -327,6 +328,79 @@
 {
     XCTAssertNoThrow([self.highlighter readClearTextStylesFromTextView],
                      @"Should handle reading styles without text view");
+}
+
+
+#pragma mark - Full-Range Clear Regression Tests (Issue #376)
+
+// Issue #376: toggling a checkbox in the preview replaces the editor's entire
+// text storage via -replaceCharactersInRange:withString:, which leaves the
+// inserted text carrying character 0's attributes — e.g. a leading heading's
+// oversized font smeared across the whole document. The bug surfaced because
+// -parseAndHighlightNow ultimately calls -applyVisibleRangeHighlighting, which
+// clears and restyles only the on-screen range; a full-document
+// -clearHighlighting is required to wipe the smear from off-screen content.
+// This test pins the load-bearing behavior deterministically (no async parse).
+// The #376 symptom was "heading size and color", so both the smeared font size
+// and the smeared foreground color are asserted.
+- (void)testClearHighlightingResetsSmearedHeadingStyleAcrossFullRange
+{
+    NSTextView *textView =
+        [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)];
+    textView.font = [NSFont systemFontOfSize:12.0];
+    textView.textColor = [NSColor blackColor];
+    textView.string = @"# Heading\n\n- [ ] task item\n";
+
+    HGMarkdownHighlighter *hl =
+        [[HGMarkdownHighlighter alloc] initWithTextView:textView];
+    hl.targetTextView = textView;
+    // Capture the clear/default baselines (default text size, trait mask, color)
+    // the same way the document does before highlighting.
+    [hl readClearTextStylesFromTextView];
+
+    // Simulate the smear: a heading-sized font AND a heading color applied across
+    // the ENTIRE range, exactly what replaceCharactersInRange:withString: produces
+    // when character 0 belongs to a heading.
+    NSTextStorage *storage = textView.textStorage;
+    NSRange fullRange = NSMakeRange(0, storage.length);
+    [storage addAttribute:NSFontAttributeName
+                    value:[NSFont systemFontOfSize:24.0]
+                    range:fullRange];
+    [storage addAttribute:NSForegroundColorAttributeName
+                    value:[NSColor redColor]
+                    range:fullRange];
+
+    NSUInteger listItemOffset = [textView.string rangeOfString:@"task"].location;
+    XCTAssertNotEqual(listItemOffset, (NSUInteger)NSNotFound,
+                      @"Test fixture should contain the list item text");
+
+    // Precondition: the heading font/color really did smear onto the list item.
+    NSFont *smearedFont = [storage attribute:NSFontAttributeName
+                                     atIndex:listItemOffset
+                              effectiveRange:NULL];
+    XCTAssertEqualWithAccuracy(smearedFont.pointSize, 24.0, 0.01,
+                               @"Precondition: heading font should smear onto the list item");
+    NSColor *smearedColor = [storage attribute:NSForegroundColorAttributeName
+                                       atIndex:listItemOffset
+                                effectiveRange:NULL];
+    XCTAssertEqualObjects(smearedColor, [NSColor redColor],
+                          @"Precondition: heading color should smear onto the list item");
+
+    // The fix: a full-range clear must wipe the off-screen smear.
+    [hl clearHighlighting];
+
+    NSFont *clearedFont = [storage attribute:NSFontAttributeName
+                                     atIndex:listItemOffset
+                              effectiveRange:NULL];
+    XCTAssertEqualWithAccuracy(clearedFont.pointSize, 12.0, 0.01,
+                               @"clearHighlighting should reset the smeared font to the body size "
+                               @"across the full document, not leave off-screen text heading-sized");
+    NSColor *clearedColor = [storage attribute:NSForegroundColorAttributeName
+                                       atIndex:listItemOffset
+                                effectiveRange:NULL];
+    XCTAssertNotEqualObjects(clearedColor, [NSColor redColor],
+                             @"clearHighlighting should reset the smeared foreground color "
+                             @"across the full document, not leave off-screen text heading-colored");
 }
 
 


### PR DESCRIPTION
## Summary

Fixes the follow-up symptom on issue #376: clicking a checkbox in the **preview** pane left the **editor** pane rendering the entire document with heading size and color (the whole document styled like a heading). Manually editing the text was the only way to recover.

### Root cause

`-handleCheckboxToggle:` updates the editor by replacing its whole text storage:

```objc
[self.editor.textStorage replaceCharactersInRange:NSMakeRange(0, length)
                                       withString:newMarkdown];
```

`replaceCharactersInRange:withString:` leaves the inserted text carrying **character 0's attributes**. When the document starts with a heading (e.g. `# Demo`), that heading's font and color get smeared across the entire document. The `HGMarkdownHighlighter` only re-parses on `NSTextDidChangeNotification`, which this direct text-storage edit deliberately does **not** fire (the existing "Gap 10" no-notification design), so the stale styling was never corrected.

### Fix

Re-highlight explicitly after the toggle edit, following `-reloadFromLoadedString`'s programmatic-swap recipe:

```objc
[self.highlighter clearHighlighting];
[self.highlighter parseAndHighlightNow];
```

The full-range `-clearHighlighting` is load-bearing: `-parseAndHighlightNow` ultimately calls `-applyVisibleRangeHighlighting`, which clears and restyles only the **on-screen** range. Without a full-document clear first, the heading smear would persist on any content scrolled off-screen until it re-entered the viewport. `-readClearTextStylesFromTextView` is intentionally omitted (unlike the full-reload path) because a checkbox toggle leaves font, theme, and default color unchanged.

### Tests

Adds `testClearHighlightingResetsSmearedHeadingStyleAcrossFullRange` to `HGMarkdownHighlighterTests.m` — a deterministic (no async) regression test that smears a heading-size font and heading color across a whole document, then asserts full-range `-clearHighlighting` resets **both** font size and foreground color on off-screen content.

## Related Issue

Related to #376

## Review Notes

Developed through the project's issue workflow with an architect review and a two-reviewer ("rule of two") code review:
- **Architect**: caught that `-parseAndHighlightNow` alone only repaints the visible range, requiring the full-document `-clearHighlighting`.
- **Reviewer 1**: APPROVE — confirmed correctness, safety of the clear call at toggle time, and test validity.
- **Reviewer 2**: APPROVE — confirmed no regressions/deadlocks, that keeping `replaceCharactersInRange:` (vs the `string` setter) is correct to preserve the no-notification design, and prompted the comment clarification + the color assertion in the test.

## Manual Testing Plan

1. Open a document beginning with a heading followed by a long task list, e.g.:
   ```
   # Demo Checkbox

   - [ ] item
   - [ ] item
   - [x] item
   ```
2. Click a checkbox in the preview pane.
3. **Expected:** the corresponding `[ ]`/`[x]` toggles in the editor and the editor keeps normal per-line styling (heading stays a heading; list items stay body text). Previously the whole editor turned heading-sized/colored.
4. Repeat with content scrolled partly off-screen to confirm off-screen lines are also styled correctly after a toggle.

Note: tests run on macOS CI only (per `CLAUDE.md`); the change was verified by code reading in this Linux environment and will be exercised by GitHub Actions on macOS.

---
_Generated by [Claude Code](https://claude.ai/code/session_015FmX8KoFm6Zno63ZxPfLHt)_