### PR TITLE
Dynamic preferences pane sizing for localized strings

### DIFF
--- a/MacDown/Code/Preferences/MPPreferencesViewController.m
+++ b/MacDown/Code/Preferences/MPPreferencesViewController.m
@@ -29,36 +29,53 @@ NSString * const MPDidRequestEditorSetupNotification =
 
     NSView *contentView = self.view;
     NSRect frame = contentView.frame;
+    CGFloat englishDesignWidth  = NSWidth(frame);
+    CGFloat englishDesignHeight = NSHeight(frame);
 
     NSView *wrapper = [[NSView alloc] initWithFrame:frame];
     contentView.translatesAutoresizingMaskIntoConstraints = NO;
     [wrapper addSubview:contentView];
 
-    // Keep the panel's designed width and start at the designed height. The
-    // height is grown below once the content has been laid out.
-    NSLayoutConstraint *heightConstraint =
-        [contentView.heightAnchor constraintEqualToConstant:NSHeight(frame)];
+    // Center the content in the wrapper (unchanged from before).
     [NSLayoutConstraint activateConstraints:@[
         [contentView.centerXAnchor constraintEqualToAnchor:wrapper.centerXAnchor],
         [contentView.centerYAnchor constraintEqualToAnchor:wrapper.centerYAnchor],
-        [contentView.widthAnchor  constraintEqualToConstant:NSWidth(frame)],
-        heightConstraint,
     ]];
 
-    self.view = wrapper;
-
-    // Now that the content is wrapped at its designed width, grow the height to
-    // fit the content for the active locale: longer localized strings (e.g.
-    // French, Italian) wrap onto extra lines, so the panel must expand to fit
-    // them instead of clipping. The English design height acts as a floor so we
-    // never shrink a panel.
+    // --- Pass 1: resolve width ---
+    // Apply a >= floor so the pane never shrinks below the English design width,
+    // then ask Auto Layout for the width the content actually needs.
+    NSLayoutConstraint *widthFloor =
+        [contentView.widthAnchor constraintGreaterThanOrEqualToConstant:englishDesignWidth];
+    widthFloor.active = YES;
     [wrapper layoutSubtreeIfNeeded];
-    CGFloat height = MAX(contentView.fittingSize.height, NSHeight(frame));
-    heightConstraint.constant = height;
+    CGFloat width = MAX(contentView.fittingSize.width, englishDesignWidth);
+    widthFloor.active = NO;
 
+    // Pin the resolved width with an = constraint for the height pass.
+    NSLayoutConstraint *widthPin =
+        [contentView.widthAnchor constraintEqualToConstant:width];
+    widthPin.active = YES;
+
+    // --- Pass 2: resolve height at the resolved width ---
+    NSLayoutConstraint *heightFloor =
+        [contentView.heightAnchor constraintGreaterThanOrEqualToConstant:englishDesignHeight];
+    heightFloor.active = YES;
+    [wrapper layoutSubtreeIfNeeded];
+    CGFloat height = MAX(contentView.fittingSize.height, englishDesignHeight);
+    heightFloor.active = NO;
+
+    // Pin the resolved height.
+    NSLayoutConstraint *heightPin =
+        [contentView.heightAnchor constraintEqualToConstant:height];
+    heightPin.active = YES;
+
+    // Update the wrapper frame so MASPreferences reads the correct minimum size.
     NSRect wrapperFrame = wrapper.frame;
-    wrapperFrame.size.height = height;
+    wrapperFrame.size = NSMakeSize(width, height);
     wrapper.frame = wrapperFrame;
+
+    self.view = wrapper;
 }
 
 - (void)dealloc

--- a/MacDown/Localization/Base.lproj/MPEditorPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPEditorPreferencesViewController.xib
@@ -353,7 +353,8 @@
                 <constraint firstItem="g0N-qr-H8K" firstAttribute="leading" secondItem="lt1-Up-OVO" secondAttribute="trailing" constant="8" symbolic="YES" id="5Ap-d0-b4o"/>
                 <constraint firstItem="77u-zZ-bC0" firstAttribute="leading" secondItem="3ow-hg-Gmo" secondAttribute="trailing" constant="5" id="6Tk-8W-iSy"/>
                 <constraint firstItem="77u-zZ-bC0" firstAttribute="top" secondItem="uUN-8R-G1c" secondAttribute="top" id="7tN-YB-ZdQ"/>
-                <constraint firstItem="6JP-Pc-JFd" firstAttribute="centerX" secondItem="Hz6-mo-xeY" secondAttribute="centerX" id="80z-Pl-92m"/>
+                <constraint firstItem="6JP-Pc-JFd" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="dyn-Ed-Ld1"/>
+                <constraint firstAttribute="trailing" secondItem="6JP-Pc-JFd" secondAttribute="trailing" constant="20" id="dyn-Ed-Tr1"/>
                 <constraint firstItem="g0N-qr-H8K" firstAttribute="leading" secondItem="JZh-8k-zMC" secondAttribute="leading" id="8Oh-FM-4u7"/>
                 <constraint firstItem="jde-Kw-4ly" firstAttribute="leading" secondItem="JZh-8k-zMC" secondAttribute="trailing" constant="8" symbolic="YES" id="8tY-NH-DnD"/>
                 <constraint firstItem="lt1-Up-OVO" firstAttribute="leading" secondItem="pwq-Pg-zCk" secondAttribute="leading" id="BD0-LL-mdF"/>

--- a/MacDown/Localization/Base.lproj/MPMarkdownPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPMarkdownPreferencesViewController.xib
@@ -212,6 +212,8 @@
                 <constraint firstItem="x36-52-U0p" firstAttribute="leading" secondItem="TXy-fD-S4Y" secondAttribute="leading" id="aXZ-Pm-NEe"/>
                 <constraint firstItem="TXy-fD-S4Y" firstAttribute="top" secondItem="x36-52-U0p" secondAttribute="bottom" constant="8" id="nUm-2S-CCN"/>
                 <constraint firstItem="TXy-fD-S4Y" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="rVA-W8-cMW"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="TXy-fD-S4Y" secondAttribute="bottom" constant="20" id="dyn-Md-Bt1"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Ycc-Px-jbu" secondAttribute="bottom" constant="20" id="dyn-Md-Bt2"/>
             </constraints>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="4rH-6F-B28"/>

--- a/MacDown/Localization/Base.lproj/MPTerminalPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPTerminalPreferencesViewController.xib
@@ -40,11 +40,8 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="320" translatesAutoresizingMaskIntoConstraints="NO" id="jXn-KV-WQB">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jXn-KV-WQB">
                     <rect key="frame" x="20" y="82" width="324" height="51"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="320" id="4IK-PY-Scf"/>
-                    </constraints>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="By activating shell support you can use the macdown utility to open MacDown and documents from a shell." id="W5n-x2-ygz">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -89,6 +86,7 @@
                 <constraint firstItem="oUF-aA-NID" firstAttribute="leading" secondItem="jQ4-bt-VFs" secondAttribute="trailing" constant="5" id="oLe-wI-n0K"/>
                 <constraint firstItem="jXn-KV-WQB" firstAttribute="top" secondItem="QYt-FS-lHh" secondAttribute="bottom" constant="8" id="pGj-R1-E8c"/>
                 <constraint firstItem="GyN-lb-9B9" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="wQ0-u9-0uy"/>
+                <constraint firstAttribute="trailing" secondItem="jXn-KV-WQB" secondAttribute="trailing" constant="20" id="dyn-Tm-Tr1"/>
             </constraints>
             <point key="canvasLocation" x="79" y="152.5"/>
         </customView>

--- a/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
+++ b/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
@@ -366,14 +366,45 @@ static NSArray<NSButton *> *MPCheckboxes(NSView *content)
         // Measure the height the content needs at its pinned width (the width
         // must stay fixed, or wrapping labels would balloon the height). The
         // applied height must accommodate that — i.e. nothing is clipped.
+        XCTAssertTrue(widthPin.active,
+            @"%@ pane: width pin must be active during height measurement", name);
         CGFloat appliedHeight = heightPin.constant;
         heightPin.active = NO;
         [content layoutSubtreeIfNeeded];
         CGFloat neededHeight = content.fittingSize.height;
+        heightPin.active = YES;
 
         XCTAssertGreaterThanOrEqual(appliedHeight + 0.5, neededHeight,
             @"%@ pane: content height (%g) must accommodate its content (%g)",
             name, appliedHeight, neededHeight);
+    }];
+}
+
+// Every resolved pane width should be within a sane range — wide enough to show
+// content but not ballooning to absurd sizes (which would indicate a runaway
+// fittingSize calculation).
+- (void)testResolvedWidthIsWithinSaneBounds
+{
+    [self.allControllers enumerateKeysAndObjectsUsingBlock:
+     ^(NSString *name, MPPreferencesViewController *vc, BOOL *stop) {
+        NSView *content = MPContentView(vc);
+
+        NSLayoutConstraint *widthPin = nil;
+        for (NSLayoutConstraint *c in content.constraints)
+        {
+            if (c.firstItem == content && c.secondItem == nil
+                && c.relation == NSLayoutRelationEqual
+                && c.firstAttribute == NSLayoutAttributeWidth)
+                widthPin = c;
+        }
+        XCTAssertNotNil(widthPin,
+            @"%@ pane: loadView should pin the content width", name);
+        XCTAssertGreaterThan(widthPin.constant, 200,
+            @"%@ pane: resolved width (%g) is suspiciously narrow",
+            name, widthPin.constant);
+        XCTAssertLessThan(widthPin.constant, 2000,
+            @"%@ pane: resolved width (%g) is suspiciously wide",
+            name, widthPin.constant);
     }];
 }
 


### PR DESCRIPTION
## Summary

- Replace single-pass `loadView` (fixed width, grow height only) with two-pass dynamic sizing that resolves both width and height using `>=` floors at the English design dimensions
- Fix incomplete constraint graphs in three XIBs so `fittingSize` returns meaningful values: Editor (leading/trailing instead of centerX), Markdown (bottom constraints on both columns), Terminal (trailing pin instead of fixed-width text field)
- Add `testResolvedWidthIsWithinSaneBounds` sanity test and defensive assertions in existing layout test

## Test plan

- [x] 1004 tests pass locally (0 unexpected failures)
- [x] New `testResolvedWidthIsWithinSaneBounds` confirms all five panes resolve to sane widths (200–2000pt)
- [x] Existing `testContentIsSizedToFitItsContent` confirms height accommodates content at resolved width
- [ ] CI passes on macOS runner
- [ ] Visual verification with French and Italian locales (reporters @rcuisnier and @massimo-cassandro validate in rc.2)

Related to #397