### PR TITLE
Address issue #479: fix crash on empty Markdown headings

### DIFF
--- a/MacDown/Code/Extension/hoedown_html_patch.c
+++ b/MacDown/Code/Extension/hoedown_html_patch.c
@@ -28,6 +28,16 @@ void hoedown_patch_reset_checkbox_index(void)
     g_checkbox_index = 0;
 }
 
+// hoedown_buffer_new() stores its argument as the buffer's growth "unit", and
+// hoedown_buffer_grow() asserts that unit is non-zero. Passing a size hint of 0
+// (e.g. when a heading or code-fence info string is empty) therefore produces a
+// buffer that aborts the process the first time anything is written to it. Clamp
+// the hint so a derived buffer is always growable. Related to GitHub issue #479.
+static hoedown_buffer *new_growable_buffer(size_t size_hint)
+{
+    return hoedown_buffer_new(size_hint ? size_hint : 16);
+}
+
 int hoedown_patch_get_checkbox_index(void)
 {
     return g_checkbox_index;
@@ -48,8 +58,8 @@ void hoedown_patch_render_blockcode(
     hoedown_buffer *back = NULL;
     if (lang && USE_BLOCKCODE_INFORMATION(state))
     {
-        front = hoedown_buffer_new(lang->size);
-        back = hoedown_buffer_new(lang->size);
+        front = new_growable_buffer(lang->size);
+        back = new_growable_buffer(lang->size);
 
         hoedown_buffer *current = front;
         for (size_t i = 0; i < lang->size; i++)
@@ -237,7 +247,7 @@ void hoedown_patch_render_header(
     (void)data;
     if (ob->size) hoedown_buffer_putc(ob, '\n');
 
-    hoedown_buffer *slug = hoedown_buffer_new(content ? content->size : 16);
+    hoedown_buffer *slug = new_growable_buffer(content ? content->size : 16);
     slugify(slug, content);
     if (slug->size == 0)
         HOEDOWN_BUFPUTSL(slug, "section");
@@ -285,7 +295,7 @@ void hoedown_patch_render_toc_header(
             HOEDOWN_BUFPUTSL(ob,"</li>\n<li>\n");
         }
 
-        hoedown_buffer *slug = hoedown_buffer_new(content ? content->size : 16);
+        hoedown_buffer *slug = new_growable_buffer(content ? content->size : 16);
         slugify(slug, content);
         if (slug->size == 0)
             HOEDOWN_BUFPUTSL(slug, "section");

--- a/MacDownCore/MPQuickLookRenderer.m
+++ b/MacDownCore/MPQuickLookRenderer.m
@@ -248,6 +248,16 @@ static void mp_quicklook_slugify(hoedown_buffer *out, const hoedown_buffer *cont
         out->size--;
 }
 
+// hoedown_buffer_new() stores its argument as the buffer's growth "unit", and
+// hoedown_buffer_grow() asserts that unit is non-zero. A size hint of 0 (an
+// empty heading, e.g. a bare setext underline) therefore yields a buffer that
+// aborts the process on first write. Clamp the hint so the buffer is always
+// growable. Mirrors new_growable_buffer() in hoedown_html_patch.c. Issue #479.
+static hoedown_buffer *mp_quicklook_new_growable_buffer(size_t size_hint)
+{
+    return hoedown_buffer_new(size_hint ? size_hint : 16);
+}
+
 // Emit headings with text-derived id attributes so anchor links work in
 // Quick Look previews, matching the main MacDown preview behavior.
 static void mp_quicklook_render_header(
@@ -257,7 +267,8 @@ static void mp_quicklook_render_header(
     (void)data;
     if (ob->size) hoedown_buffer_putc(ob, '\n');
 
-    hoedown_buffer *slug = hoedown_buffer_new(content ? content->size : 16);
+    hoedown_buffer *slug =
+        mp_quicklook_new_growable_buffer(content ? content->size : 16);
     mp_quicklook_slugify(slug, content);
     if (slug->size == 0)
         HOEDOWN_BUFPUTSL(slug, "section");

--- a/MacDownTests/MPMarkdownRenderingTests.m
+++ b/MacDownTests/MPMarkdownRenderingTests.m
@@ -925,4 +925,59 @@
                   @"Heading must carry the matching id. Got: %@", html);
 }
 
+#pragma mark - Empty Heading Crash Regression (#479)
+
+// A lone setext underline ('-' or '=') with no preceding text makes Hoedown
+// emit a heading whose content is empty. The slug buffer must not be created
+// with a zero unit, or Hoedown's hoedown_buffer_grow assertion aborts the
+// whole app on the background render queue. These render through the real
+// parse path, so before the fix they crash the test process outright.
+// Related to #479.
+
+- (void)testLoneHyphenHeadingDoesNotCrash
+{
+    NSString *html = [self renderMarkdown:@"-"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"section\""],
+                  @"Empty setext heading must render with the fallback id without "
+                  @"crashing. Got: %@", html);
+}
+
+- (void)testLoneEqualsHeadingDoesNotCrash
+{
+    NSString *html = [self renderMarkdown:@"="
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"section\""],
+                  @"Empty setext H1 heading must render with the fallback id "
+                  @"without crashing. Got: %@", html);
+}
+
+- (void)testReportedHyphenCrashInputRenders
+{
+    // Exact document from the issue: it ends in a lone '-' after a blank line,
+    // which Hoedown treats as an empty setext heading underline.
+    NSString *html = [self renderMarkdown:@"_ - _ - _ -\n-\n\n-"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertNotNil(html,
+                  @"Reported crash input must render to a non-nil string.");
+    XCTAssertTrue([html containsString:@"id=\"section\""],
+                  @"The trailing empty heading must render with the fallback id. "
+                  @"Got: %@", html);
+}
+
+- (void)testEmptyHeadingWithTOCDoesNotCrash
+{
+    // The TOC header renderer has the same buffer-creation pattern and must
+    // also survive empty heading content.
+    self.delegate.renderTOC = YES;
+    NSString *html = [self renderMarkdown:@"[TOC]\n\n-"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertNotNil(html,
+                  @"Empty heading with TOC enabled must render without crashing.");
+}
+
 @end

--- a/MacDownTests/MPQuickLookRendererTests.m
+++ b/MacDownTests/MPQuickLookRendererTests.m
@@ -700,6 +700,19 @@
                   @"Quick Look heading id should drop ASCII punctuation. Got: %@", html);
 }
 
+// A bare setext underline ('-' or '=') makes Hoedown emit a heading with empty
+// content. The Quick Look renderer mirrors the preview's slug logic, so it has
+// the same zero-unit buffer hazard and must also survive empty headings without
+// aborting the Quick Look render process. Related to #479.
+
+- (void)testQuickLookEmptyHeadingDoesNotCrash
+{
+    NSString *html = [self.renderer renderMarkdown:@"-"];
+    XCTAssertTrue([html containsString:@"id=\"section\""],
+                  @"Quick Look must render an empty heading with the fallback id "
+                  @"without crashing. Got: %@", html);
+}
+
 @end
 
 #else


### PR DESCRIPTION
## Summary

Typing a lone setext underline (`-` or `=`) on an otherwise-empty line crashed the app. The crash is a C `assert()` (`SIGABRT`) inside Hoedown's `hoedown_buffer_grow` — `assert(buf && buf->unit)` — reached from MacDown's patched heading renderer, running on `MPRenderer`'s background render `NSOperationQueue` (matching the faulting thread in the report).

A bare `-`/`=` makes Hoedown emit a heading with **empty content**. The patched heading renderers built the slug buffer with `hoedown_buffer_new(content->size)`, so an empty heading produced a buffer with a zero growth *unit*. The fallback `HOEDOWN_BUFPUTSL(slug, "section")` then grew that buffer and tripped the assert. Minimal reproduction: a document containing only `-` (or only `=`); the reported `_ - _ - _ -\n-\n\n-` ends in exactly such a trailing lone `-`.

I reproduced this directly by building Hoedown 3.0.7 with the MacDown patch and rendering the reported input — it aborts in `hoedown_buffer_put` from `hoedown_patch_render_header`, with the second header callback receiving `content->size == 0`.

## Root cause / origin

Introduced in 0.7-rc.1 by the slug-based heading IDs change (#430). Before #430 there was no custom `header` callback, so Hoedown's built-in renderer handled empty headings harmlessly. #430 both added the custom renderer **and** sized its working buffer from the heading content length, which is `0` for an empty heading.

The same slug/heading logic was copied verbatim into the **Quick Look** renderer in #430, so it carried the identical crash — reachable by previewing a `.md` file with a bare `-`/`=` heading in Finder/Spotlight. That copy is fixed here too.

## Changes

- `MacDown/Code/Extension/hoedown_html_patch.c` — add a `new_growable_buffer()` helper that clamps a zero size hint to a non-zero unit; use it in `hoedown_patch_render_header`, `hoedown_patch_render_toc_header`, and the analogous block-code info-string buffers.
- `MacDownCore/MPQuickLookRenderer.m` — same fix via a mirrored `mp_quicklook_new_growable_buffer()` helper for `mp_quicklook_render_header`.
- `MacDownTests/MPMarkdownRenderingTests.m` — regression tests rendering a lone `-`, a lone `=`, the exact reported input, and an empty heading with TOC enabled, all through the real render path.
- `MacDownTests/MPQuickLookRendererTests.m` — regression test rendering a bare `-` heading through the Quick Look renderer.

After the fix, an empty heading renders as `<h2 id="section"></h2>` (no crash) and normal headings keep their slugs; verified across the preview and TOC paths and the Quick Look renderer.

## Related Issue

Related to #479. The regression originates in #430 (slug-based heading IDs). The reporter arrived here while exercising the selection-count thread in #452, which is a separate, unrelated issue.

## Manual Testing Plan

1. New empty document; type `-` on the first line → must not crash; preview shows an (empty) heading.
2. Type `=` alone on a line → must not crash.
3. Reproduce the report: type
   ```
   _ - _ - _ -
   -

   -
   ```
   typing the final `-` last → must not crash.
4. Normal headings (`# Hello`, `## Foo Bar`) still render with correct slug ids (`id="hello"`, `id="foo-bar"`).
5. Enable TOC (`[TOC]`) in a document that also contains an empty heading → must not crash; TOC links resolve.
6. In Finder, select a `.md` file whose content is just `-` and press Space (Quick Look) → preview renders without the Quick Look process aborting.

## Review Notes

- Tests run on macOS CI only; the regression tests exercise the real `parseMarkdown:`/Quick Look render paths, so before the fix they abort the test process and after it they pass.
- Noted but not changed: #430 also switched TOC anchors from `#toc_N` to `#<slug>`, so duplicate heading texts collapse to the same id (already pinned by an existing test) — flagged for a possible future slug-dedup, not a crash.