### PR TITLE
Address issue #478: harden file watching against transient paths and remote volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Fix the Insert Table toolbar button doing nothing when the editor pane had focus, and corrupting the document when clicked repeatedly (a second table was inserted inside the first table's cell); every click now inserts a clean, well-separated table regardless of which pane has focus (#278) -- thanks @rcuisnier for the report!
+- Fix auto-reload silently breaking after an external editor's atomic save by making the local-volume watcher check fall back to the parent directory when the file is transiently missing; also guard resource-file watchers against remote volumes and tear down any prior watcher before re-arming (#478)
 - Fix the Preview pane still auto-scrolling toward the editor when typing after Sync Panes was turned off mid-session; toggling Sync Panes now takes effect immediately (settling the panes on disable, re-syncing on enable) without needing to reopen the document (#441) -- thanks @gregwillits!
 - Fix blank preview when opening saved or externally-originated documents: the real document file is no longer used as the preview's base resource, which WebKit on macOS 26 can silently refuse to load (e.g. files with the execute bit set by sync clients like OneDrive, or stale TCC/provenance state) (#431, #405) -- thanks @maskedspitz, @songjianbupt, and @craigrodger for the diagnosis!
 - Improve render-path responsiveness: single-pass word/character counting, cached body-extraction regex, and bounded renderer polling with cancellation (#388)

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -3856,10 +3856,13 @@ to link outside that scope.", \
 
 - (void)startFileWatching
 {
+    // Tear down any previously-armed watcher first, so an early return below
+    // (nil URL, or a path that cannot be watched) can never leak a stale
+    // watcher for an old session. Related to #478.
+    [self stopFileWatching];
+
     if (!self.fileURL || !self.fileURL.isFileURL)
         return;
-
-    [self stopFileWatching];
 
     if (![MPFileWatcher canWatchPath:self.fileURL.path])
         return;

--- a/MacDown/Code/Utility/MPFileWatcher.h
+++ b/MacDown/Code/Utility/MPFileWatcher.h
@@ -16,7 +16,11 @@
 /// YES if currently watching.
 @property (nonatomic, readonly, getter=isWatching) BOOL watching;
 
-/// YES if the path is on a local volume that should receive vnode watchers.
+/// YES if the path can receive vnode watchers: it is non-nil, non-empty, and
+/// resides on a local volume. When the file itself does not exist (e.g. during
+/// an external editor's atomic rename-replace save) the locality check falls
+/// back to the parent directory. Returns NO for nil, empty, non-local, or
+/// otherwise unresolvable paths.
 + (BOOL)canWatchPath:(NSString *)path;
 
 /// Create a watcher for the given path. Calls handler on the main queue

--- a/MacDown/Code/Utility/MPFileWatcher.m
+++ b/MacDown/Code/Utility/MPFileWatcher.m
@@ -21,11 +21,26 @@
     if (!path.length)
         return NO;
 
-    NSURL *url = [NSURL fileURLWithPath:path];
+    // NSURLVolumeIsLocalKey can only be read from a URL that resolves to an
+    // existing item. During an external editor's atomic rename-replace save the
+    // file transiently disappears, so probing the file itself would wrongly
+    // report the path as non-local and disable auto-reload. Fall back to the
+    // parent directory's volume in that case. Related to #478.
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *probePath = path;
+    if (![fileManager fileExistsAtPath:probePath])
+        probePath = [path stringByDeletingLastPathComponent];
+    if (!probePath.length || ![fileManager fileExistsAtPath:probePath])
+        return NO;
+
+    NSURL *url = [NSURL fileURLWithPath:probePath];
     NSNumber *isLocal = nil;
+    NSError *error = nil;
     if (![url getResourceValue:&isLocal
-                        forKey:NSURLVolumeIsLocalKey error:NULL])
+                        forKey:NSURLVolumeIsLocalKey error:&error])
     {
+        NSLog(@"MPFileWatcher: cannot determine volume locality for %@: %@",
+              probePath, error.localizedDescription);
         return NO;
     }
 

--- a/MacDown/Code/Utility/MPResourceWatcherSet.m
+++ b/MacDown/Code/Utility/MPResourceWatcherSet.m
@@ -57,6 +57,12 @@
 
 - (void)addWatcherForPath:(NSString *)path
 {
+    // Skip paths that cannot receive vnode watchers (nil/empty or on a remote
+    // volume) before constructing a watcher, mirroring the guard in
+    // -[MPDocument startFileWatching]. Related to #478.
+    if (![MPFileWatcher canWatchPath:path])
+        return;
+
     __weak MPResourceWatcherSet *weakSelf = self;
     NSString *watchedPath = [path copy];
 

--- a/MacDownTests/MPFileWatcherTests.m
+++ b/MacDownTests/MPFileWatcherTests.m
@@ -87,6 +87,32 @@
     XCTAssertFalse([MPFileWatcher canWatchPath:nil]);
 }
 
+- (void)testCannotWatchEmptyPath
+{
+    XCTAssertFalse([MPFileWatcher canWatchPath:@""]);
+}
+
+- (void)testCanWatchNonexistentLocalPath
+{
+    // A file that does not yet exist (e.g. mid atomic rename-replace save) on a
+    // local volume must still be considered watchable: the locality check falls
+    // back to the parent directory. Otherwise auto-reload silently dies during
+    // an external editor's save. Related to #478.
+    NSString *path = [self.testDirectory stringByAppendingPathComponent:@"gone.txt"];
+    XCTAssertFalse([self.fileManager fileExistsAtPath:path]);
+    XCTAssertTrue([MPFileWatcher canWatchPath:path]);
+}
+
+- (void)testCannotWatchPathWithNonexistentParent
+{
+    // Neither the file nor its parent directory exists -> nothing to probe for
+    // volume locality, so watching is not possible.
+    NSString *path = [[self.testDirectory
+                       stringByAppendingPathComponent:@"missing-dir"]
+                      stringByAppendingPathComponent:@"file.txt"];
+    XCTAssertFalse([MPFileWatcher canWatchPath:path]);
+}
+
 #pragma mark - Event Handling
 
 - (void)testHandlerCalledOnFileWrite

--- a/MacDownTests/MPResourceWatcherSetTests.m
+++ b/MacDownTests/MPResourceWatcherSetTests.m
@@ -122,6 +122,15 @@
     XCTAssertEqual(self.watcherSet.watchedPaths.count, 0u);
 }
 
+- (void)testSkipsUnwatchablePath
+{
+    // An unwatchable path (here an empty string, but in practice a remote
+    // volume) must be rejected before a watcher is constructed and never
+    // stored. Related to #478.
+    [self.watcherSet updateWatchedPaths:[NSSet setWithObject:@""]];
+    XCTAssertEqual(self.watcherSet.watchedPaths.count, 0u);
+}
+
 - (void)testDelegateCalledOnChange
 {
     NSString *path = [self createTestFileWithName:@"watch.png"];


### PR DESCRIPTION
## Summary

Closes the three file-watcher gaps identified in review of the merged PR #424 (`canWatchPath:` local-volume gating). The headline fix is an auto-reload regression: after an external editor's atomic rename-replace save, the locality check could disable watching and silently stop live preview updates.

### Changes

- **`+[MPFileWatcher canWatchPath:]`** — `NSURLVolumeIsLocalKey` can only be read from a URL that resolves to an existing item. When the file is transiently missing (mid atomic save), probe the **parent directory's** volume instead, so auto-reload isn't wrongly disabled. Return `NO` only if neither the path nor its parent resolves, or the volume is non-local. Also captures the `NSError` from `getResourceValue:` (was `NULL`) and `NSLog`s it to help diagnose "Device not configured" failures.
- **`-[MPResourceWatcherSet addWatcherForPath:]`** — added an explicit `canWatchPath:` guard up front, mirroring the document watcher. (Resource watchers were already filtered indirectly via `MPFileWatcher`'s internal check + the `isWatching` store gate, so this is clarity/symmetry/testability, not a behavior fix.)
- **`-[MPDocument startFileWatching]`** — moved `[self stopFileWatching]` to the top, above the nil/non-file-URL early return, so no early return can leak a previously-armed watcher.
- **Doc comment** — rewrote the `canWatchPath:` header comment to describe all return-`NO` cases (nil/empty/non-local/unresolvable) and the parent-directory fallback.

### Notes on the issue framing

Two of the three "gaps" turned out to be milder than the issue body suggested, and I've documented that on the issue:

- **Gap 1 (resource watchers unguarded)** was not a live defect — remote-volume resources were already skipped gracefully. The explicit guard is added anyway for clarity.
- **Gap 3 (stale watcher)** was mostly handled already — `stopFileWatching` ran before the `canWatchPath:` return; only the nil-URL guard preceded it. The reorder closes that remaining edge.

The substantive fix is **Gap 2** (the atomic-save auto-reload regression).

## Tests

Added to existing suites (no new files, so no Xcode target wiring needed):

- `MPFileWatcherTests`: `testCannotWatchEmptyPath`, `testCanWatchNonexistentLocalPath` (the regression lock — fails against the old code), `testCannotWatchPathWithNonexistentParent`.
- `MPResourceWatcherSetTests`: `testSkipsUnwatchablePath`.

Existing tests (`testInitWithNonexistentPath`, `testSkipsNonexistentFiles`) still hold: `canWatchPath:` now returns `YES` for a non-existent-but-local path, but `initWithPath:`'s `open(O_EVTONLY)` still fails for a truly absent file, so nothing is falsely watched.

Tests run on macOS CI only (per `CLAUDE.md`); changes verified by code reading and a fresh-eyes review in this Linux environment.

## Manual Testing Plan

1. Open a Markdown document; confirm the preview live-reloads when you edit the file in an external editor that does **atomic** saves (e.g. BBEdit, VS Code, or `printf ... > tmp && mv tmp file.md`).
2. **Repeat the external save several times in a row** — auto-reload should keep working every time (previously it could silently stop after the first atomic save).
3. Place a `.md` file on a **remote/network volume** (SMB/AFP share) and open it — the app should behave normally with live-watching simply skipped (no errors/hangs).
4. Reference a local image/CSS in the document, then modify that resource externally — the preview should update.
5. Use **Save As** to a new location, then save the original file externally — the watcher should follow the current document and not fire for the old path.

## Related Issue

Related to #478

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkicx7bYVhag4XggfHcKDN)_