### PR TITLE
Add folder workspaces: hideable sidebar + native tabs + macdown .

### DIFF
--- a/MacDown 3000.xcodeproj/project.pbxproj
+++ b/MacDown 3000.xcodeproj/project.pbxproj
@@ -7,10 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00F6EAD22CA0765C131AA4EC /* MPFileNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A0A5A0E543A6B3CE9E17EE7B /* MPFileNodeTests.m */; };
 		0319BD8F4A64D9E406448C13 /* MPSyntaxHighlightingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C64395EB126274BB2E01E01 /* MPSyntaxHighlightingTests.m */; };
 		03224E1B02E36783D5307F4A /* MPDocumentIOTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35FB5AC5D9A67BFB58A9430F /* MPDocumentIOTests.m */; };
+		057EEF5152CEAB472DFF20FD /* MPFolderSidebarViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BDC351D0D920E583085F2C6 /* MPFolderSidebarViewControllerTests.m */; };
 		0A33AF1E979F50E868FEE7DC /* libPods-MacDownCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F2375876A05ADEB6544CB4EB /* libPods-MacDownCore.a */; };
+		0F6EFB9168CB2E074C8EEE64 /* MPFolderWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ED6745ED95492186AF6E844 /* MPFolderWatcher.m */; };
 		1457815B1A710E4C40F07FCA /* MPPaneToggleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E44CF1BD72E49A99DA6A4C1 /* MPPaneToggleTests.m */; };
+		1882ADC14E60D20538509FCA /* MPSidebarSplitView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B004FFBE8014E25420887FD /* MPSidebarSplitView.m */; };
 		197TESTS0B00000000197RSTB /* MPRendererStateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 197TESTS0F00000000197RSTF /* MPRendererStateTests.m */; };
 		1F002A23195B3DAE008B8D93 /* MPRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F002A22195B3DAE008B8D93 /* MPRenderer.m */; };
 		1F0D9D65194AC7CF008E1856 /* NSString+Lookup.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0D9D5F194AC7CF008E1856 /* NSString+Lookup.m */; };
@@ -91,6 +95,7 @@
 		1FFEB32D19ABCD1300B2254F /* MPMarkdownRenderingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FFEB32F19ABCD1500B2254F /* MPMarkdownRenderingTests.m */; };
 		1FFF301D1948A5320009AF24 /* MPStringLookupTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FFF301C1948A5320009AF24 /* MPStringLookupTests.m */; };
 		216C6596D7D94CFE5BD278BF /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25948CF406215AF81C0EA4DA /* Cocoa.framework */; };
+		2BFA7B61B4FA1F0C0860037B /* MPDocumentWorkspaceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AA947C490F49EE01830E163 /* MPDocumentWorkspaceTests.m */; };
 		3028039E1FD84EAC0055B0DA /* contribute.md in Resources */ = {isa = PBXBuildFile; fileRef = 3028039D1FD84EAB0055B0DA /* contribute.md */; };
 		34C7CDD88457F3330405D3A5 /* MPQuickLookRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DBD9CC5E9FE89EDAAFA779B /* MPQuickLookRenderer.m */; };
 		3A741C120087C1EEF6862627 /* MPUpdaterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AB47A87B03D655D2F2285141 /* MPUpdaterTests.m */; };
@@ -101,11 +106,15 @@
 		504AC0000000000000000007 /* PDFKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 504AC0000000000000000006 /* PDFKit.framework */; };
 		504AC0000000000000000008 /* PDFKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 504AC0000000000000000006 /* PDFKit.framework */; };
 		53878B92ED0F95BE37209ECC /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25948CF406215AF81C0EA4DA /* Cocoa.framework */; };
+		545BC1E3C5C9EC20E12575B3 /* MPDocumentTabReuseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC4903A09EAD86914984F6F1 /* MPDocumentTabReuseTests.m */; };
 		5AD88BF0766B938F9D61A831 /* MPEditorViewSubstitutionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3BD139B59E787FBB9F38228 /* MPEditorViewSubstitutionTests.m */; };
+		632DE4286F689FB448FF9357 /* MPFileNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FE8D35A5366F9BE39227CEC /* MPFileNode.m */; };
+		75738FA5CDF1AA53FECC5495 /* MPFolderWatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A01DF3116B648FB08F2D42B0 /* MPFolderWatcherTests.m */; };
 		770BB49E962A302D0715A6A5 /* libPods-MacDown.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 42F926DD38559C7CEDB6E42F /* libPods-MacDown.a */; };
 		7BDE056B97C37ECFE76271F6 /* MPQuickLookPreferences.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CE5C37476A61D05FCC741F9 /* MPQuickLookPreferences.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		852D523C1E260A6400BA7162 /* MPTerminalPreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 852D523A1E260A6400BA7162 /* MPTerminalPreferencesViewController.m */; };
 		85E24E5C1E5019C00056E696 /* MPToolbarController.m in Sources */ = {isa = PBXBuildFile; fileRef = 85E24E5B1E5019C00056E696 /* MPToolbarController.m */; };
+		8F6598F79605DBA110909D3E /* MPMainControllerFolderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C695901868F7E76EAB0EBA6 /* MPMainControllerFolderTests.m */; };
 		905EF1A9196164CA00FC3CE9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 905EF1A8196164CA00FC3CE9 /* Foundation.framework */; };
 		905EF1B7196164F300FC3CE9 /* macdown in Copy Command Line Utility */ = {isa = PBXBuildFile; fileRef = 905EF1A7196164CA00FC3CE9 /* macdown */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		9490DBB6C6742726279610B6 /* MPQuickLookRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 96115B1933D8C446B45DCB7A /* MPQuickLookRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -117,12 +126,16 @@
 		A2310231000000000001IMAG /* Images in Resources */ = {isa = PBXBuildFile; fileRef = A2310231000000000000IMAG /* Images */; };
 		A30E1B2D2D3E4F5A6B7C8D9F /* MPHTMLExportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A30E1B2C2D3E4F5A6B7C8D9E /* MPHTMLExportTests.m */; };
 		A7BD440CD9E36EB46B87B143 /* MacDownQuickLook.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = D80F0F27E815934603CB0A05 /* MacDownQuickLook.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AD8A942CA7FEA4BD27C18A0E /* MPMainControllerMenuTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D17D80F3F55A027304992DED /* MPMainControllerMenuTests.m */; };
+		B2DAA822F8635954B416A764 /* MPSidebarSyncCoordinatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 16399DCF6DD45265101115E0 /* MPSidebarSyncCoordinatorTests.m */; };
 		B5C5C1666A506FEA86435D25 /* libPods-macdown-cmd.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 263367245B2D78A42C2F19D7 /* libPods-macdown-cmd.a */; };
 		B5E8BC2FB2156BF747E84248 /* MacDownCore.h in Headers */ = {isa = PBXBuildFile; fileRef = D30FDB4BDFBD13C1577ECFB4 /* MacDownCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B9A8DE030E3748EB899BD45E /* MPScrollSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C2B84BF8A8BC4F4B871646F8 /* MPScrollSyncTests.m */; };
 		B9A9E04CBEE140C3AF8880B9 /* MPResourceWatcherSetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8579778C7BF70F28920CE089 /* MPResourceWatcherSetTests.m */; };
 		BA2B9EC2E95175092A97B41E /* MPResourceWatcherSet.m in Sources */ = {isa = PBXBuildFile; fileRef = E6D070A6E080254A17B3B197 /* MPResourceWatcherSet.m */; };
+		C53D672DA7E35889E7361FF3 /* MPFolderSidebarViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F5475503E4264E68C149AA9E /* MPFolderSidebarViewController.m */; };
 		CCD97578A2886FFE73BD96F7 /* MPMathJaxRenderingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6811F39B13C649FC86C4CE5B /* MPMathJaxRenderingTests.m */; };
+		CD03CB15DD4AE325CBF3BEF3 /* MPSidebarSyncCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = 53056C5D1D3F14882629B27C /* MPSidebarSyncCoordinator.m */; };
 		CHKBOXTGL0001BUILDFILER /* MPCheckboxToggleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CHKBOXTGL0001FILEREFID /* MPCheckboxToggleTests.m */; };
 		D29776CC6E7EB5B4AA2E0537 /* MPFileWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = A81247E840EB5C07669FF165 /* MPFileWatcher.m */; };
 		D3877A6637DE48017448C8DB /* MPRendererTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E2FC4B9389A012264DC6214 /* MPRendererTestHelpers.m */; };
@@ -132,6 +145,7 @@
 		EA05ACEB1EBB3F64827A3E0C /* MacDownCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 86AE530AAF3D3E54B419F5BB /* MacDownCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EA2D3FB9196BC4F7CA0235DC /* MPFileWatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 779606A8E0525000200B4EC5 /* MPFileWatcherTests.m */; };
 		EBFE3157737058F5A63699C8 /* libPods-MacDownTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C949FDE45493AE77DAD9BF4 /* libPods-MacDownTests.a */; };
+		F2D5D4C51C5B62C27B256CFE /* MPSidebarSplitViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 626779D9F12A022B4F57258D /* MPSidebarSplitViewTests.m */; };
 		ISSUE16RNDRDEFRBUILDFILE /* MPRenderDeferralTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE16RNDRDEFRFILEREF /* MPRenderDeferralTests.m */; };
 		ISSUE278TABLEBUILDFILE /* MPInsertTableTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE278TABLEFILEREF /* MPInsertTableTests.m */; };
 		ISSUE285SMARTQTBUILDFILE /* MPSmartQuoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ISSUE285SMARTQTFILEREF /* MPSmartQuoteTests.m */; };
@@ -264,7 +278,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0925B76B06FC62100372111F /* MPFolderSidebarViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MPFolderSidebarViewController.h; path = MacDown/Code/Sidebar/MPFolderSidebarViewController.h; sourceTree = "<group>"; };
+		0AA947C490F49EE01830E163 /* MPDocumentWorkspaceTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPDocumentWorkspaceTests.m; sourceTree = "<group>"; };
 		0D0EC0DE9FEA22F962083921 /* Pods-MacDownTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacDownTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MacDownTests/Pods-MacDownTests.release.xcconfig"; sourceTree = "<group>"; };
+		16399DCF6DD45265101115E0 /* MPSidebarSyncCoordinatorTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPSidebarSyncCoordinatorTests.m; sourceTree = "<group>"; };
 		197TESTS0F00000000197RSTF /* MPRendererStateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPRendererStateTests.m; sourceTree = "<group>"; };
 		1A198D1BA59D710201DD3BC8 /* Pods-MacDown.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacDown.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MacDown/Pods-MacDown.debug.xcconfig"; sourceTree = "<group>"; };
 		1F002A21195B3DAE008B8D93 /* MPRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPRenderer.h; sourceTree = "<group>"; };
@@ -592,18 +609,23 @@
 		3D175F0F1974282400A5EFE8 /* WebView+WebViewPrivateHeaders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WebView+WebViewPrivateHeaders.h"; sourceTree = "<group>"; };
 		3E2FC4B9389A012264DC6214 /* MPRendererTestHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPRendererTestHelpers.m; sourceTree = "<group>"; };
 		42F926DD38559C7CEDB6E42F /* libPods-MacDown.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MacDown.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4BDC351D0D920E583085F2C6 /* MPFolderSidebarViewControllerTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPFolderSidebarViewControllerTests.m; sourceTree = "<group>"; };
+		4C695901868F7E76EAB0EBA6 /* MPMainControllerFolderTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPMainControllerFolderTests.m; sourceTree = "<group>"; };
 		4DBAA63927A60EB2150642B3 /* Pods-macdown-cmd.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-macdown-cmd.debug.xcconfig"; path = "Pods/Target Support Files/Pods-macdown-cmd/Pods-macdown-cmd.debug.xcconfig"; sourceTree = "<group>"; };
 		504AC0000000000000000001 /* MPPDFAnchorInjector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPPDFAnchorInjector.h; sourceTree = "<group>"; };
 		504AC0000000000000000002 /* MPPDFAnchorInjector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPPDFAnchorInjector.m; sourceTree = "<group>"; };
 		504AC0000000000000000004 /* MPPDFAnchorInjectorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPPDFAnchorInjectorTests.m; sourceTree = "<group>"; };
 		504AC0000000000000000006 /* PDFKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PDFKit.framework; path = System/Library/Frameworks/PDFKit.framework; sourceTree = SDKROOT; };
 		5162FB5F85C6B4B09403BE65 /* MPHTMLResourceURLs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPHTMLResourceURLs.h; sourceTree = "<group>"; };
+		53056C5D1D3F14882629B27C /* MPSidebarSyncCoordinator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MPSidebarSyncCoordinator.m; path = MacDown/Code/Sidebar/MPSidebarSyncCoordinator.m; sourceTree = "<group>"; };
 		54C0AE6E3F479CE9D9310DCE /* MacDownQuickLook.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MacDownQuickLook/MacDownQuickLook.entitlements; sourceTree = SOURCE_ROOT; };
 		5C2E23A49DBCCD5CFA3B8104 /* libPods-MacDownQuickLook.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MacDownQuickLook.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CE5C37476A61D05FCC741F9 /* MPQuickLookPreferences.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MacDownCore/MPQuickLookPreferences.h; sourceTree = SOURCE_ROOT; };
 		5E44CF1BD72E49A99DA6A4C1 /* MPPaneToggleTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPPaneToggleTests.m; sourceTree = "<group>"; };
+		5ED6745ED95492186AF6E844 /* MPFolderWatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MPFolderWatcher.m; path = MacDown/Code/Sidebar/MPFolderWatcher.m; sourceTree = "<group>"; };
 		5F23020AD4494E700E72C264 /* MPRendererTestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPRendererTestHelpers.h; sourceTree = "<group>"; };
 		615588251EB35DEE6204B94E /* MPResourceWatcherSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPResourceWatcherSet.h; sourceTree = "<group>"; };
+		626779D9F12A022B4F57258D /* MPSidebarSplitViewTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPSidebarSplitViewTests.m; sourceTree = "<group>"; };
 		6811F39B13C649FC86C4CE5B /* MPMathJaxRenderingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPMathJaxRenderingTests.m; sourceTree = "<group>"; };
 		7512A2D56BCD495E40222950 /* PreviewViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MacDownQuickLook/PreviewViewController.h; sourceTree = SOURCE_ROOT; };
 		779606A8E0525000200B4EC5 /* MPFileWatcherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPFileWatcherTests.m; sourceTree = "<group>"; };
@@ -611,6 +633,7 @@
 		7DBD9CC5E9FE89EDAAFA779B /* MPQuickLookRenderer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MacDownCore/MPQuickLookRenderer.m; sourceTree = SOURCE_ROOT; };
 		7EDA4DCB8E20B177D4704F77 /* MPHTMLResourceURLs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPHTMLResourceURLs.m; sourceTree = "<group>"; };
 		83B73B6D4862F9509E619943 /* Pods-MacDownCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacDownCore.release.xcconfig"; path = "Pods/Target Support Files/Pods-MacDownCore/Pods-MacDownCore.release.xcconfig"; sourceTree = "<group>"; };
+		848CB0745DA0086DDD4A129A /* MPSidebarSplitView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MPSidebarSplitView.h; path = MacDown/Code/Sidebar/MPSidebarSplitView.h; sourceTree = "<group>"; };
 		852D52391E260A6400BA7162 /* MPTerminalPreferencesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPTerminalPreferencesViewController.h; sourceTree = "<group>"; };
 		852D523A1E260A6400BA7162 /* MPTerminalPreferencesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPTerminalPreferencesViewController.m; sourceTree = "<group>"; };
 		8552820CEE8D00E83AEE3897 /* MPHTMLResourceURLsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPHTMLResourceURLsTests.m; sourceTree = "<group>"; };
@@ -619,11 +642,15 @@
 		85E24E5B1E5019C00056E696 /* MPToolbarController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MPToolbarController.m; path = Code/Application/MPToolbarController.m; sourceTree = "<group>"; };
 		86AE530AAF3D3E54B419F5BB /* MacDownCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MacDownCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8CDC5EA0050D2F722FB1AADD /* Pods-MacDownTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacDownTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MacDownTests/Pods-MacDownTests.debug.xcconfig"; sourceTree = "<group>"; };
+		8FE8D35A5366F9BE39227CEC /* MPFileNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MPFileNode.m; path = MacDown/Code/Sidebar/MPFileNode.m; sourceTree = "<group>"; };
 		905EF1A7196164CA00FC3CE9 /* macdown */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = macdown; sourceTree = BUILT_PRODUCTS_DIR; };
 		905EF1A8196164CA00FC3CE9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		9495AEB20E28D87807E17B8B /* Pods-MacDownQuickLook.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacDownQuickLook.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MacDownQuickLook/Pods-MacDownQuickLook.debug.xcconfig"; sourceTree = "<group>"; };
 		96115B1933D8C446B45DCB7A /* MPQuickLookRenderer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MacDownCore/MPQuickLookRenderer.h; sourceTree = SOURCE_ROOT; };
+		9B004FFBE8014E25420887FD /* MPSidebarSplitView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MPSidebarSplitView.m; path = MacDown/Code/Sidebar/MPSidebarSplitView.m; sourceTree = "<group>"; };
 		9C64395EB126274BB2E01E01 /* MPSyntaxHighlightingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPSyntaxHighlightingTests.m; sourceTree = "<group>"; };
+		A01DF3116B648FB08F2D42B0 /* MPFolderWatcherTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPFolderWatcherTests.m; sourceTree = "<group>"; };
+		A0A5A0E543A6B3CE9E17EE7B /* MPFileNodeTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPFileNodeTests.m; sourceTree = "<group>"; };
 		A1DDD7292F19A20300C407CD /* FileURLInliningTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FileURLInliningTests.m; sourceTree = "<group>"; };
 		A1E2BE312F0A74E500DF65A1 /* FileURLInlining.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileURLInlining.h; sourceTree = "<group>"; };
 		A1E2BE332F0A754F00DF65A1 /* FileURLInlining.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FileURLInlining.m; sourceTree = "<group>"; };
@@ -631,16 +658,20 @@
 		A30E1B2C2D3E4F5A6B7C8D9E /* MPHTMLExportTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPHTMLExportTests.m; sourceTree = "<group>"; };
 		A50D9D0484B046D0B8BADDA6 /* MPQuickLookPreferences.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MacDownCore/MPQuickLookPreferences.m; sourceTree = SOURCE_ROOT; };
 		A81247E840EB5C07669FF165 /* MPFileWatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPFileWatcher.m; sourceTree = "<group>"; };
+		A975F4E209243A57A0040072 /* MPSidebarSyncCoordinator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MPSidebarSyncCoordinator.h; path = MacDown/Code/Sidebar/MPSidebarSyncCoordinator.h; sourceTree = "<group>"; };
 		AB47A87B03D655D2F2285141 /* MPUpdaterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPUpdaterTests.m; sourceTree = "<group>"; };
 		ADEEE219B17DDB468C3A7EBF /* Pods-MacDownQuickLook.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacDownQuickLook.release.xcconfig"; path = "Pods/Target Support Files/Pods-MacDownQuickLook/Pods-MacDownQuickLook.release.xcconfig"; sourceTree = "<group>"; };
 		B2C3D4E5F67890ABCDEF1234 /* MPZoomTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPZoomTests.m; sourceTree = "<group>"; };
 		B3BD139B59E787FBB9F38228 /* MPEditorViewSubstitutionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPEditorViewSubstitutionTests.m; sourceTree = "<group>"; };
+		C13407D1311EAF420CEE31C9 /* MPFileNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MPFileNode.h; path = MacDown/Code/Sidebar/MPFileNode.h; sourceTree = "<group>"; };
 		C2B84BF8A8BC4F4B871646F8 /* MPScrollSyncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPScrollSyncTests.m; sourceTree = "<group>"; };
 		C8D2C0415282E2600BD87E85 /* PreviewViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MacDownQuickLook/PreviewViewController.m; sourceTree = SOURCE_ROOT; };
 		CHKBOXTGL0001FILEREFID /* MPCheckboxToggleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPCheckboxToggleTests.m; sourceTree = "<group>"; };
+		D17D80F3F55A027304992DED /* MPMainControllerMenuTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPMainControllerMenuTests.m; sourceTree = "<group>"; };
 		D30FDB4BDFBD13C1577ECFB4 /* MacDownCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MacDownCore/MacDownCore.h; sourceTree = SOURCE_ROOT; };
 		D80F0F27E815934603CB0A05 /* MacDownQuickLook.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MacDownQuickLook.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDDB87873110C02114439C2C /* MPFileWatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPFileWatcher.h; sourceTree = "<group>"; };
+		DF12A026D4752AFA395CF10B /* MPFolderWatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MPFolderWatcher.h; path = MacDown/Code/Sidebar/MPFolderWatcher.h; sourceTree = "<group>"; };
 		E64879065D20A4124AD56945 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = MacDownQuickLook/Info.plist; sourceTree = SOURCE_ROOT; };
 		E6D070A6E080254A17B3B197 /* MPResourceWatcherSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPResourceWatcherSet.m; sourceTree = "<group>"; };
 		E70ECDD4241C933C00537A46 /* ru-RU */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ru-RU"; path = "Localization/ru-RU.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -687,7 +718,9 @@
 		E77E5D72241C935100699B5A /* da-DK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "da-DK"; path = "Localization/da-DK.lproj/MPDocument.strings"; sourceTree = "<group>"; };
 		E7D458CB241C933800411A36 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = Localization/fi.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		E7DD09F1241C9368008FBC25 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = Localization/da.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		EC4903A09EAD86914984F6F1 /* MPDocumentTabReuseTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPDocumentTabReuseTests.m; sourceTree = "<group>"; };
 		F2375876A05ADEB6544CB4EB /* libPods-MacDownCore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MacDownCore.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F5475503E4264E68C149AA9E /* MPFolderSidebarViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MPFolderSidebarViewController.m; path = MacDown/Code/Sidebar/MPFolderSidebarViewController.m; sourceTree = "<group>"; };
 		ISSUE16RNDRDEFRFILEREF /* MPRenderDeferralTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPRenderDeferralTests.m; sourceTree = "<group>"; };
 		ISSUE278TABLEFILEREF /* MPInsertTableTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPInsertTableTests.m; sourceTree = "<group>"; };
 		ISSUE285SMARTQTFILEREF /* MPSmartQuoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPSmartQuoteTests.m; sourceTree = "<group>"; };
@@ -1003,6 +1036,7 @@
 				QLEXT00000GRP0000000 /* MacDownQuickLook */,
 				A6DB3A1620B71665F8B84FCB /* MacDownCore */,
 				3021716F41B8166076554514 /* MacDownQuickLook */,
+				41F9FE56D19253D1DEE58CCF /* Sidebar */,
 			);
 			sourceTree = "<group>";
 			usesTabs = 0;
@@ -1150,6 +1184,15 @@
 				5E44CF1BD72E49A99DA6A4C1 /* MPPaneToggleTests.m */,
 				504AC0000000000000000004 /* MPPDFAnchorInjectorTests.m */,
 				B2C3D4E5F67890ABCDEF1234 /* MPZoomTests.m */,
+				A0A5A0E543A6B3CE9E17EE7B /* MPFileNodeTests.m */,
+				A01DF3116B648FB08F2D42B0 /* MPFolderWatcherTests.m */,
+				4BDC351D0D920E583085F2C6 /* MPFolderSidebarViewControllerTests.m */,
+				16399DCF6DD45265101115E0 /* MPSidebarSyncCoordinatorTests.m */,
+				626779D9F12A022B4F57258D /* MPSidebarSplitViewTests.m */,
+				0AA947C490F49EE01830E163 /* MPDocumentWorkspaceTests.m */,
+				EC4903A09EAD86914984F6F1 /* MPDocumentTabReuseTests.m */,
+				4C695901868F7E76EAB0EBA6 /* MPMainControllerFolderTests.m */,
+				D17D80F3F55A027304992DED /* MPMainControllerMenuTests.m */,
 			);
 			path = MacDownTests;
 			sourceTree = "<group>";
@@ -1187,6 +1230,23 @@
 			);
 			name = MacDownQuickLook;
 			path = MacDownQuickLook;
+			sourceTree = "<group>";
+		};
+		41F9FE56D19253D1DEE58CCF /* Sidebar */ = {
+			isa = PBXGroup;
+			children = (
+				C13407D1311EAF420CEE31C9 /* MPFileNode.h */,
+				8FE8D35A5366F9BE39227CEC /* MPFileNode.m */,
+				DF12A026D4752AFA395CF10B /* MPFolderWatcher.h */,
+				5ED6745ED95492186AF6E844 /* MPFolderWatcher.m */,
+				0925B76B06FC62100372111F /* MPFolderSidebarViewController.h */,
+				F5475503E4264E68C149AA9E /* MPFolderSidebarViewController.m */,
+				A975F4E209243A57A0040072 /* MPSidebarSyncCoordinator.h */,
+				53056C5D1D3F14882629B27C /* MPSidebarSyncCoordinator.m */,
+				848CB0745DA0086DDD4A129A /* MPSidebarSplitView.h */,
+				9B004FFBE8014E25420887FD /* MPSidebarSplitView.m */,
+			);
+			name = Sidebar;
 			sourceTree = "<group>";
 		};
 		5A349F73880AD1B10615BFC9 /* OS X */ = {
@@ -1818,6 +1878,11 @@
 				BA2B9EC2E95175092A97B41E /* MPResourceWatcherSet.m in Sources */,
 				1F13B5E1110695033F2B57AE /* MPHTMLResourceURLs.m in Sources */,
 				504AC0000000000000000003 /* MPPDFAnchorInjector.m in Sources */,
+				632DE4286F689FB448FF9357 /* MPFileNode.m in Sources */,
+				0F6EFB9168CB2E074C8EEE64 /* MPFolderWatcher.m in Sources */,
+				C53D672DA7E35889E7361FF3 /* MPFolderSidebarViewController.m in Sources */,
+				CD03CB15DD4AE325CBF3BEF3 /* MPSidebarSyncCoordinator.m in Sources */,
+				1882ADC14E60D20538509FCA /* MPSidebarSplitView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1877,6 +1942,15 @@
 				1457815B1A710E4C40F07FCA /* MPPaneToggleTests.m in Sources */,
 				504AC0000000000000000005 /* MPPDFAnchorInjectorTests.m in Sources */,
 				A1B2C3D4E5F67890ABCDEF12 /* MPZoomTests.m in Sources */,
+				00F6EAD22CA0765C131AA4EC /* MPFileNodeTests.m in Sources */,
+				75738FA5CDF1AA53FECC5495 /* MPFolderWatcherTests.m in Sources */,
+				057EEF5152CEAB472DFF20FD /* MPFolderSidebarViewControllerTests.m in Sources */,
+				B2DAA822F8635954B416A764 /* MPSidebarSyncCoordinatorTests.m in Sources */,
+				F2D5D4C51C5B62C27B256CFE /* MPSidebarSplitViewTests.m in Sources */,
+				2BFA7B61B4FA1F0C0860037B /* MPDocumentWorkspaceTests.m in Sources */,
+				545BC1E3C5C9EC20E12575B3 /* MPDocumentTabReuseTests.m in Sources */,
+				8F6598F79605DBA110909D3E /* MPMainControllerFolderTests.m in Sources */,
+				AD8A942CA7FEA4BD27C18A0E /* MPMainControllerMenuTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacDown/Code/Application/MPMainController.h
+++ b/MacDown/Code/Application/MPMainController.h
@@ -23,4 +23,8 @@
     "Check for Updates…" main-menu item. */
 - (IBAction)checkForUpdates:(id)sender;
 
+/** Prompts for a directory and opens it as a folder workspace; target of the
+    "Open Folder…" main-menu item. */
+- (IBAction)openFolder:(id)sender;
+
 @end

--- a/MacDown/Code/Application/MPMainController.m
+++ b/MacDown/Code/Application/MPMainController.m
@@ -276,7 +276,9 @@ NS_INLINE void treat()
 
 - (BOOL)applicationShouldOpenUntitledFile:(NSApplication *)sender
 {
-    if (self.preferences.filesToOpen.count || self.preferences.pipedContentFileToOpen)
+    if (self.preferences.filesToOpen.count
+        || self.preferences.pipedContentFileToOpen
+        || self.preferences.foldersToOpen.count)
         return NO;
     return !self.preferences.supressesUntitledDocumentOnLaunch;
 }
@@ -290,6 +292,7 @@ NS_INLINE void treat()
 {
     [self openPendingPipedContent];
     [self openPendingFiles];
+    [self openPendingFolders];
     treat();
 }
 
@@ -367,6 +370,41 @@ NS_INLINE void treat()
     }
 
     self.preferences.filesToOpen = nil;
+    [self.preferences synchronize];
+}
+
+- (IBAction)openFolder:(id)sender
+{
+    NSOpenPanel *panel = [NSOpenPanel openPanel];
+    panel.canChooseFiles = NO;
+    panel.canChooseDirectories = YES;
+    panel.allowsMultipleSelection = NO;
+    if ([panel runModal] == NSModalResponseOK && panel.URL)
+        [self openWorkspaceAtURL:panel.URL];
+}
+
+- (void)openWorkspaceAtURL:(NSURL *)url
+{
+    NSDocumentController *c = [NSDocumentController sharedDocumentController];
+    NSError *error = nil;
+    MPDocument *doc =
+        (MPDocument *)[c openUntitledDocumentAndDisplay:NO error:&error];
+    if (!doc)
+        return;
+    doc.workspaceRootURL = url;          // set BEFORE the nib loads the sidebar
+    [doc makeWindowControllers];
+    [doc showWindows];
+}
+
+- (void)openPendingFolders
+{
+    for (NSString *path in self.preferences.foldersToOpen)
+    {
+        NSURL *url = [NSURL fileURLWithPath:path isDirectory:YES];
+        if ([url checkResourceIsReachableAndReturnError:NULL])
+            [self openWorkspaceAtURL:url];
+    }
+    self.preferences.foldersToOpen = nil;
     [self.preferences synchronize];
 }
 

--- a/MacDown/Code/Document/MPDocument.h
+++ b/MacDown/Code/Document/MPDocument.h
@@ -19,6 +19,18 @@
 @property (nonatomic, readwrite) NSString *markdown;
 @property (nonatomic, readonly) NSString *html;
 
+/// When non-nil, this document's window is a folder workspace and shows a
+/// folder sidebar rooted at this URL.
+///
+/// Must be set BEFORE -makeWindowControllers: the sidebar is installed while
+/// the window's nib loads, so setting this afterwards is silently ignored and
+/// the window comes up with no sidebar. Open the document with display:NO, set
+/// this, then make the window controllers.
+///
+/// Stored with symlinks resolved, so that one folder is one workspace however
+/// it was reached.
+@property (nonatomic, copy) NSURL *workspaceRootURL;
+
 /**
  * Toggle the checkbox at the specified index in the markdown source.
  * Unchecked checkboxes ([ ]) become checked ([x]), and vice versa.

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -34,6 +34,9 @@
 #import "MPResourceWatcherSet.h"
 #import "MPHTMLResourceURLs.h"
 #import "MPURLSecurityPolicy.h"
+#import "MPFolderSidebarViewController.h"
+#import "MPSidebarSplitView.h"
+#import "MPSidebarSyncCoordinator.h"
 #import <JavaScriptCore/JavaScriptCore.h>
 // Issue #504: PDF export post-processing (clickable internal anchor links).
 #import <PDFKit/PDFKit.h>
@@ -248,7 +251,8 @@ NS_INLINE NSColor *MPGetWebViewBackgroundColor(WebView *webview)
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101100
      WebEditingDelegate, WebFrameLoadDelegate, WebPolicyDelegate, WebResourceLoadDelegate, WebUIDelegate,
 #endif
-     MPAutosaving, MPRendererDataSource, MPRendererDelegate, MPResourceWatcherSetDelegate>
+     MPAutosaving, MPRendererDataSource, MPRendererDelegate, MPResourceWatcherSetDelegate,
+     MPFolderSidebarDelegate>
 
 typedef NS_ENUM(NSUInteger, MPWordCountType) {
     MPWordCountTypeWord,
@@ -372,6 +376,10 @@ typedef NS_ENUM(NSInteger, MPReferenceKind) {
 
 // Issue #110: Watch local resources for cache-busting
 @property (strong) MPResourceWatcherSet *resourceWatcherSet;
+
+// Folder-workspace sidebar support
+@property (nonatomic, strong) MPFolderSidebarViewController *sidebarController;
+@property (nonatomic, strong) MPSidebarSplitView *outerSplitView;
 
 // Completion handlers for deferred operations when preview is hidden (issue #16)
 @property (strong) NSMutableArray<void (^)(void)> *renderCompletionHandlers;
@@ -687,6 +695,7 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 - (void)windowControllerDidLoadNib:(NSWindowController *)controller
 {
     [super windowControllerDidLoadNib:controller];
+    [self installFolderSidebarForController:controller];
 
     // All files use their absolute path to keep their window states.
     NSString *autosaveName = kMPDefaultAutosaveName;
@@ -854,6 +863,280 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     return range;
 }
 
+#pragma mark - Folder sidebar
+
+// Canonicalise on the way in, so one folder is one workspace however it was
+// reached. `macdown /tmp/proj` and File > Open Folder... on the same directory
+// otherwise produce file:///tmp/proj/ and file:///private/tmp/proj/, which the
+// sync coordinator would treat as two unrelated workspaces -- silently, since
+// everything except sync canonicalises already.
+- (void)setWorkspaceRootURL:(NSURL *)workspaceRootURL
+{
+    _workspaceRootURL =
+        [workspaceRootURL.URLByResolvingSymlinksInPath copy] ?: [workspaceRootURL copy];
+}
+
+- (void)installFolderSidebarForController:(NSWindowController *)controller
+{
+    if (!self.workspaceRootURL)
+        return;
+
+    NSWindow *window = controller.window;
+    NSView *content = window.contentView;
+    MPDocumentSplitView *inner = self.splitView;
+    if (!inner || inner.superview != content)
+        return;   // unexpected hierarchy; skip rather than corrupt the window
+
+    self.sidebarController =
+        [[MPFolderSidebarViewController alloc] initWithRootURL:self.workspaceRootURL];
+    self.sidebarController.sidebarDelegate = self;
+
+    MPSidebarSplitView *outer =
+        [[MPSidebarSplitView alloc] initWithFrame:content.bounds];
+    outer.vertical = YES;
+    outer.dividerStyle = NSSplitViewDividerStyleThin;
+    outer.delegate = self.sidebarController;          // NOT MPDocument
+    // No autosaveName: width persistence + cross-tab sync is owned by
+    // MPSidebarSyncCoordinator; a shared NSSplitView autosave would fight it.
+    outer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+
+    [inner removeFromSuperview];
+
+    NSView *sidebarView = self.sidebarController.view;
+    // Start at this workspace's shared width so this tab matches its siblings.
+    CGFloat startWidth = [[MPSidebarSyncCoordinator sharedCoordinator]
+        sidebarWidthForRoot:self.workspaceRootURL];
+
+    [outer addSubview:sidebarView];                   // index 0 = leading sidebar
+    [outer addSubview:inner];                         // index 1 = editor/preview
+
+    // The sidebar is pinned to a fixed width by the delegate's
+    // -splitView:resizeSubviewsWithOldSize: (holding priorities don't pin during
+    // an autoresize — NSSplitView falls back to proportional resizing).
+    outer.frame = content.bounds;
+    [content addSubview:outer];
+    self.outerSplitView = outer;
+    [outer adjustSubviews];
+    [outer setPosition:startWidth ofDividerAtIndex:0];
+
+    // Match this workspace's visibility (a new tab opened while the sidebar was
+    // hidden in its sibling tabs should also start hidden).
+    if (![[MPSidebarSyncCoordinator sharedCoordinator]
+              sidebarVisibleForRoot:self.workspaceRootURL])
+        [self hideSidebarPane];
+
+    // Live sync across tabs. Width is reported only on a genuine divider drag
+    // (see -outerSplitDidResize:), so opening a tab or resizing the window never
+    // nudges the shared width. Observers are removed in -close (removeObserver:self).
+    [[NSNotificationCenter defaultCenter]
+        addObserver:self selector:@selector(outerSplitDidResize:)
+               name:NSSplitViewDidResizeSubviewsNotification object:outer];
+    [[NSNotificationCenter defaultCenter]
+        addObserver:self selector:@selector(sidebarSyncDidChange:)
+               name:MPSidebarSyncDidChangeNotification object:nil];
+}
+
+// Propagate a width change ONLY when it comes from the user dragging the
+// divider. The same notification also fires for programmatic -setPosition:,
+// window resizing, and tab insertion; those must not broadcast (that reset the
+// shared width every time a tab opened). MPSidebarSplitView knows when it is
+// inside a divider-drag tracking loop, which -[NSApp currentEvent] cannot
+// reliably tell apart from a layout-triggered resize.
+- (void)outerSplitDidResize:(NSNotification *)note
+{
+    if (!self.outerSplitView.isDraggingDivider)
+        return;
+    NSView *sidebarView = self.sidebarController.view;
+    if (sidebarView.superview != self.outerSplitView)
+        return;
+    CGFloat w = NSWidth(sidebarView.frame);
+    if (w > 0)
+        [[MPSidebarSyncCoordinator sharedCoordinator]
+            setSidebarWidth:w forRoot:self.workspaceRootURL source:self];
+}
+
+// Whether the sidebar is actually on screen. The pane can be absent (hidden via
+// ⌘\, which removes it so no divider is drawn) or present but collapsed to zero
+// width by a divider drag; both read as not visible.
+- (BOOL)isSidebarVisible
+{
+    NSView *sidebarView = self.sidebarController.view;
+    if (!self.outerSplitView || sidebarView.superview != self.outerSplitView)
+        return NO;
+    return ![self.outerSplitView isSubviewCollapsed:sidebarView];
+}
+
+- (void)showSidebarPane
+{
+    NSSplitView *outer = self.outerSplitView;
+    NSView *sidebarView = self.sidebarController.view;
+    if (!outer)
+        return;
+    // The coordinator is the single source of truth for this workspace's
+    // width; it is the only one that sees this tab's own divider drags, which
+    // -sidebarSyncDidChange: skips because it ignores its own broadcasts.
+    CGFloat w = [[MPSidebarSyncCoordinator sharedCoordinator]
+        sidebarWidthForRoot:self.workspaceRootURL];
+    if (sidebarView.superview == outer)
+    {
+        // Present but dragged shut: reopen it at the workspace's width. A
+        // collapsed pane is left hidden by AppKit, and it can also be re-added
+        // in that state, so clear it here rather than rely on -setPosition:.
+        if ([outer isSubviewCollapsed:sidebarView] || sidebarView.hidden)
+        {
+            sidebarView.hidden = NO;
+            [outer setPosition:w ofDividerAtIndex:0];
+        }
+        return;
+    }
+    sidebarView.hidden = NO;
+    [outer addSubview:sidebarView positioned:NSWindowBelow relativeTo:self.splitView];
+    [outer adjustSubviews];
+    [outer setPosition:w ofDividerAtIndex:0];
+}
+
+- (void)hideSidebarPane
+{
+    NSSplitView *outer = self.outerSplitView;
+    NSView *sidebarView = self.sidebarController.view;
+    if (!outer || sidebarView.superview != outer)
+        return;
+    [sidebarView removeFromSuperview];          // removing the pane draws no divider
+    [outer adjustSubviews];
+}
+
+- (IBAction)toggleFolderSidebar:(id)sender
+{
+    if (!self.sidebarController || !self.outerSplitView)
+        return;
+    BOOL shown = self.isSidebarVisible;
+    if (shown)
+        [self hideSidebarPane];
+    else
+        [self showSidebarPane];
+    // Broadcast so the other tabs of THIS workspace match.
+    [[MPSidebarSyncCoordinator sharedCoordinator]
+        setSidebarVisible:!shown forRoot:self.workspaceRootURL source:self];
+}
+
+// Another tab of the SAME workspace changed the shared width/visibility: match
+// it here. Changes from a window open on a different folder are ignored — those
+// are independent workspaces that happen to share the process.
+- (void)sidebarSyncDidChange:(NSNotification *)note
+{
+    if (note.object == self)
+        return;                                  // ignore our own change
+    NSString *kind = note.userInfo[MPSidebarSyncKindKey];
+    NSURL *root = note.userInfo[MPSidebarSyncRootKey];
+    if (![root.absoluteString isEqualToString:self.workspaceRootURL.absoluteString])
+        return;                                  // a different workspace
+
+    MPSidebarSyncCoordinator *coord = [MPSidebarSyncCoordinator sharedCoordinator];
+    if ([kind isEqualToString:MPSidebarSyncKindWidth])
+    {
+        CGFloat width = [coord sidebarWidthForRoot:self.workspaceRootURL];
+        if (self.sidebarController.view.superview == self.outerSplitView)
+            [self.outerSplitView setPosition:width ofDividerAtIndex:0];
+    }
+    else if ([kind isEqualToString:MPSidebarSyncKindVisible])
+    {
+        if ([coord sidebarVisibleForRoot:self.workspaceRootURL])
+            [self showSidebarPane];
+        else
+            [self hideSidebarPane];
+    }
+}
+
++ (MPDocument *)openDocumentForFileURL:(NSURL *)url
+{
+    NSDocument *doc =
+        [[NSDocumentController sharedDocumentController] documentForURL:url];
+    return [doc isKindOfClass:[MPDocument class]] ? (MPDocument *)doc : nil;
+}
+
+// What to show the user when opening a sidebar file produced no document.
+// Returns nil when there is nothing worth reporting. Split out from the
+// presentation so it can be tested without putting a modal alert on screen.
++ (NSError *)sidebarOpenErrorForError:(NSError *)error URL:(NSURL *)url
+{
+    // The user cancelling (e.g. at an authentication prompt) is not a failure.
+    if ([error.domain isEqualToString:NSCocoaErrorDomain]
+        && error.code == NSUserCancelledError)
+    {
+        return nil;
+    }
+    if (error)
+        return error;
+
+    // No document and no error: synthesise one rather than fail silently.
+    NSString *fmt = NSLocalizedString(@"The file “%@” could not be opened.",
+                                      @"Sidebar file open failure");
+    NSMutableDictionary *info = [NSMutableDictionary dictionary];
+    info[NSLocalizedDescriptionKey] =
+        [NSString stringWithFormat:fmt, url.lastPathComponent ?: @""];
+    if (url)
+        info[NSURLErrorKey] = url;
+    return [NSError errorWithDomain:NSCocoaErrorDomain
+                               code:NSFileReadUnknownError userInfo:info];
+}
+
+- (void)presentSidebarOpenError:(NSError *)error forURL:(NSURL *)url
+{
+    NSError *toShow = [MPDocument sidebarOpenErrorForError:error URL:url];
+    if (toShow)
+        [self presentError:toShow];
+}
+
+- (void)folderSidebar:(MPFolderSidebarViewController *)sidebar
+   didActivateFileURL:(NSURL *)url
+{
+    // 1. Already open? Just raise that tab. The highlight belongs in the tab
+    //    that displays the file, which is the one being raised — not this one,
+    //    which goes on showing whatever it had.
+    MPDocument *existing = [MPDocument openDocumentForFileURL:url];
+    if (existing)
+    {
+        [existing showWindows];
+        [existing.sidebarController selectFileURL:url];
+        return;
+    }
+
+    // 2. Open without display so we can set the workspace root before the
+    //    nib loads (so the new tab gets its own sidebar), then tab it in.
+    NSWindow *hostWindow = self.windowControllers.firstObject.window;
+    NSURL *root = self.workspaceRootURL;
+    NSDocumentController *c = [NSDocumentController sharedDocumentController];
+    [c openDocumentWithContentsOfURL:url display:NO
+                  completionHandler:^(NSDocument *opened, BOOL wasOpen, NSError *err) {
+        if (wasOpen)
+        {
+            // Its nib has already loaded, so setting workspaceRootURL now would
+            // be ignored while still overwriting the root it syncs against.
+            [opened showWindows];
+            if ([opened isKindOfClass:[MPDocument class]])
+                [((MPDocument *)opened).sidebarController selectFileURL:url];
+            return;
+        }
+        if (![opened isKindOfClass:[MPDocument class]])
+        {
+            // display:NO opts out of NSDocumentController's automatic error
+            // alert, so a file that was deleted or is unreadable would fail
+            // silently — report it ourselves.
+            [self presentSidebarOpenError:err forURL:url];
+            return;
+        }
+        MPDocument *mp = (MPDocument *)opened;
+        mp.workspaceRootURL = root;
+        if (mp.windowControllers.count == 0)
+            [mp makeWindowControllers];
+        NSWindow *newWindow = mp.windowControllers.firstObject.window;
+        if (hostWindow && newWindow && newWindow != hostWindow)
+            [hostWindow addTabbedWindow:newWindow ordered:NSWindowAbove];
+        [mp showWindows];
+        [mp.sidebarController selectFileURL:url];
+    }];
+}
+
 // Shared by three paths: the initial document open, a manual Revert, and an
 // external-change reload (silent or post-Discard). The selection/scroll
 // preservation below therefore affects all three — a change made here for one
@@ -948,6 +1231,7 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
         // Issue #290: Stop file watching to prevent leaks
         [self stopFileWatching];
+        [self.sidebarController stopWatching];
 
         // Need to cleanup these so that callbacks won't crash the app.
         [self.highlighter deactivate];
@@ -1029,9 +1313,27 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     // If URL changed (Save As), restart watching the new file
     if (result && (!previousURL || ![url isEqual:previousURL]))
     {
-        // URL was updated by super, restart watching the new file
         dispatch_async(dispatch_get_main_queue(), ^{
+            // URL was updated by super, restart watching the new file
             [self startFileWatching];
+
+            // A new path also appeared on disk. Folder sidebars watch with
+            // kFSEventStreamCreateFlagIgnoreSelf (so ordinary re-saves don't
+            // cause a reload storm), which also means they never see files WE
+            // create — tell them directly.
+            //
+            // The test is on the document's own URL, not on `url`: a safe save
+            // hands -writeToURL: a path inside an NSItemReplacementDirectory
+            // and swaps it into place afterwards, so `url` is never the file
+            // the user ends up with. By the time this block runs NSDocument has
+            // updated fileURL, so a change against previousURL means a first
+            // save or a Save As — the cases that add a path to the tree.
+            NSURL *saved = self.fileURL;
+            if (saved && ![saved isEqual:previousURL])
+            {
+                [[MPSidebarSyncCoordinator sharedCoordinator]
+                    notifyFileSavedAtURL:saved source:self];
+            }
         });
     }
 
@@ -1284,6 +1586,16 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     else if (action == @selector(selectDocumentZoom:))
     {
         return YES;
+    }
+    else if (action == @selector(toggleFolderSidebar:))
+    {
+        NSMenuItem *it = ((NSMenuItem *)item);
+        BOOL hasWorkspace = (self.workspaceRootURL != nil);
+        BOOL shown = hasWorkspace && self.isSidebarVisible;
+        it.title = shown
+            ? NSLocalizedString(@"Hide Sidebar", @"View menu item")
+            : NSLocalizedString(@"Show Sidebar", @"View menu item");
+        return hasWorkspace;
     }
     return result;
 }

--- a/MacDown/Code/Preferences/MPPreferences.h
+++ b/MacDown/Code/Preferences/MPPreferences.h
@@ -87,6 +87,7 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 
 // Convinience methods.
 @property (nonatomic, assign) NSArray *filesToOpen;
+@property (nonatomic, assign) NSArray *foldersToOpen;
 @property (nonatomic, assign) NSString *pipedContentFileToOpen;
 
 @end

--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -333,6 +333,18 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
                     inSuiteNamed:kMPApplicationSuiteName];
 }
 
+- (NSArray *)foldersToOpen
+{
+    return [self.userDefaults objectForKey:kMPFoldersToOpenKey
+                              inSuiteNamed:kMPApplicationSuiteName];
+}
+
+- (void)setFoldersToOpen:(NSArray *)foldersToOpen
+{
+    [self.userDefaults setObject:foldersToOpen forKey:kMPFoldersToOpenKey
+                    inSuiteNamed:kMPApplicationSuiteName];
+}
+
 - (NSString *)pipedContentFileToOpen {
     return [self.userDefaults objectForKey:kMPPipedContentFileToOpen
                               inSuiteNamed:kMPApplicationSuiteName];

--- a/MacDown/Code/Sidebar/MPFileNode.h
+++ b/MacDown/Code/Sidebar/MPFileNode.h
@@ -1,0 +1,36 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MPFileNode : NSObject
+
+@property (nonatomic, readonly, copy) NSURL *URL;
+@property (nonatomic, readonly) BOOL isDirectory;
+@property (nonatomic, readonly, copy) NSString *name;
+
+/// The URL to actually open, with symlinks resolved. Same as URL for anything
+/// that isn't a link. Opening a link's own URL fails — NSDocumentController
+/// type-detects it as public.symlink rather than Markdown.
+@property (nonatomic, readonly, copy) NSURL *resolvedURL;
+
+- (instancetype)initWithURL:(NSURL *)url isDirectory:(BOOL)isDirectory;
+
+/// Lazily computed and cached. Directories return non-hidden subdirectories
+/// plus Markdown files, folders first then case-insensitive by name.
+/// Files and empty directories return @[].
+///
+/// Symlinks are followed, so a symlinked folder is browsable, except that a
+/// link resolving to somewhere already on the path from the root is dropped
+/// (otherwise the tree would never bottom out). Broken links are skipped.
+- (NSArray<MPFileNode *> *)children;
+
+/// Drop the cached children of this node and (recursively) of any already-built
+/// child nodes, so the next -children call re-reads the disk.
+- (void)invalidateChildrenRecursively;
+
+/// YES when url's extension is md/markdown (case-insensitive).
++ (BOOL)isMarkdownFileURL:(NSURL *)url;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MacDown/Code/Sidebar/MPFileNode.m
+++ b/MacDown/Code/Sidebar/MPFileNode.m
@@ -1,0 +1,196 @@
+#import "MPFileNode.h"
+#import <stdlib.h>
+#import <limits.h>
+
+// Mirrors MacDown-Info.plist CFBundleDocumentTypes → CFBundleTypeExtensions.
+static NSArray<NSString *> *MPMarkdownExtensions(void)
+{
+    static NSArray<NSString *> *exts;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ exts = @[@"md", @"markdown"]; });
+    return exts;
+}
+
+// Physical on-disk path, used to detect symlink cycles. realpath(3) is used
+// rather than -URLByResolvingSymlinksInPath because cycle detection needs the
+// physical location: two paths are the same node only when they resolve to the
+// same real path. Returns nil for a path that does not resolve, i.e. a broken
+// symlink.
+static NSString *MPRealPath(NSURL *url)
+{
+    char buf[PATH_MAX];
+    const char *p = url.path.fileSystemRepresentation;
+    if (p && realpath(p, buf))
+        return @(buf);
+    return nil;
+}
+
+@interface MPFileNode ()
+@property (nonatomic, copy) NSURL *URL;
+@property (nonatomic, assign) BOOL isDirectory;
+@property (nonatomic, strong, nullable) NSArray<MPFileNode *> *cachedChildren;
+/// This node's fully resolved path.
+@property (nonatomic, copy) NSString *realPath;
+/// Resolved paths of this node and every ancestor, i.e. the whole chain from
+/// the root. A directory child whose resolved path is already in here would
+/// re-enter the tree, so it is dropped — without this a symlink pointing at its
+/// own ancestor makes an infinitely deep, infinitely expandable sidebar.
+@property (nonatomic, copy) NSSet<NSString *> *ancestorRealPaths;
+@end
+
+@implementation MPFileNode
+
+- (instancetype)initWithURL:(NSURL *)url isDirectory:(BOOL)isDirectory
+{
+    return [self initWithURL:url isDirectory:isDirectory
+                    realPath:nil ancestorRealPaths:nil];
+}
+
+- (instancetype)initWithURL:(NSURL *)url
+                isDirectory:(BOOL)isDirectory
+                   realPath:(NSString *)realPath
+          ancestorRealPaths:(NSSet<NSString *> *)ancestors
+{
+    self = [super init];
+    if (self)
+    {
+        _URL = [url copy];
+        _isDirectory = isDirectory;
+        // Only directories descend, so only they need a resolved path and an
+        // ancestor chain; resolving every file would be a syscall per entry for
+        // values nothing reads.
+        if (isDirectory)
+        {
+            _realPath = [(realPath ?: MPRealPath(url)
+                                   ?: url.path.stringByStandardizingPath
+                                   ?: @"") copy];
+            _ancestorRealPaths = ancestors ?: [NSSet setWithObject:_realPath];
+        }
+        else
+        {
+            // Only a symlinked file carries one — a regular file's own URL is
+            // already the one to open, and resolving every file would be a
+            // syscall per entry for a value nothing reads.
+            _realPath = [realPath copy];
+        }
+    }
+    return self;
+}
+
+- (NSString *)name
+{
+    return self.URL.lastPathComponent;
+}
+
+- (NSURL *)resolvedURL
+{
+    if (!self.realPath.length)
+        return self.URL;
+    return [NSURL fileURLWithPath:self.realPath isDirectory:self.isDirectory];
+}
+
++ (BOOL)isMarkdownFileURL:(NSURL *)url
+{
+    NSString *ext = url.pathExtension.lowercaseString;
+    return ext.length > 0 && [MPMarkdownExtensions() containsObject:ext];
+}
+
+- (NSArray<MPFileNode *> *)children
+{
+    if (self.cachedChildren)
+        return self.cachedChildren;
+
+    if (!self.isDirectory)
+    {
+        self.cachedChildren = @[];
+        return self.cachedChildren;
+    }
+
+    NSFileManager *fm = [NSFileManager defaultManager];
+    // Enumerate the RESOLVED path, not self.URL: -contentsOfDirectoryAtURL:
+    // refuses to enumerate through a symlink ("couldn't be opened"), so a
+    // symlinked folder would always look empty. Children therefore carry
+    // canonical URLs, which also keeps tab reuse from treating the same file
+    // reached by two paths as two documents. The node's display name still
+    // comes from self.URL, so the sidebar shows the link's name.
+    NSURL *dir = [NSURL fileURLWithPath:self.realPath isDirectory:YES];
+    NSArray<NSURL *> *contents =
+        [fm contentsOfDirectoryAtURL:dir
+          includingPropertiesForKeys:@[NSURLIsDirectoryKey,
+                                       NSURLIsSymbolicLinkKey]
+                             options:NSDirectoryEnumerationSkipsHiddenFiles
+                               error:NULL];
+
+    NSMutableArray<MPFileNode *> *nodes = [NSMutableArray array];
+    for (NSURL *url in contents)
+    {
+        NSNumber *isDirNum = nil, *isLinkNum = nil;
+        [url getResourceValue:&isDirNum forKey:NSURLIsDirectoryKey error:NULL];
+        [url getResourceValue:&isLinkNum
+                       forKey:NSURLIsSymbolicLinkKey error:NULL];
+        BOOL isLink = isLinkNum.boolValue;
+
+        // NSURLIsDirectoryKey does NOT follow symlinks — it reports NO for a
+        // link pointing at a folder. Resolve links ourselves so a symlinked
+        // folder is browsable instead of silently missing from the tree.
+        NSString *childReal;
+        BOOL isDir;
+        if (isLink)
+        {
+            childReal = MPRealPath(url);
+            if (!childReal)
+                continue;                  // broken link: nothing to show
+            BOOL resolvedIsDir = NO;
+            [fm fileExistsAtPath:childReal isDirectory:&resolvedIsDir];
+            isDir = resolvedIsDir;
+        }
+        else
+        {
+            // A real subdirectory can't re-enter the tree, so skip realpath():
+            // its resolved path is just ours plus its name.
+            childReal = [self.realPath
+                stringByAppendingPathComponent:url.lastPathComponent];
+            isDir = isDirNum.boolValue;
+        }
+
+        if (isDir)
+        {
+            if ([self.ancestorRealPaths containsObject:childReal])
+                continue;                  // symlink cycle; would never bottom out
+
+            [nodes addObject:
+                [[MPFileNode alloc]
+                    initWithURL:url isDirectory:YES
+                       realPath:childReal
+              ancestorRealPaths:[self.ancestorRealPaths
+                                    setByAddingObject:childReal]]];
+        }
+        else if ([MPFileNode isMarkdownFileURL:url])
+        {
+            // A link keeps the link's URL for display but remembers its target,
+            // which is what -resolvedURL hands to NSDocumentController.
+            [nodes addObject:
+                [[MPFileNode alloc] initWithURL:url isDirectory:NO
+                                       realPath:(isLink ? childReal : nil)
+                              ancestorRealPaths:nil]];
+        }
+    }
+
+    [nodes sortUsingComparator:^NSComparisonResult(MPFileNode *a, MPFileNode *b) {
+        if (a.isDirectory != b.isDirectory)
+            return a.isDirectory ? NSOrderedAscending : NSOrderedDescending;
+        return [a.name caseInsensitiveCompare:b.name];
+    }];
+
+    self.cachedChildren = [nodes copy];
+    return self.cachedChildren;
+}
+
+- (void)invalidateChildrenRecursively
+{
+    for (MPFileNode *child in self.cachedChildren)
+        [child invalidateChildrenRecursively];
+    self.cachedChildren = nil;
+}
+
+@end

--- a/MacDown/Code/Sidebar/MPFolderSidebarViewController.h
+++ b/MacDown/Code/Sidebar/MPFolderSidebarViewController.h
@@ -1,0 +1,47 @@
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class MPFolderSidebarViewController;
+
+@protocol MPFolderSidebarDelegate <NSObject>
+- (void)folderSidebar:(MPFolderSidebarViewController *)sidebar
+   didActivateFileURL:(NSURL *)url;
+@end
+
+/// The sidebar's outline view. Handles Return itself rather than leaving it to
+/// the responder chain: whether NSOutlineView forwards an unhandled Return to
+/// its next responder depends on how the table is configured, so relying on
+/// that would make Return silently stop working after an unrelated change.
+@interface MPSidebarOutlineView : NSOutlineView
+
+@property (nonatomic, weak) MPFolderSidebarViewController *sidebar;
+
+@end
+
+@interface MPFolderSidebarViewController : NSViewController <NSSplitViewDelegate>
+
+@property (nonatomic, weak) id<MPFolderSidebarDelegate> sidebarDelegate;
+@property (nonatomic, readonly, copy) NSURL *rootURL;
+
+- (instancetype)initWithRootURL:(NSURL *)rootURL;
+
+/// Rebuild the tree from disk, preserving expansion + selection where possible.
+- (void)reload;
+
+/// Select/scroll to the row for url, if it is currently visible in the tree.
+- (void)selectFileURL:(NSURL *)url;
+
+/// Open the selected row, if it is a Markdown file. Returns whether it did.
+- (BOOL)activateSelectedRow;
+
+/// Stop the folder watcher immediately (e.g. when the owning document closes).
+- (void)stopWatching;
+
+/// YES when url is at or below this sidebar's root (symlinks resolved on both
+/// sides, so /tmp and /private/tmp compare equal).
+- (BOOL)containsURL:(NSURL *)url;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MacDown/Code/Sidebar/MPFolderSidebarViewController.m
+++ b/MacDown/Code/Sidebar/MPFolderSidebarViewController.m
@@ -1,0 +1,514 @@
+#import "MPFolderSidebarViewController.h"
+#import "MPFileNode.h"
+#import "MPFolderWatcher.h"
+#import "MPSidebarSplitView.h"
+#import "MPSidebarSyncCoordinator.h"
+
+@interface MPFolderSidebarViewController ()
+    <NSOutlineViewDataSource, NSOutlineViewDelegate>
+@property (nonatomic, copy) NSURL *rootURL;
+@property (nonatomic, strong) MPFileNode *rootNode;
+@property (nonatomic, strong) NSOutlineView *outlineView;
+@property (nonatomic, strong) NSScrollView *scrollView;
+@property (nonatomic, strong) MPFolderWatcher *watcher;
+@property (nonatomic, assign) BOOL applyingSharedExpansion;  // suppress re-broadcast
+@end
+
+@implementation MPSidebarOutlineView
+
+- (void)keyDown:(NSEvent *)event
+{
+    unichar c = event.charactersIgnoringModifiers.length
+        ? [event.charactersIgnoringModifiers characterAtIndex:0] : 0;
+    if ((c == NSCarriageReturnCharacter || c == NSEnterCharacter)
+        && [self.sidebar activateSelectedRow])
+    {
+        return;
+    }
+    [super keyDown:event];
+}
+
+@end
+
+
+@implementation MPFolderSidebarViewController
+
+- (instancetype)initWithRootURL:(NSURL *)rootURL
+{
+    self = [super initWithNibName:nil bundle:nil];
+    if (self)
+    {
+        _rootURL = [rootURL copy];
+        _rootNode = [[MPFileNode alloc] initWithURL:rootURL isDirectory:YES];
+    }
+    return self;
+}
+
+- (void)loadView
+{
+    NSScrollView *scroll =
+        [[NSScrollView alloc] initWithFrame:NSMakeRect(0, 0, 220, 400)];
+    scroll.hasVerticalScroller = YES;
+    scroll.autohidesScrollers = YES;
+    scroll.drawsBackground = NO;
+
+    MPSidebarOutlineView *outline =
+        [[MPSidebarOutlineView alloc] initWithFrame:scroll.bounds];
+    outline.sidebar = self;
+    NSTableColumn *col =
+        [[NSTableColumn alloc] initWithIdentifier:@"name"];
+    col.resizingMask = NSTableColumnAutoresizingMask | NSTableColumnUserResizingMask;
+    col.minWidth = 60;
+    [outline addTableColumn:col];
+    outline.outlineTableColumn = col;
+    // The single column must fill the panel width and grow when the sidebar is
+    // widened; otherwise it stays at the default ~100pt and truncates names.
+    outline.columnAutoresizingStyle = NSTableViewUniformColumnAutoresizingStyle;
+    outline.headerView = nil;
+    outline.rowSizeStyle = NSTableViewRowSizeStyleDefault;
+    outline.floatsGroupRows = NO;
+    if (@available(macOS 11.0, *))
+        outline.style = NSTableViewStyleSourceList;
+    outline.dataSource = self;
+    outline.delegate = self;
+    outline.target = self;
+    outline.doubleAction = @selector(handleDoubleClick:);
+
+    NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
+    NSMenuItem *reveal = [menu addItemWithTitle:NSLocalizedString(@"Reveal in Finder", @"Sidebar context menu")
+                                         action:@selector(revealInFinder:) keyEquivalent:@""];
+    NSMenuItem *copy = [menu addItemWithTitle:NSLocalizedString(@"Copy Path", @"Sidebar context menu")
+                                       action:@selector(copyPath:) keyEquivalent:@""];
+    reveal.target = self;
+    copy.target = self;
+    outline.menu = menu;
+
+    scroll.documentView = outline;
+    [outline sizeLastColumnToFit];
+    self.outlineView = outline;
+    self.scrollView = scroll;
+    self.view = scroll;
+
+    [self startWatching];
+
+    [[NSNotificationCenter defaultCenter]
+        addObserver:self selector:@selector(sidebarSyncDidChange:)
+               name:MPSidebarSyncDidChangeNotification object:nil];
+}
+
+- (void)viewDidAppear
+{
+    [super viewDidAppear];
+    // Match the folders other tabs of this workspace have expanded.
+    [self applyExpandedPaths:
+        [[MPSidebarSyncCoordinator sharedCoordinator] expandedPathsForRoot:self.rootURL]];
+}
+
+#pragma mark - Expansion sync across tabs
+
+- (NSArray<NSString *> *)currentExpandedPaths
+{
+    NSMutableArray<NSString *> *paths = [NSMutableArray array];
+    for (NSInteger row = 0; row < self.outlineView.numberOfRows; row++)
+    {
+        MPFileNode *node = [self.outlineView itemAtRow:row];
+        if (node.isDirectory && [self.outlineView isItemExpanded:node])
+            [paths addObject:node.URL.path];
+    }
+    return paths;
+}
+
+- (void)reportExpansion
+{
+    if (self.applyingSharedExpansion)
+        return;                                  // don't echo a change we're applying
+    [[MPSidebarSyncCoordinator sharedCoordinator]
+        setExpandedPaths:[self currentExpandedPaths] forRoot:self.rootURL source:self];
+}
+
+- (void)applyExpandedPaths:(NSArray<NSString *> *)paths
+{
+    if (!self.outlineView)
+        return;
+    self.applyingSharedExpansion = YES;
+    [self applyExpansionUnderItem:nil wanted:[NSSet setWithArray:paths]];
+    self.applyingSharedExpansion = NO;
+}
+
+- (void)applyExpansionUnderItem:(MPFileNode *)item wanted:(NSSet<NSString *> *)wanted
+{
+    NSInteger count = [self outlineView:self.outlineView numberOfChildrenOfItem:item];
+    for (NSInteger i = 0; i < count; i++)
+    {
+        MPFileNode *child = [self outlineView:self.outlineView child:i ofItem:item];
+        if (!child.isDirectory)
+            continue;
+        BOOL want = [wanted containsObject:child.URL.path];
+        if (want && ![self.outlineView isItemExpanded:child])
+            [self.outlineView expandItem:child];
+        else if (!want && [self.outlineView isItemExpanded:child])
+            [self.outlineView collapseItem:child];
+        if (want)
+            [self applyExpansionUnderItem:child wanted:wanted];
+    }
+}
+
+- (void)outlineViewItemDidExpand:(NSNotification *)notification
+{
+    [self reportExpansion];
+}
+
+- (void)outlineViewItemDidCollapse:(NSNotification *)notification
+{
+    [self reportExpansion];
+}
+
+- (void)sidebarSyncDidChange:(NSNotification *)note
+{
+    if (note.object == self)
+        return;
+    NSString *kind = note.userInfo[MPSidebarSyncKindKey];
+
+    if ([kind isEqualToString:MPSidebarSyncKindExpansion])
+    {
+        NSURL *root = note.userInfo[MPSidebarSyncRootKey];
+        if (![root.absoluteString isEqualToString:self.rootURL.absoluteString])
+            return;                              // a different workspace
+        [self applyExpandedPaths:
+            [[MPSidebarSyncCoordinator sharedCoordinator]
+                expandedPathsForRoot:self.rootURL]];
+    }
+    else if ([kind isEqualToString:MPSidebarSyncKindTreeChanged])
+    {
+        // MacDown wrote a file somewhere; kFSEventStreamCreateFlagIgnoreSelf
+        // means our watcher won't report it, so refresh if it landed in here.
+        NSURL *url = note.userInfo[MPSidebarSyncURLKey];
+        if ([self containsURL:url])
+            [self reload];
+    }
+}
+
+// YES when `url` is at or below this sidebar's root. Both sides are resolved so
+// that /tmp vs /private/tmp (and other symlinked prefixes) compare equal.
+- (BOOL)containsURL:(NSURL *)url
+{
+    if (!url.isFileURL || !self.rootURL)
+        return NO;
+    NSString *root = self.rootURL.URLByResolvingSymlinksInPath.path;
+    NSString *path = url.URLByResolvingSymlinksInPath.path;
+    if (!root.length || !path.length)
+        return NO;
+    if ([path isEqualToString:root])
+        return YES;
+    NSString *prefix = [root hasSuffix:@"/"] ? root
+                                             : [root stringByAppendingString:@"/"];
+    return [path hasPrefix:prefix];
+}
+
+- (void)startWatching
+{
+    __weak typeof(self) weakSelf = self;
+    self.watcher = [[MPFolderWatcher alloc] initWithRootURL:self.rootURL
+                                                    handler:^{
+        [weakSelf reload];
+    }];
+}
+
+// Called when the owning document closes. Drops the sync observation too:
+// otherwise a closed document's sidebar keeps reloading on every tree change
+// until the document is finally released.
+- (void)stopWatching
+{
+    [self.watcher stop];
+    [[NSNotificationCenter defaultCenter]
+        removeObserver:self name:MPSidebarSyncDidChangeNotification object:nil];
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [_watcher stop];
+}
+
+#pragma mark - Reload / selection
+
+- (void)reload
+{
+    if (!self.outlineView)
+        return;
+    // Preserve the set of expanded directory URLs and the selected URL.
+    NSMutableSet<NSURL *> *expanded = [NSMutableSet set];
+    for (NSInteger row = 0; row < self.outlineView.numberOfRows; row++)
+    {
+        MPFileNode *node = [self.outlineView itemAtRow:row];
+        if ([self.outlineView isItemExpanded:node])
+            [expanded addObject:node.URL];
+    }
+    MPFileNode *selected = [self.outlineView itemAtRow:self.outlineView.selectedRow];
+    NSURL *selectedURL = selected.URL;
+
+    [self.rootNode invalidateChildrenRecursively];
+    [self.outlineView reloadData];
+
+    // Restoring expansion fires didExpand notifications; don't echo them back
+    // to the sync coordinator (the set is unchanged).
+    self.applyingSharedExpansion = YES;
+    [self expandNodesMatchingURLs:expanded underItem:nil];
+    self.applyingSharedExpansion = NO;
+    if (selectedURL)
+        [self selectFileURL:selectedURL];
+}
+
+- (void)expandNodesMatchingURLs:(NSSet<NSURL *> *)urls underItem:(MPFileNode *)item
+{
+    NSInteger count = [self outlineView:self.outlineView numberOfChildrenOfItem:item];
+    for (NSInteger i = 0; i < count; i++)
+    {
+        MPFileNode *child = [self outlineView:self.outlineView child:i ofItem:item];
+        if (child.isDirectory && [urls containsObject:child.URL])
+        {
+            [self.outlineView expandItem:child];
+            [self expandNodesMatchingURLs:urls underItem:child];
+        }
+    }
+}
+
+- (void)selectFileURL:(NSURL *)url
+{
+    // The row for `url` itself always wins. Only if there is none does a link
+    // pointing at it count, because activation reports a link's target rather
+    // than the link: without the two passes, a tree holding both real.md and
+    // alias.md -> real.md would select whichever sorts first.
+    NSInteger row = [self rowForURL:url resolvingLinks:NO];
+    if (row < 0)
+        row = [self rowForURL:url resolvingLinks:YES];
+    if (row < 0)
+        return;
+
+    [self.outlineView selectRowIndexes:[NSIndexSet indexSetWithIndex:row]
+                  byExtendingSelection:NO];
+    [self.outlineView scrollRowToVisible:row];
+}
+
+- (NSInteger)rowForURL:(NSURL *)url resolvingLinks:(BOOL)resolvingLinks
+{
+    for (NSInteger row = 0; row < self.outlineView.numberOfRows; row++)
+    {
+        MPFileNode *node = [self.outlineView itemAtRow:row];
+        // A symlinked folder resolves equal to the real folder's own row, so
+        // only files are matched by target.
+        BOOL match = resolvingLinks
+            ? (!node.isDirectory && [node.resolvedURL isEqual:url])
+            : [node.URL isEqual:url];
+        if (match)
+            return row;
+    }
+    return -1;
+}
+
+#pragma mark - Activation
+
+- (void)handleDoubleClick:(id)sender
+{
+    NSInteger row = self.outlineView.clickedRow;
+    if (row < 0)
+        return;
+    MPFileNode *node = [self.outlineView itemAtRow:row];
+    if (node.isDirectory)
+    {
+        if ([self.outlineView isItemExpanded:node])
+            [self.outlineView collapseItem:node];
+        else
+            [self.outlineView expandItem:node];
+        return;
+    }
+    if ([MPFileNode isMarkdownFileURL:node.URL])
+        [self.sidebarDelegate folderSidebar:self
+                         didActivateFileURL:node.resolvedURL];
+}
+
+- (BOOL)activateSelectedRow
+{
+    NSInteger row = self.outlineView.selectedRow;
+    if (row < 0)
+        return NO;
+    MPFileNode *node = [self.outlineView itemAtRow:row];
+    if (!node || ![MPFileNode isMarkdownFileURL:node.URL])
+        return NO;
+    [self.sidebarDelegate folderSidebar:self
+                     didActivateFileURL:node.resolvedURL];
+    return YES;
+}
+
+#pragma mark - NSOutlineViewDataSource
+
+- (NSInteger)outlineView:(NSOutlineView *)outlineView
+  numberOfChildrenOfItem:(id)item
+{
+    MPFileNode *node = item ?: self.rootNode;
+    return node.children.count;
+}
+
+- (id)outlineView:(NSOutlineView *)outlineView child:(NSInteger)index ofItem:(id)item
+{
+    MPFileNode *node = item ?: self.rootNode;
+    return node.children[index];
+}
+
+- (BOOL)outlineView:(NSOutlineView *)outlineView isItemExpandable:(id)item
+{
+    return [(MPFileNode *)item isDirectory];
+}
+
+- (id)outlineView:(NSOutlineView *)outlineView
+    objectValueForTableColumn:(NSTableColumn *)tableColumn byItem:(id)item
+{
+    return [(MPFileNode *)item name];
+}
+
+#pragma mark - NSOutlineViewDelegate
+
+- (NSView *)outlineView:(NSOutlineView *)outlineView
+     viewForTableColumn:(NSTableColumn *)tableColumn item:(id)item
+{
+    MPFileNode *node = item;
+    NSTableCellView *cell = [outlineView makeViewWithIdentifier:@"cell" owner:self];
+    if (!cell)
+    {
+        cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
+        cell.identifier = @"cell";
+        NSTextField *label = [NSTextField labelWithString:@""];
+        label.translatesAutoresizingMaskIntoConstraints = NO;
+        label.lineBreakMode = NSLineBreakByTruncatingTail;
+        [label setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow
+                                        forOrientation:NSLayoutConstraintOrientationHorizontal];
+        NSImageView *icon = [[NSImageView alloc] initWithFrame:NSZeroRect];
+        icon.translatesAutoresizingMaskIntoConstraints = NO;
+        [cell addSubview:icon];
+        [cell addSubview:label];
+        cell.imageView = icon;
+        cell.textField = label;
+        [NSLayoutConstraint activateConstraints:@[
+            [icon.leadingAnchor constraintEqualToAnchor:cell.leadingAnchor constant:2],
+            [icon.centerYAnchor constraintEqualToAnchor:cell.centerYAnchor],
+            [icon.widthAnchor constraintEqualToConstant:16],
+            [icon.heightAnchor constraintEqualToConstant:16],
+            [label.leadingAnchor constraintEqualToAnchor:icon.trailingAnchor constant:4],
+            [label.trailingAnchor constraintEqualToAnchor:cell.trailingAnchor constant:-2],
+            [label.centerYAnchor constraintEqualToAnchor:cell.centerYAnchor],
+        ]];
+    }
+    cell.textField.stringValue = node.name;
+    cell.imageView.image = node.isDirectory
+        ? [NSImage imageNamed:NSImageNameFolder]
+        : [[NSWorkspace sharedWorkspace] iconForFileType:node.URL.pathExtension];
+    return cell;
+}
+
+#pragma mark - NSSplitViewDelegate (for the outer, sidebar-hosting split view)
+
+- (CGFloat)splitView:(NSSplitView *)splitView
+    constrainMinCoordinate:(CGFloat)proposedMin ofSubviewAt:(NSInteger)dividerIndex
+{
+    return dividerIndex == 0 ? 150.0 : proposedMin;   // min sidebar width
+}
+
+- (CGFloat)splitView:(NSSplitView *)splitView
+    constrainMaxCoordinate:(CGFloat)proposedMax ofSubviewAt:(NSInteger)dividerIndex
+{
+    return dividerIndex == 0 ? 420.0 : proposedMax;   // max sidebar width
+}
+
+- (BOOL)splitView:(NSSplitView *)splitView canCollapseSubview:(NSView *)subview
+{
+    return subview == self.view;                      // only the sidebar collapses
+}
+
+// Hold the sidebar at the workspace's width and give all window-resize delta to
+// the editor pane. NSSplitView's holding priorities do NOT do this during an
+// autoresize (it falls back to proportional resizing), which made a new tab's
+// sidebar stretch when its window grew to join the tab group.
+//
+// The width to hold is the workspace's, not whatever the pane currently
+// measures. Reading the live frame makes the width monotonically non-increasing:
+// the window's minimum size is far below the sidebar's, so squeezing the window
+// would shrink the sidebar and growing it back would never restore it.
+- (CGFloat)desiredSidebarWidthForSplitView:(NSSplitView *)splitView
+{
+    // During a divider drag NSSplitView has already written the user's new
+    // width into the frame, and that is the value to keep.
+    if ([splitView isKindOfClass:[MPSidebarSplitView class]]
+        && [(MPSidebarSplitView *)splitView isDraggingDivider])
+    {
+        return NSWidth(splitView.subviews.firstObject.frame);
+    }
+    return [[MPSidebarSyncCoordinator sharedCoordinator]
+        sidebarWidthForRoot:self.rootURL];
+}
+
+- (void)splitView:(NSSplitView *)splitView
+    resizeSubviewsWithOldSize:(NSSize)oldSize
+{
+    if (splitView.subviews.count != 2)
+    {
+        [splitView adjustSubviews];
+        return;
+    }
+    NSView *sidebar = splitView.subviews[0];
+    NSView *main = splitView.subviews[1];
+    CGFloat thickness = splitView.dividerThickness;
+    NSSize newSize = splitView.frame.size;
+
+    // A collapsed pane keeps its old frame width, so measuring it would lay the
+    // editor out beyond a blank strip the width of the hidden sidebar.
+    if ([splitView isSubviewCollapsed:sidebar])
+    {
+        main.frame = NSMakeRect(thickness, 0,
+                                MAX(0, newSize.width - thickness), newSize.height);
+        return;
+    }
+
+    // Squeeze only as far as the window forces; the editor pane must never be
+    // given a negative width (AppKit then overrides both frames and logs about
+    // inconsistent arranged-view frames).
+    CGFloat sidebarWidth = MIN([self desiredSidebarWidthForSplitView:splitView],
+                               MAX(0, newSize.width - thickness));
+    sidebar.frame = NSMakeRect(0, 0, sidebarWidth, newSize.height);
+    CGFloat mainX = sidebarWidth + thickness;
+    main.frame = NSMakeRect(mainX, 0, MAX(0, newSize.width - mainX), newSize.height);
+}
+
+#pragma mark - Context menu
+
+- (MPFileNode *)contextTargetNode
+{
+    NSInteger row = self.outlineView.clickedRow;
+    if (row < 0)
+        row = self.outlineView.selectedRow;
+    if (row < 0)
+        return nil;
+    return [self.outlineView itemAtRow:row];
+}
+
+- (IBAction)revealInFinder:(id)sender
+{
+    MPFileNode *node = [self contextTargetNode];
+    if (node)
+        [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:@[node.URL]];
+}
+
+- (IBAction)copyPath:(id)sender
+{
+    MPFileNode *node = [self contextTargetNode];
+    if (node)
+        [self copyPath:node.URL.path toPasteboard:[NSPasteboard generalPasteboard]];
+}
+
+// Factored for testability.
+- (void)copyPath:(NSString *)path toPasteboard:(NSPasteboard *)pasteboard
+{
+    [pasteboard clearContents];
+    [pasteboard setString:path forType:NSPasteboardTypeString];
+}
+
+@end

--- a/MacDown/Code/Sidebar/MPFolderWatcher.h
+++ b/MacDown/Code/Sidebar/MPFolderWatcher.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MPFolderWatcher : NSObject
+
+/// Watches rootURL and its entire subtree. handler runs on the main queue,
+/// coalesced, whenever anything beneath rootURL changes. Does nothing (and
+/// isWatching stays NO) when the path is not a watchable local volume.
+- (instancetype)initWithRootURL:(NSURL *)rootURL handler:(void (^)(void))handler;
+
+- (void)stop;
+
+@property (nonatomic, readonly, getter=isWatching) BOOL watching;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MacDown/Code/Sidebar/MPFolderWatcher.m
+++ b/MacDown/Code/Sidebar/MPFolderWatcher.m
@@ -1,0 +1,110 @@
+#import "MPFolderWatcher.h"
+#import "MPFileWatcher.h"
+#import <CoreServices/CoreServices.h>
+
+// Owns the callback block on behalf of the FSEvents stream.
+//
+// The stream retains THIS object (via the context retain/release callbacks)
+// rather than the watcher itself, for two reasons: a callback already in flight
+// can never dereference a freed pointer, and there is no retain cycle keeping
+// the watcher alive (which is what would happen if the context retained the
+// watcher, since the watcher owns the stream).
+//
+// -handler is atomic so that clearing it in -stop is safe with respect to a
+// callback reading it.
+@interface MPFolderWatcherTarget : NSObject
+@property (atomic, copy) void (^handler)(void);
+@end
+
+@implementation MPFolderWatcherTarget
+@end
+
+
+@interface MPFolderWatcher ()
+@property (nonatomic, strong) MPFolderWatcherTarget *target;
+@property (nonatomic, assign) FSEventStreamRef stream;
+@end
+
+static void MPFolderWatcherCallback(
+    ConstFSEventStreamRef streamRef, void *clientCallBackInfo,
+    size_t numEvents, void *eventPaths,
+    const FSEventStreamEventFlags eventFlags[],
+    const FSEventStreamEventId eventIds[])
+{
+    MPFolderWatcherTarget *target =
+        (__bridge MPFolderWatcherTarget *)clientCallBackInfo;
+    void (^handler)(void) = target.handler;
+    if (handler)
+        handler();                  // already on the main queue; see -startWatchingPath:
+}
+
+@implementation MPFolderWatcher
+
+- (instancetype)initWithRootURL:(NSURL *)rootURL handler:(void (^)(void))handler
+{
+    self = [super init];
+    if (self)
+    {
+        _target = [[MPFolderWatcherTarget alloc] init];
+        _target.handler = handler;
+        if ([MPFileWatcher canWatchPath:rootURL.path])
+            [self startWatchingPath:rootURL.path];
+    }
+    return self;
+}
+
+- (void)startWatchingPath:(NSString *)path
+{
+    FSEventStreamContext context = {
+        0, (__bridge void *)self.target,
+        (CFAllocatorRetainCallBack)CFRetain,
+        (CFAllocatorReleaseCallBack)CFRelease,
+        NULL
+    };
+    NSArray<NSString *> *paths = @[path];
+    self.stream = FSEventStreamCreate(
+        kCFAllocatorDefault, &MPFolderWatcherCallback, &context,
+        (__bridge CFArrayRef)paths, kFSEventStreamEventIdSinceNow,
+        0.3 /* latency: coalesce bursts */,
+        kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer
+        // Our own writes (autosave, Save As) must not re-trigger a full
+        // synchronous sidebar reload on every keystroke-driven save. Files that
+        // MacDown itself creates in the folder are picked up by an explicit
+        // refresh after a save instead — see MPDocument.
+        | kFSEventStreamCreateFlagIgnoreSelf);
+    if (!self.stream)
+        return;
+    // Main queue, matching MPFileWatcher: callbacks are then serialized with
+    // -stop/-dealloc and with the sidebar reload they drive, so there is no
+    // window in which the stream fires against a torn-down watcher.
+    FSEventStreamSetDispatchQueue(self.stream, dispatch_get_main_queue());
+    if (!FSEventStreamStart(self.stream))
+    {
+        FSEventStreamInvalidate(self.stream);
+        FSEventStreamRelease(self.stream);
+        self.stream = NULL;
+    }
+}
+
+- (BOOL)isWatching
+{
+    return self.stream != NULL;
+}
+
+- (void)stop
+{
+    self.target.handler = nil;      // any in-flight callback becomes a no-op
+    if (!self.stream)
+        return;
+    FSEventStreamStop(self.stream);
+    FSEventStreamInvalidate(self.stream);
+    FSEventStreamRelease(self.stream);
+    self.stream = NULL;
+}
+
+- (void)dealloc
+{
+    [self stop];
+}
+
+@end

--- a/MacDown/Code/Sidebar/MPSidebarSplitView.h
+++ b/MacDown/Code/Sidebar/MPSidebarSplitView.h
@@ -1,0 +1,24 @@
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// The split view hosting the folder sidebar next to the editor/preview pane.
+///
+/// Its one job beyond NSSplitView is to say whether the user is currently
+/// dragging the divider. NSSplitViewDidResizeSubviewsNotification fires for
+/// programmatic -setPosition:, window resizes and tab insertion too, and only a
+/// genuine drag should broadcast a new shared width — otherwise the width creeps
+/// every time a tab opens.
+@interface MPSidebarSplitView : NSSplitView
+
+/// YES only for the duration of a divider-drag tracking loop.
+@property (nonatomic, readonly, getter=isDraggingDivider) BOOL draggingDivider;
+
+/// Runs `body` with -isDraggingDivider set, clearing it again even if `body`
+/// raises. -mouseDown: uses this to wrap NSSplitView's tracking loop; it is
+/// exposed so the bracketing can be exercised without a live drag.
+- (void)performDividerDrag:(nullable void (^)(void))body;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MacDown/Code/Sidebar/MPSidebarSplitView.m
+++ b/MacDown/Code/Sidebar/MPSidebarSplitView.m
@@ -1,0 +1,38 @@
+#import "MPSidebarSplitView.h"
+
+@interface MPSidebarSplitView ()
+@property (nonatomic, readwrite, getter=isDraggingDivider) BOOL draggingDivider;
+@end
+
+@implementation MPSidebarSplitView
+
+// NSSplitView handles a divider drag by running its own modal event-tracking
+// loop inside -mouseDown:, and it posts its resize notifications from within
+// that loop. Bracketing the call therefore marks exactly the drag, with no
+// guessing from [NSApp currentEvent] — which cannot reliably tell a real drag
+// from a layout-triggered resize.
+//
+// NSSplitView's -hitTest: only routes a click here when it lands on a divider;
+// clicks inside either pane go to that pane's view.
+- (void)mouseDown:(NSEvent *)event
+{
+    [self performDividerDrag:^{
+        [super mouseDown:event];
+    }];
+}
+
+- (void)performDividerDrag:(nullable void (^)(void))body
+{
+    self.draggingDivider = YES;
+    @try
+    {
+        if (body)
+            body();
+    }
+    @finally
+    {
+        self.draggingDivider = NO;
+    }
+}
+
+@end

--- a/MacDown/Code/Sidebar/MPSidebarSyncCoordinator.h
+++ b/MacDown/Code/Sidebar/MPSidebarSyncCoordinator.h
@@ -1,0 +1,62 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Posted when any shared sidebar state changes. `object` is the source that
+/// made the change (observers skip their own). `userInfo` carries the kind and
+/// the workspace root the change applies to.
+extern NSString * const MPSidebarSyncDidChangeNotification;
+extern NSString * const MPSidebarSyncKindKey;   // NSString, one of the kinds below
+extern NSString * const MPSidebarSyncRootKey;   // NSURL (all but tree changes)
+extern NSString * const MPSidebarSyncURLKey;    // NSURL (tree changes only)
+
+extern NSString * const MPSidebarSyncKindWidth;
+extern NSString * const MPSidebarSyncKindVisible;
+extern NSString * const MPSidebarSyncKindExpansion;
+extern NSString * const MPSidebarSyncKindTreeChanged;
+
+/// Shares sidebar width / visibility / expansion across the (per-document)
+/// sidebars of native window tabs, so switching tabs looks seamless. Changes
+/// broadcast via NSNotification; no-op (equal-value) updates are ignored, which
+/// breaks sync feedback loops.
+///
+/// All state is scoped to a workspace root: two windows open on different
+/// folders are independent, and only the tabs sharing a folder stay in step.
+@interface MPSidebarSyncCoordinator : NSObject
+
++ (instancetype)sharedCoordinator;
+
+/// Sidebar width for a workspace (clamped 150–420). A root not seen before
+/// starts at the last width the user dragged anywhere, which is persisted as
+/// the global default so new workspaces open at a familiar size.
+- (CGFloat)sidebarWidthForRoot:(nullable NSURL *)root;
+
+/// Sidebar visibility for a workspace (in-memory; defaults to YES each launch).
+- (BOOL)sidebarVisibleForRoot:(nullable NSURL *)root;
+
+/// Currently-expanded folder paths for a workspace root (empty if none known).
+- (NSArray<NSString *> *)expandedPathsForRoot:(nullable NSURL *)root;
+
+/// Setters: update + broadcast to the other sidebars OF THE SAME WORKSPACE.
+/// Equal values are ignored (no notification), so applying a broadcast change
+/// never re-broadcasts.
+- (void)setSidebarWidth:(CGFloat)width
+                forRoot:(nullable NSURL *)root
+                 source:(nullable id)source;
+- (void)setSidebarVisible:(BOOL)visible
+                  forRoot:(nullable NSURL *)root
+                   source:(nullable id)source;
+- (void)setExpandedPaths:(NSArray<NSString *> *)paths
+                 forRoot:(nullable NSURL *)root
+                  source:(nullable id)source;
+
+/// Announce that MacDown itself created or moved a file on disk. The folder
+/// watcher is created with kFSEventStreamCreateFlagIgnoreSelf (so our own saves
+/// don't cause a reload storm), which also means it never sees files we write;
+/// this is how those still show up. Every sidebar rooted at an ancestor of
+/// `url` reloads. Carries no state, and is not scoped to one root.
+- (void)notifyFileSavedAtURL:(NSURL *)url source:(nullable id)source;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MacDown/Code/Sidebar/MPSidebarSyncCoordinator.m
+++ b/MacDown/Code/Sidebar/MPSidebarSyncCoordinator.m
@@ -1,0 +1,158 @@
+#import "MPSidebarSyncCoordinator.h"
+
+NSString * const MPSidebarSyncDidChangeNotification =
+    @"MPSidebarSyncDidChangeNotification";
+NSString * const MPSidebarSyncKindKey = @"kind";
+NSString * const MPSidebarSyncRootKey = @"root";
+NSString * const MPSidebarSyncURLKey = @"url";
+NSString * const MPSidebarSyncKindWidth = @"width";
+NSString * const MPSidebarSyncKindVisible = @"visible";
+NSString * const MPSidebarSyncKindExpansion = @"expansion";
+NSString * const MPSidebarSyncKindTreeChanged = @"tree";
+
+static NSString * const kMPSidebarWidthDefaultsKey = @"MPSidebarSharedWidth";
+static NSString * const kMPSidebarNoRootKey = @"";
+static const CGFloat kMPSidebarMinWidth = 150.0;
+static const CGFloat kMPSidebarMaxWidth = 420.0;
+static const CGFloat kMPSidebarDefaultWidth = 220.0;
+
+@interface MPSidebarSyncCoordinator ()
+/// Last width the user dragged anywhere; persisted, and used to seed a
+/// workspace that has no width of its own yet.
+@property (nonatomic) CGFloat defaultWidth;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *widthByRoot;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *visibleByRoot;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSArray<NSString *> *> *expandedByRoot;
+@end
+
+@implementation MPSidebarSyncCoordinator
+
++ (instancetype)sharedCoordinator
+{
+    static MPSidebarSyncCoordinator *shared;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ shared = [[MPSidebarSyncCoordinator alloc] init]; });
+    return shared;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        _widthByRoot = [NSMutableDictionary dictionary];
+        _visibleByRoot = [NSMutableDictionary dictionary];
+        _expandedByRoot = [NSMutableDictionary dictionary];
+
+        NSNumber *saved = [[NSUserDefaults standardUserDefaults]
+            objectForKey:kMPSidebarWidthDefaultsKey];
+        _defaultWidth = saved ? [self clampWidth:saved.doubleValue]
+                              : kMPSidebarDefaultWidth;
+    }
+    return self;
+}
+
+- (CGFloat)clampWidth:(CGFloat)width
+{
+    if (width < kMPSidebarMinWidth) return kMPSidebarMinWidth;
+    if (width > kMPSidebarMaxWidth) return kMPSidebarMaxWidth;
+    return width;
+}
+
+// Documents with no workspace share one (unused) bucket rather than needing a
+// nil check at every call site.
+- (NSString *)keyForRoot:(NSURL *)root
+{
+    return root.absoluteString ?: kMPSidebarNoRootKey;
+}
+
+#pragma mark - Reading
+
+- (CGFloat)sidebarWidthForRoot:(NSURL *)root
+{
+    NSString *key = [self keyForRoot:root];
+    NSNumber *w = self.widthByRoot[key];
+    if (w)
+        return [self clampWidth:w.doubleValue];
+    // Pin the seed on first ask. Without this a workspace the user never drags
+    // has no entry of its own, so it would follow defaultWidth and jump when
+    // some other workspace is resized.
+    self.widthByRoot[key] = @(self.defaultWidth);
+    return self.defaultWidth;
+}
+
+- (BOOL)sidebarVisibleForRoot:(NSURL *)root
+{
+    NSNumber *v = self.visibleByRoot[[self keyForRoot:root]];
+    return v ? v.boolValue : YES;
+}
+
+- (NSArray<NSString *> *)expandedPathsForRoot:(NSURL *)root
+{
+    return self.expandedByRoot[[self keyForRoot:root]] ?: @[];
+}
+
+#pragma mark - Writing
+
+- (void)setSidebarWidth:(CGFloat)width forRoot:(NSURL *)root source:(id)source
+{
+    CGFloat clamped = [self clampWidth:width];
+    if (fabs(clamped - [self sidebarWidthForRoot:root]) < 0.5)
+        return;                                  // no-op: breaks the sync loop
+    self.widthByRoot[[self keyForRoot:root]] = @(clamped);
+    // Persisted globally, not per root: it only seeds workspaces opened later.
+    self.defaultWidth = clamped;
+    [[NSUserDefaults standardUserDefaults] setDouble:clamped
+                                              forKey:kMPSidebarWidthDefaultsKey];
+    [self postKind:MPSidebarSyncKindWidth root:root source:source];
+}
+
+- (void)setSidebarVisible:(BOOL)visible forRoot:(NSURL *)root source:(id)source
+{
+    if (visible == [self sidebarVisibleForRoot:root])
+        return;
+    self.visibleByRoot[[self keyForRoot:root]] = @(visible);
+    [self postKind:MPSidebarSyncKindVisible root:root source:source];
+}
+
+- (void)setExpandedPaths:(NSArray<NSString *> *)paths
+                 forRoot:(NSURL *)root
+                  source:(id)source
+{
+    if (!root)
+        return;
+    NSString *key = [self keyForRoot:root];
+    NSArray<NSString *> *current = self.expandedByRoot[key] ?: @[];
+    // Order-independent comparison.
+    if ([[NSSet setWithArray:paths] isEqualToSet:[NSSet setWithArray:current]])
+        return;
+    self.expandedByRoot[key] = [paths copy];
+    [self postKind:MPSidebarSyncKindExpansion root:root source:source];
+}
+
+- (void)notifyFileSavedAtURL:(NSURL *)url source:(id)source
+{
+    if (!url.isFileURL)
+        return;
+    NSMutableDictionary *info = [NSMutableDictionary dictionary];
+    info[MPSidebarSyncKindKey] = MPSidebarSyncKindTreeChanged;
+    info[MPSidebarSyncURLKey] = url;
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:MPSidebarSyncDidChangeNotification
+                      object:source
+                    userInfo:info];
+}
+
+- (void)postKind:(NSString *)kind root:(NSURL *)root source:(id)source
+{
+    NSMutableDictionary *info = [NSMutableDictionary dictionary];
+    info[MPSidebarSyncKindKey] = kind;
+    if (root)
+        info[MPSidebarSyncRootKey] = root;
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:MPSidebarSyncDidChangeNotification
+                      object:source
+                    userInfo:info];
+}
+
+@end

--- a/MacDown/Code/Utility/MPGlobals.h
+++ b/MacDown/Code/Utility/MPGlobals.h
@@ -27,3 +27,4 @@ static NSString * const kMPVersionKey = @"version";
 
 static NSString * const kMPFilesToOpenKey = @"filesToOpenOnNextLaunch";
 static NSString * const kMPPipedContentFileToOpen = @"pipedContentFileToOpenOnNextLaunch";
+static NSString * const kMPFoldersToOpenKey = @"foldersToOpenOnNextLaunch";

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -83,6 +83,12 @@
                                     <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Open Folder…" id="F0l-dr-Op1">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="openFolder:" target="eq0-c4-vgQ" id="F0l-dr-ac1"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Open Recent" id="tXI-mr-wws">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
@@ -370,6 +376,12 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="View" id="EQZ-Zp-VNE">
                         <items>
+                            <menuItem title="Show Sidebar" keyEquivalent="\" id="Sd1-br-Tg1">
+                                <connections>
+                                    <action selector="toggleFolderSidebar:" target="-1" id="Sd1-br-ac1"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="Sd1-br-Sep"/>
                             <menuItem title="Render Markdown" keyEquivalent="r" id="Vh1-jg-bbV">
                                 <connections>
                                     <action selector="render:" target="-1" id="rvl-Jx-Hji"/>

--- a/MacDownTests/MPDocumentLifecycleTests.m
+++ b/MacDownTests/MPDocumentLifecycleTests.m
@@ -926,4 +926,16 @@
         @"The base URL must point at a non-existent sentinel, not a real file");
 }
 
+
+#pragma mark - Workspace Tests
+
+- (void)testWorkspaceRootURLDefaultsToNilAndIsSettable
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    XCTAssertNil(doc.workspaceRootURL);
+    NSURL *root = [NSURL fileURLWithPath:@"/tmp" isDirectory:YES];
+    doc.workspaceRootURL = root;
+    XCTAssertEqualObjects(doc.workspaceRootURL, root);
+}
+
 @end

--- a/MacDownTests/MPDocumentTabReuseTests.m
+++ b/MacDownTests/MPDocumentTabReuseTests.m
@@ -1,0 +1,158 @@
+#import <XCTest/XCTest.h>
+#import "MPDocument.h"
+
+@interface MPDocument (TabReuseTesting)
++ (MPDocument *)openDocumentForFileURL:(NSURL *)url;
++ (NSError *)sidebarOpenErrorForError:(NSError *)error URL:(NSURL *)url;
+@end
+
+@interface MPDocumentTabReuseTests : XCTestCase
+@property (strong) NSURL *root;
+@end
+
+@implementation MPDocumentTabReuseTests
+
+- (void)setUp
+{
+    [super setUp];
+    NSString *unique = [NSProcessInfo processInfo].globallyUniqueString;
+    self.root = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+                 URLByAppendingPathComponent:unique isDirectory:YES];
+    [[NSFileManager defaultManager] createDirectoryAtURL:self.root
+        withIntermediateDirectories:YES attributes:nil error:NULL];
+}
+
+- (void)tearDown
+{
+    [[NSFileManager defaultManager] removeItemAtURL:self.root error:NULL];
+    self.root = nil;
+    [super tearDown];
+}
+
+- (NSURL *)writeMarkdownNamed:(NSString *)name
+{
+    NSURL *url = [self.root URLByAppendingPathComponent:name];
+    [@"# hello" writeToURL:url atomically:YES
+                  encoding:NSUTF8StringEncoding error:NULL];
+    return url;
+}
+
+/// Opens a document without showing a window, or fails the test.
+- (MPDocument *)openDocumentAtURL:(NSURL *)url
+{
+    XCTestExpectation *opened = [self expectationWithDescription:@"opened"];
+    __block MPDocument *document = nil;
+    [[NSDocumentController sharedDocumentController]
+        openDocumentWithContentsOfURL:url display:NO
+                    completionHandler:^(NSDocument *doc, BOOL wasOpen,
+                                        NSError *error) {
+        XCTAssertNil(error, @"could not open the fixture document");
+        if ([doc isKindOfClass:[MPDocument class]])
+            document = (MPDocument *)doc;
+        [opened fulfill];
+    }];
+    [self waitForExpectations:@[opened] timeout:10.0];
+    return document;
+}
+
+#pragma mark - Lookup
+
+- (void)testReturnsNilWhenNoDocumentIsOpenForURL
+{
+    NSURL *url = [NSURL fileURLWithPath:@"/tmp/definitely-not-open-xyz.md"];
+    XCTAssertNil([MPDocument openDocumentForFileURL:url]);
+}
+
+// The branch that makes activating a sidebar file reuse an existing tab rather
+// than open the same file twice.
+- (void)testReturnsTheOpenDocumentForItsURL
+{
+    NSURL *url = [self writeMarkdownNamed:@"reuse.md"];
+    MPDocument *document = [self openDocumentAtURL:url];
+    XCTAssertNotNil(document);
+
+    @try
+    {
+        MPDocument *found = [MPDocument openDocumentForFileURL:url];
+        XCTAssertNotNil(found, @"an open document must be found by its URL");
+        XCTAssertEqual(found, document, @"and it must be the same instance");
+    }
+    @finally
+    {
+        [document close];
+    }
+}
+
+- (void)testStopsFindingTheDocumentOnceItIsClosed
+{
+    NSURL *url = [self writeMarkdownNamed:@"closed.md"];
+    MPDocument *document = [self openDocumentAtURL:url];
+    XCTAssertNotNil(document);
+    XCTAssertNotNil([MPDocument openDocumentForFileURL:url]);
+
+    [document close];
+    XCTAssertNil([MPDocument openDocumentForFileURL:url],
+                 @"a closed document must not be reused");
+}
+
+- (void)testDoesNotConfuseTwoFilesWithTheSameName
+{
+    NSURL *first = [self writeMarkdownNamed:@"same.md"];
+    NSURL *otherDir = [self.root URLByAppendingPathComponent:@"sub"
+                                                 isDirectory:YES];
+    [[NSFileManager defaultManager] createDirectoryAtURL:otherDir
+        withIntermediateDirectories:YES attributes:nil error:NULL];
+    NSURL *second = [otherDir URLByAppendingPathComponent:@"same.md"];
+    [@"# other" writeToURL:second atomically:YES
+                  encoding:NSUTF8StringEncoding error:NULL];
+
+    MPDocument *document = [self openDocumentAtURL:first];
+    XCTAssertNotNil(document);
+    @try
+    {
+        XCTAssertEqual([MPDocument openDocumentForFileURL:first], document);
+        XCTAssertNil([MPDocument openDocumentForFileURL:second],
+                     @"a same-named file in another folder is a different doc");
+    }
+    @finally
+    {
+        [document close];
+    }
+}
+
+#pragma mark - Failed open reporting
+
+// Activating a sidebar file opens with display:NO, which opts out of
+// NSDocumentController's automatic error alert — these cover what replaces it.
+
+- (void)testFailedOpenWithAnErrorIsReported
+{
+    NSError *underlying = [NSError errorWithDomain:NSCocoaErrorDomain
+                                              code:NSFileReadNoSuchFileError
+                                          userInfo:nil];
+    NSURL *url = [self.root URLByAppendingPathComponent:@"x.md"];
+    NSError *shown = [MPDocument sidebarOpenErrorForError:underlying URL:url];
+    XCTAssertEqual(shown, underlying, @"the real error should be surfaced as-is");
+}
+
+- (void)testFailedOpenWithNoErrorStillReportsSomething
+{
+    NSURL *url = [self.root URLByAppendingPathComponent:@"gone.md"];
+    NSError *shown = [MPDocument sidebarOpenErrorForError:nil URL:url];
+    XCTAssertNotNil(shown, @"a failed open must never be silent");
+    XCTAssertTrue([shown.localizedDescription containsString:@"gone.md"],
+                  @"the message should name the file, got: %@",
+                  shown.localizedDescription);
+    XCTAssertEqualObjects(shown.userInfo[NSURLErrorKey], url);
+}
+
+- (void)testUserCancellationIsNotReported
+{
+    NSError *cancelled = [NSError errorWithDomain:NSCocoaErrorDomain
+                                             code:NSUserCancelledError
+                                         userInfo:nil];
+    XCTAssertNil([MPDocument sidebarOpenErrorForError:cancelled URL:self.root],
+                 @"cancelling is not a failure worth an alert");
+}
+
+@end

--- a/MacDownTests/MPDocumentWorkspaceTests.m
+++ b/MacDownTests/MPDocumentWorkspaceTests.m
@@ -1,0 +1,197 @@
+//
+//  MPDocumentWorkspaceTests.m
+//  MacDown 3000
+//
+
+#import <XCTest/XCTest.h>
+#import "MPDocument.h"
+#import "MPSidebarSyncCoordinator.h"
+
+@interface MPDocument (WorkspaceTesting)
+- (IBAction)toggleFolderSidebar:(id)sender;
+@end
+
+/// MPDocument's -dataOfType: reads the editor text view, which only exists once
+/// the window nib has loaded. Supplying the bytes directly leaves the rest of
+/// the save path — -writeSafelyToURL:, -writeToURL: and the sidebar
+/// announcement — exactly as it runs in the app.
+@interface MPHeadlessSavingDocument : MPDocument
+@end
+
+@implementation MPHeadlessSavingDocument
+- (NSData *)dataOfType:(NSString *)typeName error:(NSError **)outError
+{
+    return [@"# hello" dataUsingEncoding:NSUTF8StringEncoding];
+}
+- (void)makeWindowControllers { }
+@end
+
+@interface MPDocumentWorkspaceTests : XCTestCase
+@property (strong) NSURL *dir;
+@end
+
+@implementation MPDocumentWorkspaceTests
+
+- (void)setUp
+{
+    [super setUp];
+    NSString *unique = [NSProcessInfo processInfo].globallyUniqueString;
+    self.dir = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+                URLByAppendingPathComponent:unique isDirectory:YES];
+    [[NSFileManager defaultManager] createDirectoryAtURL:self.dir
+        withIntermediateDirectories:YES attributes:nil error:NULL];
+}
+
+- (void)tearDown
+{
+    [[NSFileManager defaultManager] removeItemAtURL:self.dir error:NULL];
+    self.dir = nil;
+    [super tearDown];
+}
+
+- (void)testToggleSidebarDoesNotCrashWithoutWorkspace
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    XCTAssertNoThrow([doc toggleFolderSidebar:nil]);
+}
+
+- (void)testSidebarMenuItemDisabledWithoutWorkspace
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    NSMenuItem *item = [[NSMenuItem alloc]
+        initWithTitle:@"Show Sidebar"
+               action:@selector(toggleFolderSidebar:) keyEquivalent:@"\\"];
+    XCTAssertFalse([doc validateUserInterfaceItem:item],
+                   @"sidebar toggle should be disabled when not a workspace");
+}
+
+- (void)testSidebarMenuItemEnabledWithWorkspace
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.workspaceRootURL = [NSURL fileURLWithPath:@"/tmp" isDirectory:YES];
+    NSMenuItem *item = [[NSMenuItem alloc]
+        initWithTitle:@"Show Sidebar"
+               action:@selector(toggleFolderSidebar:) keyEquivalent:@"\\"];
+    XCTAssertTrue([doc validateUserInterfaceItem:item]);
+}
+
+#pragma mark - Workspace identity
+
+// One folder must be one workspace however it was reached, or two windows on
+// the same directory silently stop sharing sidebar width, visibility and
+// expansion. `macdown /tmp/proj` yields file:///tmp/proj/ while the Open Folder
+// panel yields file:///private/tmp/proj/.
+- (void)testWorkspaceRootIsStoredCanonicalised
+{
+    NSString *unique = [NSProcessInfo processInfo].globallyUniqueString;
+    NSString *name = [@"mp-workspace-" stringByAppendingString:unique];
+    NSURL *viaTmp = [NSURL fileURLWithPath:
+        [@"/tmp" stringByAppendingPathComponent:name] isDirectory:YES];
+    NSURL *viaPrivate = [NSURL fileURLWithPath:
+        [@"/private/tmp" stringByAppendingPathComponent:name] isDirectory:YES];
+    [[NSFileManager defaultManager] createDirectoryAtURL:viaPrivate
+        withIntermediateDirectories:YES attributes:nil error:NULL];
+
+    MPDocument *a = [[MPDocument alloc] init];
+    MPDocument *b = [[MPDocument alloc] init];
+    a.workspaceRootURL = viaTmp;
+    b.workspaceRootURL = viaPrivate;
+
+    XCTAssertEqualObjects(a.workspaceRootURL.absoluteString,
+                          b.workspaceRootURL.absoluteString,
+                          @"the same folder reached two ways must be one workspace");
+
+    [[NSFileManager defaultManager] removeItemAtURL:viaPrivate error:NULL];
+}
+
+- (void)testWorkspaceRootSurvivesAPathThatDoesNotExist
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    NSURL *missing = [NSURL fileURLWithPath:@"/tmp/mp-does-not-exist-xyz"
+                                isDirectory:YES];
+    doc.workspaceRootURL = missing;
+    XCTAssertNotNil(doc.workspaceRootURL,
+                    @"an unresolvable path must not become nil");
+}
+
+- (void)testWorkspaceRootCanBeCleared
+{
+    MPDocument *doc = [[MPDocument alloc] init];
+    doc.workspaceRootURL = [NSURL fileURLWithPath:@"/tmp" isDirectory:YES];
+    doc.workspaceRootURL = nil;
+    XCTAssertNil(doc.workspaceRootURL);
+}
+
+#pragma mark - Announcing files MacDown itself creates
+
+// The folder watcher runs with kFSEventStreamCreateFlagIgnoreSelf, so a file
+// MacDown writes is invisible to it. These drive a real save through
+// NSDocument, which hands -writeToURL: a temp path inside an
+// NSItemReplacementDirectory and swaps it into place — so a test that only
+// called the coordinator directly would not notice the announcement breaking.
+
+/// Saves `doc` to `url` and returns the URL announced to sidebars, if any.
+- (NSURL *)announcedURLWhileSaving:(MPDocument *)doc
+                             toURL:(NSURL *)url
+                         operation:(NSSaveOperationType)operation
+{
+    __block NSURL *announced = nil;
+    id obs = [[NSNotificationCenter defaultCenter]
+        addObserverForName:MPSidebarSyncDidChangeNotification object:nil
+                     queue:nil usingBlock:^(NSNotification *note) {
+            if ([note.userInfo[MPSidebarSyncKindKey]
+                    isEqualToString:MPSidebarSyncKindTreeChanged])
+                announced = note.userInfo[MPSidebarSyncURLKey];
+        }];
+
+    XCTestExpectation *saved = [self expectationWithDescription:@"saved"];
+    [doc saveToURL:url ofType:@"net.daringfireball.markdown"
+  forSaveOperation:operation
+ completionHandler:^(NSError *error) {
+        XCTAssertNil(error, @"save failed: %@", error);
+        [saved fulfill];
+    }];
+    [self waitForExpectations:@[saved] timeout:10.0];
+
+    // The announcement is dispatched to the main queue after the write.
+    for (int i = 0; i < 20 && !announced; i++)
+    {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    }
+    [[NSNotificationCenter defaultCenter] removeObserver:obs];
+    return announced;
+}
+
+- (void)testFirstSaveAnnouncesTheNewFile
+{
+    MPDocument *doc = [[MPHeadlessSavingDocument alloc] init];
+    NSURL *target = [self.dir URLByAppendingPathComponent:@"created.md"];
+
+    NSURL *announced = [self announcedURLWhileSaving:doc toURL:target
+                                           operation:NSSaveAsOperation];
+    XCTAssertNotNil(announced,
+                    @"a file MacDown creates must be announced — the watcher "
+                    @"ignores our own writes, so nothing else would show it");
+    XCTAssertEqualObjects(announced.lastPathComponent, @"created.md");
+    XCTAssertFalse([announced.path containsString:@"NSIRD"],
+                   @"the announced URL must be the saved file, not the "
+                   @"temporary one the safe save writes through");
+    [doc close];
+}
+
+- (void)testPlainReSaveAnnouncesNothing
+{
+    MPDocument *doc = [[MPHeadlessSavingDocument alloc] init];
+    NSURL *target = [self.dir URLByAppendingPathComponent:@"resaved.md"];
+    XCTAssertNotNil([self announcedURLWhileSaving:doc toURL:target
+                                        operation:NSSaveAsOperation]);
+
+    XCTAssertNil([self announcedURLWhileSaving:doc toURL:target
+                                     operation:NSSaveOperation],
+                 @"re-saving the same file cannot change the tree; announcing "
+                 @"would reintroduce the reload storm");
+    [doc close];
+}
+
+@end

--- a/MacDownTests/MPFileNodeTests.m
+++ b/MacDownTests/MPFileNodeTests.m
@@ -1,0 +1,239 @@
+#import <XCTest/XCTest.h>
+#import "MPFileNode.h"
+
+@interface MPFileNodeTests : XCTestCase
+@property (strong) NSURL *root;
+@end
+
+@implementation MPFileNodeTests
+
+- (void)setUp
+{
+    [super setUp];
+    NSString *unique = [NSProcessInfo processInfo].globallyUniqueString;
+    self.root = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+                 URLByAppendingPathComponent:unique isDirectory:YES];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    [fm createDirectoryAtURL:self.root withIntermediateDirectories:YES
+                  attributes:nil error:NULL];
+    // Layout:
+    //   notes.md, NOTES.MARKDOWN, image.png, .hidden.md, sub/ , .git/
+    [self writeFile:@"notes.md"];
+    [self writeFile:@"NOTES.MARKDOWN"];
+    [self writeFile:@"image.png"];
+    [self writeFile:@".hidden.md"];
+    [fm createDirectoryAtURL:[self.root URLByAppendingPathComponent:@"sub" isDirectory:YES]
+        withIntermediateDirectories:YES attributes:nil error:NULL];
+    [fm createDirectoryAtURL:[self.root URLByAppendingPathComponent:@".git" isDirectory:YES]
+        withIntermediateDirectories:YES attributes:nil error:NULL];
+}
+
+- (void)tearDown
+{
+    [[NSFileManager defaultManager] removeItemAtURL:self.root error:NULL];
+    self.root = nil;
+    [super tearDown];
+}
+
+- (void)writeFile:(NSString *)name
+{
+    NSURL *url = [self.root URLByAppendingPathComponent:name];
+    [@"# x" writeToURL:url atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+}
+
+- (void)testMarkdownDetectionIsCaseInsensitive
+{
+    XCTAssertTrue([MPFileNode isMarkdownFileURL:
+        [NSURL fileURLWithPath:@"/a/b.md"]]);
+    XCTAssertTrue([MPFileNode isMarkdownFileURL:
+        [NSURL fileURLWithPath:@"/a/b.MARKDOWN"]]);
+    XCTAssertFalse([MPFileNode isMarkdownFileURL:
+        [NSURL fileURLWithPath:@"/a/b.png"]]);
+    XCTAssertFalse([MPFileNode isMarkdownFileURL:
+        [NSURL fileURLWithPath:@"/a/b"]]);
+}
+
+- (void)testChildrenFilterAndSort
+{
+    MPFileNode *node = [[MPFileNode alloc] initWithURL:self.root isDirectory:YES];
+    NSArray<MPFileNode *> *kids = node.children;
+    NSArray<NSString *> *names = [kids valueForKey:@"name"];
+
+    // Excluded: image.png (non-md), .hidden.md (hidden), .git (hidden dir).
+    // Included: sub/ (dir), notes.md, NOTES.MARKDOWN. Folders first, then by name (ci).
+    XCTAssertEqualObjects(names, (@[@"sub", @"NOTES.MARKDOWN", @"notes.md"]));
+    XCTAssertTrue(kids.firstObject.isDirectory);
+}
+
+- (void)testFilesHaveNoChildren
+{
+    NSURL *file = [self.root URLByAppendingPathComponent:@"notes.md"];
+    MPFileNode *node = [[MPFileNode alloc] initWithURL:file isDirectory:NO];
+    XCTAssertEqualObjects(node.children, @[]);
+}
+
+- (void)testChildrenAreCachedUntilInvalidated
+{
+    MPFileNode *node = [[MPFileNode alloc] initWithURL:self.root isDirectory:YES];
+    NSArray *first = node.children;
+    XCTAssertTrue(first == node.children, @"children should be cached (same pointer)");
+    [self writeFile:@"new.md"];
+    XCTAssertEqual(node.children.count, first.count, @"still cached after disk change");
+    [node invalidateChildrenRecursively];
+    XCTAssertEqual(node.children.count, first.count + 1, @"re-reads after invalidation");
+}
+
+#pragma mark - Symlink cycles
+
+- (void)linkAt:(NSString *)relativePath toURL:(NSURL *)target
+{
+    NSURL *link = [self.root URLByAppendingPathComponent:relativePath];
+    NSError *error = nil;
+    XCTAssertTrue([[NSFileManager defaultManager]
+                       createSymbolicLinkAtURL:link
+                            withDestinationURL:target error:&error],
+                  @"could not create symlink: %@", error);
+}
+
+/// Walk the whole tree, failing rather than hanging if it never bottoms out.
+- (NSUInteger)visitAllUnder:(MPFileNode *)node depth:(NSUInteger)depth
+{
+    XCTAssertLessThan(depth, (NSUInteger)32,
+                      @"tree did not bottom out — symlink cycle guard failed");
+    if (depth >= 32)
+        return 0;
+    NSUInteger count = 1;
+    for (MPFileNode *child in node.children)
+        count += [self visitAllUnder:child depth:depth + 1];
+    return count;
+}
+
+- (NSArray<NSString *> *)namesOfChildrenOf:(MPFileNode *)node
+{
+    NSMutableArray<NSString *> *names = [NSMutableArray array];
+    for (MPFileNode *child in node.children)
+        [names addObject:child.name];
+    return names;
+}
+
+- (void)testSelfReferentialSymlinkIsNotDescended
+{
+    [self linkAt:@"selfloop" toURL:self.root];
+    MPFileNode *node = [[MPFileNode alloc] initWithURL:self.root isDirectory:YES];
+    XCTAssertFalse([[self namesOfChildrenOf:node] containsObject:@"selfloop"],
+                   @"a symlink to the root itself must not become a child");
+    [self visitAllUnder:node depth:0];
+}
+
+- (void)testSymlinkToAncestorIsNotDescended
+{
+    [self linkAt:@"sub/back" toURL:self.root];
+    MPFileNode *node = [[MPFileNode alloc] initWithURL:self.root isDirectory:YES];
+    MPFileNode *sub = nil;
+    for (MPFileNode *child in node.children)
+        if ([child.name isEqualToString:@"sub"])
+            sub = child;
+    XCTAssertNotNil(sub);
+    XCTAssertFalse([[self namesOfChildrenOf:sub] containsObject:@"back"],
+                   @"a symlink pointing at an ancestor must be dropped");
+    [self visitAllUnder:node depth:0];
+}
+
+- (void)testMutuallyRecursiveSymlinksTerminate
+{
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSURL *a = [self.root URLByAppendingPathComponent:@"a" isDirectory:YES];
+    NSURL *b = [self.root URLByAppendingPathComponent:@"b" isDirectory:YES];
+    [fm createDirectoryAtURL:a withIntermediateDirectories:YES
+                  attributes:nil error:NULL];
+    [fm createDirectoryAtURL:b withIntermediateDirectories:YES
+                  attributes:nil error:NULL];
+    [self linkAt:@"a/to-b" toURL:b];
+    [self linkAt:@"b/to-a" toURL:a];
+
+    MPFileNode *node = [[MPFileNode alloc] initWithURL:self.root isDirectory:YES];
+    // a/to-b/to-a is a repeat of `a` on this path and must terminate there.
+    XCTAssertNoThrow([self visitAllUnder:node depth:0]);
+}
+
+// The guard must only drop links that re-enter the tree, not every symlink.
+- (void)testSymlinkToUnrelatedDirectoryIsKept
+{
+    NSString *unique = [NSProcessInfo processInfo].globallyUniqueString;
+    NSURL *outside = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+                      URLByAppendingPathComponent:unique isDirectory:YES];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    [fm createDirectoryAtURL:outside withIntermediateDirectories:YES
+                  attributes:nil error:NULL];
+    [@"# x" writeToURL:[outside URLByAppendingPathComponent:@"far.md"]
+            atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+    [self linkAt:@"elsewhere" toURL:outside];
+
+    MPFileNode *node = [[MPFileNode alloc] initWithURL:self.root isDirectory:YES];
+    MPFileNode *linked = nil;
+    for (MPFileNode *child in node.children)
+        if ([child.name isEqualToString:@"elsewhere"])
+            linked = child;
+    XCTAssertNotNil(linked, @"a symlink outside the tree should still be shown");
+    XCTAssertTrue([[self namesOfChildrenOf:linked] containsObject:@"far.md"]);
+
+    [fm removeItemAtURL:outside error:NULL];
+}
+
+// Opening a symlink's own URL fails — NSDocumentController type-detects it as
+// public.symlink, not Markdown — so a link must report its target instead.
+- (void)testSymlinkedFileResolvesToItsTargetForOpening
+{
+    NSString *unique = [NSProcessInfo processInfo].globallyUniqueString;
+    NSURL *outside = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+                      URLByAppendingPathComponent:unique isDirectory:YES];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    [fm createDirectoryAtURL:outside withIntermediateDirectories:YES
+                  attributes:nil error:NULL];
+    NSURL *target = [outside URLByAppendingPathComponent:@"target.md"];
+    [@"# x" writeToURL:target atomically:YES
+              encoding:NSUTF8StringEncoding error:NULL];
+    [self linkAt:@"alias.md" toURL:target];
+
+    MPFileNode *node = [[MPFileNode alloc] initWithURL:self.root isDirectory:YES];
+    MPFileNode *alias = nil;
+    for (MPFileNode *child in node.children)
+        if ([child.name isEqualToString:@"alias.md"])
+            alias = child;
+
+    XCTAssertNotNil(alias, @"a link to a Markdown file should be listed");
+    XCTAssertEqualObjects(alias.name, @"alias.md",
+                          @"the sidebar shows the link's own name");
+    XCTAssertEqualObjects(alias.resolvedURL.URLByResolvingSymlinksInPath,
+                          target.URLByResolvingSymlinksInPath,
+                          @"but opening it must reach the target file");
+    XCTAssertNotEqualObjects(alias.resolvedURL, alias.URL);
+
+    [fm removeItemAtURL:outside error:NULL];
+}
+
+- (void)testOrdinaryFileResolvesToItself
+{
+    MPFileNode *node = [[MPFileNode alloc] initWithURL:self.root isDirectory:YES];
+    NSUInteger checked = 0;
+    for (MPFileNode *child in node.children)
+    {
+        if (child.isDirectory)
+            continue;
+        checked++;
+        XCTAssertEqualObjects(child.resolvedURL, child.URL,
+                              @"%@ is not a link", child.name);
+    }
+    XCTAssertGreaterThan(checked, 0u, @"the loop must actually assert something");
+}
+
+- (void)testBrokenSymlinkIsSkipped
+{
+    [self linkAt:@"dangling.md"
+           toURL:[self.root URLByAppendingPathComponent:@"does-not-exist.md"]];
+    MPFileNode *node = [[MPFileNode alloc] initWithURL:self.root isDirectory:YES];
+    XCTAssertFalse([[self namesOfChildrenOf:node] containsObject:@"dangling.md"],
+                   @"a broken symlink has nothing to open");
+}
+
+@end

--- a/MacDownTests/MPFolderSidebarViewControllerTests.m
+++ b/MacDownTests/MPFolderSidebarViewControllerTests.m
@@ -1,0 +1,505 @@
+#import <XCTest/XCTest.h>
+#import <Cocoa/Cocoa.h>
+#import "MPFolderSidebarViewController.h"
+#import "MPFileNode.h"
+#import "MPSidebarSplitView.h"
+#import "MPSidebarSyncCoordinator.h"
+
+@interface MPFolderSidebarViewController (Testing)
+    <NSOutlineViewDataSource, NSSplitViewDelegate>
+@property (nonatomic, strong) NSOutlineView *outlineView;
+- (void)copyPath:(NSString *)path toPasteboard:(NSPasteboard *)pasteboard;
+- (void)handleDoubleClick:(id)sender;
+- (NSInteger)rowForURL:(NSURL *)url resolvingLinks:(BOOL)resolvingLinks;
+@end
+
+/// Lets a test say which row was clicked/selected without a real mouse.
+/// Subclasses the production outline view so -keyDown: exercises the real path
+/// rather than calling the controller directly.
+@interface MPStubOutlineView : MPSidebarOutlineView
+@property (nonatomic) NSInteger stubClickedRow;
+@property (nonatomic) NSInteger stubSelectedRow;
+@end
+
+@implementation MPStubOutlineView
+- (NSInteger)clickedRow { return self.stubClickedRow; }
+- (NSInteger)selectedRow { return self.stubSelectedRow; }
+@end
+
+/// Records what the sidebar asked to open.
+@interface MPRecordingSidebarDelegate : NSObject <MPFolderSidebarDelegate>
+@property (nonatomic, strong) NSMutableArray<NSURL *> *activated;
+@end
+
+@implementation MPRecordingSidebarDelegate
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+        _activated = [NSMutableArray array];
+    return self;
+}
+- (void)folderSidebar:(MPFolderSidebarViewController *)sidebar
+   didActivateFileURL:(NSURL *)url
+{
+    [self.activated addObject:url];
+}
+@end
+
+@interface MPFolderSidebarViewControllerTests : XCTestCase
+@property (strong) NSURL *root;
+@property (strong) MPFolderSidebarViewController *vc;
+@property (strong) MPStubOutlineView *outline;
+@property (strong) MPRecordingSidebarDelegate *delegate;
+@property (strong) NSNumber *savedWidthDefault;
+@property (strong) NSURL *outsideDir;
+@end
+
+@implementation MPFolderSidebarViewControllerTests
+
+- (void)setUp
+{
+    [super setUp];
+    NSString *unique = [NSProcessInfo processInfo].globallyUniqueString;
+    self.root = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+                 URLByAppendingPathComponent:unique isDirectory:YES];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    [fm createDirectoryAtURL:self.root withIntermediateDirectories:YES
+                  attributes:nil error:NULL];
+    [@"# a" writeToURL:[self.root URLByAppendingPathComponent:@"a.md"]
+            atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+    [@"# b" writeToURL:[self.root URLByAppendingPathComponent:@"b.md"]
+            atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+    [fm createDirectoryAtURL:[self.root URLByAppendingPathComponent:@"sub" isDirectory:YES]
+        withIntermediateDirectories:YES attributes:nil error:NULL];
+    self.vc = [[MPFolderSidebarViewController alloc] initWithRootURL:self.root];
+    (void)self.vc.view;   // force loadView so the outline view exists
+
+    // Swap in an outline view whose clicked/selected row the test controls.
+    // Rows, collapsed: 0 = sub/, 1 = a.md, 2 = b.md.
+    self.outline = [[MPStubOutlineView alloc]
+        initWithFrame:NSMakeRect(0, 0, 220, 400)];
+    NSTableColumn *col = [[NSTableColumn alloc] initWithIdentifier:@"name"];
+    [self.outline addTableColumn:col];
+    self.outline.outlineTableColumn = col;
+    self.outline.dataSource = (id)self.vc;
+    self.outline.delegate = (id)self.vc;
+    self.outline.stubClickedRow = -1;
+    self.outline.stubSelectedRow = -1;
+    self.outline.sidebar = self.vc;
+    self.vc.outlineView = self.outline;
+    [self.outline reloadData];
+
+    self.delegate = [[MPRecordingSidebarDelegate alloc] init];
+    self.vc.sidebarDelegate = self.delegate;
+
+    self.savedWidthDefault = [[NSUserDefaults standardUserDefaults]
+        objectForKey:@"MPSidebarSharedWidth"];
+}
+
+- (void)tearDown
+{
+    // The geometry tests set a sidebar width, which persists as the global
+    // seed; don't leave the running user's preference changed.
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if (self.savedWidthDefault)
+        [defaults setObject:self.savedWidthDefault forKey:@"MPSidebarSharedWidth"];
+    else
+        [defaults removeObjectForKey:@"MPSidebarSharedWidth"];
+    self.savedWidthDefault = nil;
+
+    [[NSFileManager defaultManager] removeItemAtURL:self.root error:NULL];
+    if (self.outsideDir)
+        [[NSFileManager defaultManager] removeItemAtURL:self.outsideDir error:NULL];
+    self.outsideDir = nil;
+    self.outline = nil;
+    self.delegate = nil;
+    self.vc = nil;
+    self.root = nil;
+    [super tearDown];
+}
+
+- (NSEvent *)returnKeyEvent
+{
+    return [NSEvent keyEventWithType:NSEventTypeKeyDown
+                            location:NSZeroPoint
+                       modifierFlags:0
+                           timestamp:0
+                        windowNumber:0
+                             context:nil
+                          characters:@"\r"
+         charactersIgnoringModifiers:@"\r"
+                           isARepeat:NO
+                             keyCode:36];
+}
+
+- (void)testRootURLIsExposed
+{
+    XCTAssertEqualObjects(self.vc.rootURL, self.root);
+}
+
+- (void)testTopLevelChildCountAndOrder
+{
+    // nil item == root level. Expect sub/ (dir first), then a.md, b.md.
+    NSInteger n = [self.vc outlineView:self.outline numberOfChildrenOfItem:nil];
+    XCTAssertEqual(n, 3);
+    id first = [self.vc outlineView:self.outline child:0 ofItem:nil];
+    XCTAssertTrue([self.vc outlineView:self.outline isItemExpandable:first],
+                  @"first row should be the 'sub' directory (expandable)");
+}
+
+- (void)testCopyPathWritesPathToNamedPasteboard
+{
+    NSPasteboard *pb = [NSPasteboard pasteboardWithName:@"MPFolderSidebarCopyPathTestPB"];
+    [pb clearContents];
+    [self.vc copyPath:@"/tmp/example.md" toPasteboard:pb];
+    XCTAssertEqualObjects([pb stringForType:NSPasteboardTypeString], @"/tmp/example.md");
+}
+
+#pragma mark - Activation: double click
+
+- (void)testDoubleClickOnMarkdownFileActivatesIt
+{
+    self.outline.stubClickedRow = 1;              // a.md
+    [self.vc handleDoubleClick:nil];
+    XCTAssertEqual(self.delegate.activated.count, 1u);
+    XCTAssertEqualObjects(self.delegate.activated.firstObject.lastPathComponent,
+                          @"a.md");
+}
+
+- (void)testDoubleClickOnDirectoryTogglesExpansionWithoutActivating
+{
+    id sub = [self.vc outlineView:self.outline child:0 ofItem:nil];
+    XCTAssertFalse([self.outline isItemExpanded:sub]);
+
+    self.outline.stubClickedRow = 0;              // sub/
+    [self.vc handleDoubleClick:nil];
+    XCTAssertTrue([self.outline isItemExpanded:sub], @"should expand");
+    XCTAssertEqual(self.delegate.activated.count, 0u,
+                   @"a folder is not a document");
+
+    [self.vc handleDoubleClick:nil];
+    XCTAssertFalse([self.outline isItemExpanded:sub], @"and collapse again");
+    XCTAssertEqual(self.delegate.activated.count, 0u);
+}
+
+- (void)testDoubleClickOnEmptySpaceDoesNothing
+{
+    self.outline.stubClickedRow = -1;             // click below the last row
+    XCTAssertNoThrow([self.vc handleDoubleClick:nil]);
+    XCTAssertEqual(self.delegate.activated.count, 0u);
+}
+
+- (void)testDoubleClickOnNonMarkdownFileDoesNotActivate
+{
+    [@"binary" writeToURL:[self.root URLByAppendingPathComponent:@"image.png"]
+               atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+    [self.vc reload];
+
+    // image.png is filtered out of the tree entirely, so the row count is
+    // unchanged and nothing can activate it.
+    XCTAssertEqual([self.vc outlineView:self.outline
+                 numberOfChildrenOfItem:nil], 3);
+    for (NSInteger row = 0; row < 3; row++)
+    {
+        self.outline.stubClickedRow = row;
+        [self.vc handleDoubleClick:nil];
+    }
+    for (NSURL *url in self.delegate.activated)
+        XCTAssertNotEqualObjects(url.lastPathComponent, @"image.png");
+}
+
+// Activating a symlink must report its target: NSDocumentController refuses a
+// link's own URL as public.symlink rather than Markdown. Covers the delegate
+// call sites, which the MPFileNode-level tests do not reach.
+- (NSInteger)addLinkedFileAndReturnItsRow
+{
+    NSString *unique = [NSProcessInfo processInfo].globallyUniqueString;
+    self.outsideDir = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+                       URLByAppendingPathComponent:unique isDirectory:YES];
+    [[NSFileManager defaultManager] createDirectoryAtURL:self.outsideDir
+        withIntermediateDirectories:YES attributes:nil error:NULL];
+    NSURL *target = [self.outsideDir URLByAppendingPathComponent:@"target.md"];
+    [@"# t" writeToURL:target atomically:YES
+              encoding:NSUTF8StringEncoding error:NULL];
+    [[NSFileManager defaultManager]
+        createSymbolicLinkAtURL:[self.root URLByAppendingPathComponent:@"alias.md"]
+             withDestinationURL:target error:NULL];
+
+    [self.vc reload];
+    for (NSInteger row = 0; row < self.outline.numberOfRows; row++)
+    {
+        MPFileNode *node = [self.outline itemAtRow:row];
+        if ([node.name isEqualToString:@"alias.md"])
+            return row;
+    }
+    XCTFail(@"the linked file should be listed");
+    return -1;
+}
+
+- (void)testDoubleClickOnSymlinkedFileReportsItsTarget
+{
+    NSInteger row = [self addLinkedFileAndReturnItsRow];
+    self.outline.stubClickedRow = row;
+    [self.vc handleDoubleClick:nil];
+
+    XCTAssertEqual(self.delegate.activated.count, 1u);
+    NSURL *opened = self.delegate.activated.firstObject;
+    XCTAssertEqualObjects(opened.lastPathComponent, @"target.md",
+                          @"opening a link must reach the file it points at");
+}
+
+- (void)testReturnOnSymlinkedFileReportsItsTarget
+{
+    NSInteger row = [self addLinkedFileAndReturnItsRow];
+    self.outline.stubSelectedRow = row;
+    [self.outline keyDown:[self returnKeyEvent]];
+
+    XCTAssertEqual(self.delegate.activated.count, 1u);
+    XCTAssertEqualObjects(self.delegate.activated.firstObject.lastPathComponent,
+                          @"target.md");
+}
+
+#pragma mark - Activation: Return key
+
+- (void)testReturnKeyActivatesSelectedMarkdownFile
+{
+    self.outline.stubSelectedRow = 2;             // b.md
+    [self.outline keyDown:[self returnKeyEvent]];
+    XCTAssertEqual(self.delegate.activated.count, 1u);
+    XCTAssertEqualObjects(self.delegate.activated.firstObject.lastPathComponent,
+                          @"b.md");
+}
+
+- (void)testReturnKeyWithDirectorySelectedDoesNotActivate
+{
+    self.outline.stubSelectedRow = 0;             // sub/
+    XCTAssertNoThrow([self.outline keyDown:[self returnKeyEvent]]);
+    XCTAssertEqual(self.delegate.activated.count, 0u);
+}
+
+- (void)testReturnKeyWithNothingSelectedDoesNotActivate
+{
+    self.outline.stubSelectedRow = -1;
+    XCTAssertNoThrow([self.outline keyDown:[self returnKeyEvent]]);
+    XCTAssertEqual(self.delegate.activated.count, 0u);
+}
+
+- (void)testOtherKeysDoNotActivate
+{
+    self.outline.stubSelectedRow = 1;             // a.md selected
+    NSEvent *letter = [NSEvent keyEventWithType:NSEventTypeKeyDown
+                                       location:NSZeroPoint
+                                  modifierFlags:0
+                                      timestamp:0
+                                   windowNumber:0
+                                        context:nil
+                                     characters:@"x"
+                    charactersIgnoringModifiers:@"x"
+                                      isARepeat:NO
+                                        keyCode:7];
+    XCTAssertNoThrow([self.outline keyDown:letter]);
+    XCTAssertEqual(self.delegate.activated.count, 0u);
+}
+
+#pragma mark - Production wiring
+
+// The tests above swap in their own outline view, so they would still pass if
+// -loadView stopped wiring the real one up. These pin that wiring.
+
+- (void)testLoadViewBuildsAnOutlineViewWiredForActivation
+{
+    MPFolderSidebarViewController *vc =
+        [[MPFolderSidebarViewController alloc] initWithRootURL:self.root];
+    NSScrollView *scroll = (NSScrollView *)vc.view;
+    XCTAssertTrue([scroll isKindOfClass:[NSScrollView class]]);
+
+    id outline = scroll.documentView;
+    XCTAssertTrue([outline isKindOfClass:[MPSidebarOutlineView class]],
+                  @"Return is handled by the outline view, not the controller");
+    XCTAssertEqual([(MPSidebarOutlineView *)outline sidebar], vc,
+                   @"without this back-reference Return does nothing");
+    XCTAssertEqual([outline target], vc);
+    XCTAssertEqual([outline doubleAction], @selector(handleDoubleClick:));
+}
+
+#pragma mark - Split view geometry
+
+- (NSSplitView *)splitViewWithSidebarWidth:(CGFloat)width
+                                totalWidth:(CGFloat)total
+{
+    MPSidebarSplitView *split = [[MPSidebarSplitView alloc]
+        initWithFrame:NSMakeRect(0, 0, total, 600)];
+    split.vertical = YES;
+    NSView *sidebar = self.vc.view;
+    sidebar.frame = NSMakeRect(0, 0, width, 600);
+    [split addSubview:sidebar];
+    [split addSubview:[[NSView alloc]
+        initWithFrame:NSMakeRect(width + 1, 0, total - width - 1, 600)]];
+    split.delegate = (id)self.vc;
+    return split;
+}
+
+- (void)testSidebarKeepsItsWidthWhenTheWindowGrows
+{
+    [[MPSidebarSyncCoordinator sharedCoordinator]
+        setSidebarWidth:220 forRoot:self.root source:self];
+    NSSplitView *split = [self splitViewWithSidebarWidth:220 totalWidth:800];
+
+    split.frame = NSMakeRect(0, 0, 1400, 600);
+    [self.vc splitView:split resizeSubviewsWithOldSize:NSMakeSize(800, 600)];
+    XCTAssertEqualWithAccuracy(NSWidth(split.subviews[0].frame), 220.0, 0.5,
+                               @"all the extra width belongs to the editor");
+}
+
+// Squeezing the window must not shrink the sidebar permanently.
+- (void)testSidebarWidthIsRestoredAfterTheWindowIsSqueezed
+{
+    [[MPSidebarSyncCoordinator sharedCoordinator]
+        setSidebarWidth:220 forRoot:self.root source:self];
+    NSSplitView *split = [self splitViewWithSidebarWidth:220 totalWidth:800];
+
+    // Below the sidebar's own width: it has to give way...
+    split.frame = NSMakeRect(0, 0, 94, 600);
+    [self.vc splitView:split resizeSubviewsWithOldSize:NSMakeSize(800, 600)];
+    XCTAssertLessThanOrEqual(NSWidth(split.subviews[0].frame), 94.0);
+    XCTAssertGreaterThanOrEqual(NSWidth(split.subviews[1].frame), 0.0,
+                                @"the editor pane must never go negative");
+
+    // ...and take it back when there is room again.
+    split.frame = NSMakeRect(0, 0, 800, 600);
+    [self.vc splitView:split resizeSubviewsWithOldSize:NSMakeSize(94, 600)];
+    XCTAssertEqualWithAccuracy(NSWidth(split.subviews[0].frame), 220.0, 0.5,
+                               @"the sidebar width must not ratchet down");
+}
+
+- (void)testCollapsedSidebarLeavesNoGapBesideTheEditor
+{
+    NSSplitView *split = [self splitViewWithSidebarWidth:220 totalWidth:800];
+    // A collapsed pane keeps its frame width and is merely hidden.
+    self.vc.view.hidden = YES;
+    XCTAssertTrue([split isSubviewCollapsed:self.vc.view],
+                  @"precondition: AppKit reports the pane as collapsed");
+
+    split.frame = NSMakeRect(0, 0, 900, 600);
+    [self.vc splitView:split resizeSubviewsWithOldSize:NSMakeSize(800, 600)];
+
+    NSRect editor = split.subviews[1].frame;
+    XCTAssertEqualWithAccuracy(NSMinX(editor), split.dividerThickness, 0.5,
+                               @"the editor should start at the leading edge");
+    XCTAssertEqualWithAccuracy(NSWidth(editor),
+                               900.0 - split.dividerThickness, 0.5);
+}
+
+#pragma mark - Selection with links present
+
+/// The listed node with this name, or nil.
+- (MPFileNode *)nodeNamed:(NSString *)name
+{
+    for (NSInteger row = 0; row < self.outline.numberOfRows; row++)
+    {
+        MPFileNode *node = [self.outline itemAtRow:row];
+        if ([node.name isEqualToString:name])
+            return node;
+    }
+    return nil;
+}
+
+/// Name of whatever row is currently selected, or nil. Reads the index set
+/// rather than -selectedRow, which the stub overrides for the activation tests.
+- (NSString *)selectedNodeName
+{
+    NSIndexSet *selected = self.outline.selectedRowIndexes;
+    if (!selected.count)
+        return nil;
+    return [(MPFileNode *)[self.outline itemAtRow:selected.firstIndex] name];
+}
+
+// A file and a link to it can both be listed. The file's own row must win,
+// whichever sorts first — the link only counts when the file itself is absent.
+- (void)testSelectionPrefersTheFileOverALinkToIt
+{
+    NSURL *real = [self.root URLByAppendingPathComponent:@"real.md"];
+    [@"# r" writeToURL:real atomically:YES
+              encoding:NSUTF8StringEncoding error:NULL];
+    [[NSFileManager defaultManager]
+        createSymbolicLinkAtURL:[self.root URLByAppendingPathComponent:@"alias.md"]
+             withDestinationURL:real error:NULL];
+    [self.vc reload];
+
+    // Ask with the node's own URL, as every production caller does — node URLs
+    // are canonical, built from the resolved root.
+    MPFileNode *realNode = [self nodeNamed:@"real.md"];
+    XCTAssertNotNil(realNode);
+    // "alias.md" sorts before "real.md", so a single-pass match picks the link.
+    [self.vc selectFileURL:realNode.URL];
+    XCTAssertEqualObjects([self selectedNodeName], @"real.md",
+                          @"the file's own row must win over a link to it");
+}
+
+// With no row for the file itself, the link is the right answer: that is the
+// case activation relies on.
+- (void)testSelectionFallsBackToALinkWhenTheTargetIsNotListed
+{
+    NSInteger row = [self addLinkedFileAndReturnItsRow];
+    XCTAssertGreaterThanOrEqual(row, 0);
+    MPFileNode *alias = [self.outline itemAtRow:row];
+
+    [self.vc selectFileURL:alias.resolvedURL];
+    XCTAssertEqualObjects([self selectedNodeName], @"alias.md",
+                          @"the target lives outside the tree, so the link "
+                          @"itself is the row to highlight");
+}
+
+// A symlinked folder resolves equal to the real folder's URL; the real one
+// must still be the row that gets selected.
+- (void)testSelectionPrefersTheRealFolderOverALinkToIt
+{
+    NSURL *realDir = [self.root URLByAppendingPathComponent:@"realdir"
+                                                isDirectory:YES];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    [fm createDirectoryAtURL:realDir withIntermediateDirectories:YES
+                  attributes:nil error:NULL];
+    [@"# d" writeToURL:[realDir URLByAppendingPathComponent:@"in.md"]
+            atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+    [fm createSymbolicLinkAtURL:[self.root URLByAppendingPathComponent:@"aliasdir"]
+             withDestinationURL:realDir error:NULL];
+    [self.vc reload];
+
+    MPFileNode *realNode = [self nodeNamed:@"realdir"];
+    XCTAssertNotNil(realNode);
+    [self.vc selectFileURL:realNode.URL];
+    XCTAssertEqualObjects([self selectedNodeName], @"realdir",
+                          @"'aliasdir' sorts first but is not the folder asked for");
+
+    // Asserted on the helper directly: -selectFileURL: finds realdir in pass 1
+    // and returns, so only this reaches the pass that resolves links. A
+    // symlinked folder's resolvedURL equals the real folder's own URL, so
+    // without the directory guard 'aliasdir' would match here.
+    XCTAssertEqual([self.vc rowForURL:realNode.URL resolvingLinks:YES], -1,
+                   @"link resolution must never match a directory");
+}
+
+#pragma mark - Workspace containment
+
+- (void)testContainsURLMatchesFilesUnderTheRoot
+{
+    XCTAssertTrue([self.vc containsURL:
+        [self.root URLByAppendingPathComponent:@"a.md"]]);
+    XCTAssertTrue([self.vc containsURL:
+        [self.root URLByAppendingPathComponent:@"sub/deep.md"]]);
+    XCTAssertTrue([self.vc containsURL:self.root], @"the root itself counts");
+}
+
+- (void)testContainsURLRejectsOutsiders
+{
+    XCTAssertFalse([self.vc containsURL:
+        [NSURL fileURLWithPath:@"/etc/hosts"]]);
+    // A sibling whose path merely starts with the root's path.
+    NSURL *sibling = [NSURL fileURLWithPath:
+        [self.root.path stringByAppendingString:@"-other/x.md"]];
+    XCTAssertFalse([self.vc containsURL:sibling],
+                   @"prefix matching must respect path boundaries");
+}
+
+@end

--- a/MacDownTests/MPFolderWatcherTests.m
+++ b/MacDownTests/MPFolderWatcherTests.m
@@ -1,0 +1,144 @@
+#import <XCTest/XCTest.h>
+#import "MPFolderWatcher.h"
+
+@interface MPFolderWatcherTests : XCTestCase
+@property (strong) NSURL *root;
+@end
+
+@implementation MPFolderWatcherTests
+
+- (void)setUp
+{
+    [super setUp];
+    NSString *unique = [NSProcessInfo processInfo].globallyUniqueString;
+    self.root = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+                 URLByAppendingPathComponent:unique isDirectory:YES];
+    [[NSFileManager defaultManager] createDirectoryAtURL:self.root
+        withIntermediateDirectories:YES attributes:nil error:NULL];
+}
+
+- (void)tearDown
+{
+    [[NSFileManager defaultManager] removeItemAtURL:self.root error:NULL];
+    self.root = nil;
+    [super tearDown];
+}
+
+- (void)testWatchesLocalTempDirectory
+{
+    MPFolderWatcher *watcher =
+        [[MPFolderWatcher alloc] initWithRootURL:self.root handler:^{ }];
+    XCTAssertTrue(watcher.isWatching,
+                  @"a local temp dir should be watchable");
+    [watcher stop];
+    XCTAssertFalse(watcher.isWatching);
+}
+
+- (void)testStopIsIdempotentAndNoCrash
+{
+    MPFolderWatcher *watcher =
+        [[MPFolderWatcher alloc] initWithRootURL:self.root handler:^{ }];
+    XCTAssertNoThrow([watcher stop]);
+    XCTAssertNoThrow([watcher stop]);
+}
+
+// The stream is created with kFSEventStreamCreateFlagIgnoreSelf, so a file
+// written by THIS process is deliberately not reported. Use an external process
+// to produce a change the stream should see.
+- (void)createFileExternallyNamed:(NSString *)name
+{
+    NSURL *f = [self.root URLByAppendingPathComponent:name];
+    NSTask *task = [[NSTask alloc] init];
+    task.executableURL = [NSURL fileURLWithPath:@"/usr/bin/touch"];
+    task.arguments = @[f.path];
+    XCTAssertTrue([task launchAndReturnError:NULL], @"could not launch touch");
+    [task waitUntilExit];
+}
+
+- (void)testFiresHandlerOnExternalFileCreation
+{
+    XCTestExpectation *changed =
+        [self expectationWithDescription:@"handler fired"];
+    __block BOOL fulfilled = NO;
+    MPFolderWatcher *watcher =
+        [[MPFolderWatcher alloc] initWithRootURL:self.root handler:^{
+            if (!fulfilled) { fulfilled = YES; [changed fulfill]; }
+        }];
+    // Give the stream a moment to arm, then create a file from another process.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        [self createFileExternallyNamed:@"new.md"];
+    });
+    [self waitForExpectations:@[changed] timeout:10.0];
+    [watcher stop];
+}
+
+// Guards the reload-storm fix: MacDown's own saves inside a watched folder must
+// not re-trigger the sidebar reload.
+- (void)testDoesNotFireForWritesFromThisProcess
+{
+    XCTestExpectation *changed =
+        [self expectationWithDescription:@"handler must not fire"];
+    changed.inverted = YES;
+    MPFolderWatcher *watcher =
+        [[MPFolderWatcher alloc] initWithRootURL:self.root handler:^{
+            [changed fulfill];
+        }];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        for (int i = 0; i < 5; i++)
+        {
+            NSString *name = [NSString stringWithFormat:@"self-%d.md", i];
+            NSURL *f = [self.root URLByAppendingPathComponent:name];
+            [@"# hi" writeToURL:f atomically:YES
+                       encoding:NSUTF8StringEncoding error:NULL];
+        }
+    });
+    [self waitForExpectations:@[changed] timeout:3.0];
+    [watcher stop];
+}
+
+// The stream must deliver on the main queue: that is what serializes callbacks
+// with -stop and with the sidebar reload they drive.
+- (void)testHandlerRunsOnMainQueue
+{
+    XCTestExpectation *changed =
+        [self expectationWithDescription:@"handler fired"];
+    __block BOOL fulfilled = NO;
+    __block BOOL onMain = NO;
+    MPFolderWatcher *watcher =
+        [[MPFolderWatcher alloc] initWithRootURL:self.root handler:^{
+            if (fulfilled)
+                return;
+            fulfilled = YES;
+            onMain = [NSThread isMainThread];
+            [changed fulfill];
+        }];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        [self createFileExternallyNamed:@"main-queue.md"];
+    });
+    [self waitForExpectations:@[changed] timeout:10.0];
+    XCTAssertTrue(onMain, @"FSEvents callbacks must arrive on the main queue");
+    [watcher stop];
+}
+
+// After -stop the handler must never run again, even if the watcher itself is
+// gone: the stream retains an internal target, not the watcher.
+- (void)testHandlerNeverRunsAfterStopOrDealloc
+{
+    XCTestExpectation *changed =
+        [self expectationWithDescription:@"handler must not fire"];
+    changed.inverted = YES;
+    @autoreleasepool {
+        MPFolderWatcher *watcher =
+            [[MPFolderWatcher alloc] initWithRootURL:self.root handler:^{
+                [changed fulfill];
+            }];
+        [watcher stop];
+    }
+    [self createFileExternallyNamed:@"after-stop.md"];
+    [self waitForExpectations:@[changed] timeout:2.0];
+}
+
+@end

--- a/MacDownTests/MPMainControllerFolderTests.m
+++ b/MacDownTests/MPMainControllerFolderTests.m
@@ -1,0 +1,72 @@
+//
+//  MPMainControllerFolderTests.m
+//  MacDown 3000
+//
+
+#import <XCTest/XCTest.h>
+#import "MPMainController.h"
+#import "MPPreferences.h"
+
+@interface MPMainController (FolderTesting)
+- (void)openPendingFolders;
+@end
+
+@interface MPMainControllerFolderTests : XCTestCase
+@property (strong) MPMainController *controller;
+@end
+
+@implementation MPMainControllerFolderTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.controller = [[MPMainController alloc] init];
+}
+
+- (void)tearDown
+{
+    self.controller = nil;
+    [super tearDown];
+}
+
+- (void)testUntitledIsSuppressedWhenFoldersPending
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    NSArray *savedFiles = prefs.filesToOpen;
+    NSArray *savedFolders = prefs.foldersToOpen;
+    @try
+    {
+        prefs.filesToOpen = nil;
+        prefs.foldersToOpen = @[@"/tmp/some-folder"];
+        [prefs synchronize];
+        XCTAssertFalse([self.controller applicationShouldOpenUntitledFile:NSApp],
+                       @"a pending folder must suppress the blank untitled document");
+    }
+    @finally
+    {
+        prefs.filesToOpen = savedFiles;
+        prefs.foldersToOpen = savedFolders;
+        [prefs synchronize];
+    }
+}
+
+- (void)testOpenPendingFoldersClearsTheList
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    NSArray *saved = prefs.foldersToOpen;
+    @try
+    {
+        // A non-reachable path is skipped for opening but the list is still cleared.
+        prefs.foldersToOpen = @[@"/nonexistent/path/xyz"];
+        [prefs synchronize];
+        [self.controller openPendingFolders];
+        XCTAssertNil(prefs.foldersToOpen, @"openPendingFolders must clear the list");
+    }
+    @finally
+    {
+        prefs.foldersToOpen = saved;
+        [prefs synchronize];
+    }
+}
+
+@end

--- a/MacDownTests/MPMainControllerMenuTests.m
+++ b/MacDownTests/MPMainControllerMenuTests.m
@@ -1,0 +1,109 @@
+//
+//  MPMainControllerMenuTests.m
+//  MacDown 3000
+//
+
+#import <XCTest/XCTest.h>
+#import "MPMainController.h"
+#import "MPDocument.h"
+
+// Declared for @selector() only: these are the responder-chain actions the nib
+// wires its items to, and neither is exposed in a header.
+@interface MPDocument (MenuActionTesting)
+- (IBAction)toggleFolderSidebar:(id)sender;
+- (IBAction)togglePreviewPane:(id)sender;
+@end
+
+// The folder-workspace menu items live in MainMenu.xib rather than being added
+// programmatically, so that their titles go through the project's per-locale
+// MainMenu.strings workflow. These tests assert they are actually in the nib.
+@interface MPMainControllerMenuTests : XCTestCase
+@end
+
+@implementation MPMainControllerMenuTests
+
+- (NSMenu *)submenuContainingAction:(SEL)action
+{
+    for (NSMenuItem *top in [NSApp mainMenu].itemArray)
+    {
+        NSMenu *submenu = top.submenu;
+        if (submenu && [submenu indexOfItemWithTarget:nil andAction:action] >= 0)
+            return submenu;
+    }
+    return nil;
+}
+
+- (NSMenuItem *)itemInMenu:(NSMenu *)menu withAction:(SEL)action
+{
+    for (NSMenuItem *item in menu.itemArray)
+        if (item.action == action)
+            return item;
+    return nil;
+}
+
+- (void)setUp
+{
+    [super setUp];
+    XCTAssertNotNil([NSApp mainMenu], @"tests must run against the loaded nib");
+}
+
+- (void)testFileMenuHasOpenFolderRightAfterOpen
+{
+    NSMenu *fileMenu = [self submenuContainingAction:@selector(openDocument:)];
+    XCTAssertNotNil(fileMenu);
+
+    // Not -indexOfItemWithTarget:andAction:, which also matches on target:
+    // Open… routes through the responder chain (nil target) while Open Folder…
+    // is wired straight to the delegate.
+    NSInteger openIdx = [fileMenu indexOfItem:
+        [self itemInMenu:fileMenu withAction:@selector(openDocument:)]];
+    NSInteger folderIdx = [fileMenu indexOfItem:
+        [self itemInMenu:fileMenu withAction:@selector(openFolder:)]];
+    XCTAssertNotEqual(folderIdx, -1, @"Open Folder… is missing from the File menu");
+    XCTAssertEqual(folderIdx, openIdx + 1, @"Open Folder… should follow Open…");
+}
+
+- (void)testOpenFolderTargetsTheAppDelegate
+{
+    NSMenu *fileMenu = [self submenuContainingAction:@selector(openDocument:)];
+    NSMenuItem *item = [self itemInMenu:fileMenu
+                             withAction:@selector(openFolder:)];
+    XCTAssertNotNil(item);
+    // Wired to the MPMainController instance in the nib, not the responder chain.
+    XCTAssertTrue([item.target isKindOfClass:[MPMainController class]],
+                  @"Open Folder… must be wired to MPMainController, got %@",
+                  item.target);
+}
+
+- (void)testViewMenuHasSidebarToggleWithCommandBackslash
+{
+    NSMenu *viewMenu = [self submenuContainingAction:@selector(togglePreviewPane:)];
+    XCTAssertNotNil(viewMenu);
+
+    NSMenuItem *toggle = [self itemInMenu:viewMenu
+                               withAction:@selector(toggleFolderSidebar:)];
+    XCTAssertNotNil(toggle, @"Show Sidebar is missing from the View menu");
+    XCTAssertEqualObjects(toggle.keyEquivalent, @"\\");
+    XCTAssertEqual(toggle.keyEquivalentModifierMask, NSEventModifierFlagCommand);
+    XCTAssertNil(toggle.target,
+                 @"the toggle must route through the responder chain to the "
+                 @"key window's document");
+}
+
+// Exactly one of each: a stray programmatic installer would double them up.
+- (void)testFolderMenuItemsAreNotDuplicated
+{
+    NSInteger openFolder = 0, sidebar = 0;
+    for (NSMenuItem *top in [NSApp mainMenu].itemArray)
+    {
+        for (NSMenuItem *item in top.submenu.itemArray)
+        {
+            if (item.action == @selector(openFolder:)) openFolder++;
+            if (item.action == @selector(toggleFolderSidebar:)) sidebar++;
+        }
+    }
+    XCTAssertEqual(openFolder, 1);
+    XCTAssertEqual(sidebar, 1);
+}
+
+@end

--- a/MacDownTests/MPPreferencesTests.m
+++ b/MacDownTests/MPPreferencesTests.m
@@ -1068,6 +1068,29 @@
 }
 
 
+#pragma mark - Folders To Open Tests
+
+- (void)testFoldersToOpenRoundTripsThroughSharedSuite
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    NSArray *saved = prefs.foldersToOpen;            // preserve
+    @try
+    {
+        prefs.foldersToOpen = @[@"/tmp/one", @"/tmp/two"];
+        [prefs synchronize];
+        XCTAssertEqualObjects(prefs.foldersToOpen, (@[@"/tmp/one", @"/tmp/two"]));
+        prefs.foldersToOpen = nil;
+        [prefs synchronize];
+        XCTAssertNil(prefs.foldersToOpen);
+    }
+    @finally
+    {
+        prefs.foldersToOpen = saved;
+        [prefs synchronize];
+    }
+}
+
+
 #pragma mark - Front Matter Migration Tests (Issue #307)
 
 /**

--- a/MacDownTests/MPSidebarSplitViewTests.m
+++ b/MacDownTests/MPSidebarSplitViewTests.m
@@ -1,0 +1,75 @@
+#import <XCTest/XCTest.h>
+#import "MPSidebarSplitView.h"
+
+@interface MPSidebarSplitViewTests : XCTestCase
+@property (strong) MPSidebarSplitView *splitView;
+@end
+
+@implementation MPSidebarSplitViewTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.splitView = [[MPSidebarSplitView alloc]
+        initWithFrame:NSMakeRect(0, 0, 600, 400)];
+    self.splitView.vertical = YES;
+}
+
+- (void)testNotDraggingByDefault
+{
+    XCTAssertFalse(self.splitView.isDraggingDivider,
+                   @"a resize with no drag must not broadcast a width");
+}
+
+- (void)testFlagIsSetOnlyForTheDurationOfTheDrag
+{
+    __block BOOL duringDrag = NO;
+    [self.splitView performDividerDrag:^{
+        duringDrag = self.splitView.isDraggingDivider;
+    }];
+    XCTAssertTrue(duringDrag, @"resizes inside the drag loop must broadcast");
+    XCTAssertFalse(self.splitView.isDraggingDivider, @"and must stop after it");
+}
+
+// NSSplitView's tracking loop runs user code (delegate callbacks); if any of it
+// raised, a stuck flag would make every later layout resize broadcast a width.
+- (void)testFlagIsClearedEvenIfTheDragRaises
+{
+    XCTAssertThrows([self.splitView performDividerDrag:^{
+        [NSException raise:@"MPTestException" format:@"boom"];
+    }]);
+    XCTAssertFalse(self.splitView.isDraggingDivider);
+}
+
+- (void)testNilBodyIsHarmless
+{
+    XCTAssertNoThrow([self.splitView performDividerDrag:nil]);
+    XCTAssertFalse(self.splitView.isDraggingDivider);
+}
+
+// -mouseDown: is what actually brackets NSSplitView's tracking loop; without
+// the override the flag would never be set and width sync would stop working.
+- (void)testMouseDownBracketsTheDrag
+{
+    XCTAssertTrue([MPSidebarSplitView instancesRespondToSelector:@selector(mouseDown:)]);
+    XCTAssertNotEqual(
+        [MPSidebarSplitView instanceMethodForSelector:@selector(mouseDown:)],
+        [NSSplitView instanceMethodForSelector:@selector(mouseDown:)],
+        @"MPSidebarSplitView must override -mouseDown: to mark the drag");
+
+    // A click that misses the divider returns without a tracking loop; the flag
+    // must be back to NO either way.
+    NSEvent *click = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
+                                        location:NSMakePoint(300, 200)
+                                   modifierFlags:0
+                                       timestamp:0
+                                    windowNumber:0
+                                         context:nil
+                                     eventNumber:0
+                                      clickCount:1
+                                        pressure:1.0];
+    XCTAssertNoThrow([self.splitView mouseDown:click]);
+    XCTAssertFalse(self.splitView.isDraggingDivider);
+}
+
+@end

--- a/MacDownTests/MPSidebarSyncCoordinatorTests.m
+++ b/MacDownTests/MPSidebarSyncCoordinatorTests.m
@@ -1,0 +1,229 @@
+#import <XCTest/XCTest.h>
+#import "MPSidebarSyncCoordinator.h"
+
+static NSString * const kMPSidebarWidthDefaultsKey = @"MPSidebarSharedWidth";
+
+@interface MPSidebarSyncCoordinatorTests : XCTestCase
+@property (strong) NSURL *rootA;
+@property (strong) NSURL *rootB;
+@property (strong) NSNumber *savedWidthDefault;
+@end
+
+@implementation MPSidebarSyncCoordinatorTests
+
+- (void)setUp
+{
+    [super setUp];
+    // Distinct roots per test method, so the shared coordinator's accumulated
+    // state can't leak between tests.
+    NSString *unique = [NSProcessInfo processInfo].globallyUniqueString;
+    self.rootA = [NSURL fileURLWithPath:
+        [NSString stringWithFormat:@"/tmp/sync-a-%@", unique] isDirectory:YES];
+    self.rootB = [NSURL fileURLWithPath:
+        [NSString stringWithFormat:@"/tmp/sync-b-%@", unique] isDirectory:YES];
+
+    // Setting a width persists it as the global seed; don't leave the running
+    // user's preference changed.
+    self.savedWidthDefault = [[NSUserDefaults standardUserDefaults]
+        objectForKey:kMPSidebarWidthDefaultsKey];
+}
+
+- (void)tearDown
+{
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if (self.savedWidthDefault)
+        [defaults setObject:self.savedWidthDefault
+                     forKey:kMPSidebarWidthDefaultsKey];
+    else
+        [defaults removeObjectForKey:kMPSidebarWidthDefaultsKey];
+    self.savedWidthDefault = nil;
+    [super tearDown];
+}
+
+- (void)testWidthIsClampedToRange
+{
+    MPSidebarSyncCoordinator *c = [MPSidebarSyncCoordinator sharedCoordinator];
+    [c setSidebarWidth:5000 forRoot:self.rootA source:self];
+    XCTAssertLessThanOrEqual([c sidebarWidthForRoot:self.rootA], 420.0);
+    [c setSidebarWidth:10 forRoot:self.rootA source:self];
+    XCTAssertGreaterThanOrEqual([c sidebarWidthForRoot:self.rootA], 150.0);
+}
+
+- (void)testEqualWidthDoesNotNotify
+{
+    MPSidebarSyncCoordinator *c = [MPSidebarSyncCoordinator sharedCoordinator];
+    [c setSidebarWidth:250 forRoot:self.rootA source:self];
+    __block NSInteger count = 0;
+    id obs = [[NSNotificationCenter defaultCenter]
+        addObserverForName:MPSidebarSyncDidChangeNotification object:nil
+                     queue:nil usingBlock:^(NSNotification *n) { count++; }];
+    // equal → no broadcast (breaks the loop)
+    [c setSidebarWidth:250 forRoot:self.rootA source:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:obs];
+    XCTAssertEqual(count, 0);
+    XCTAssertEqualWithAccuracy([c sidebarWidthForRoot:self.rootA], 250.0, 0.5);
+}
+
+- (void)testChangedWidthNotifiesWithKindAndRoot
+{
+    MPSidebarSyncCoordinator *c = [MPSidebarSyncCoordinator sharedCoordinator];
+    [c setSidebarWidth:200 forRoot:self.rootA source:self];
+    id token = [NSObject new];
+    XCTestExpectation *e = [self expectationWithDescription:@"notified"];
+    id obs = [[NSNotificationCenter defaultCenter]
+        addObserverForName:MPSidebarSyncDidChangeNotification object:token
+                     queue:nil usingBlock:^(NSNotification *n) {
+            XCTAssertEqualObjects(n.userInfo[MPSidebarSyncKindKey],
+                                  MPSidebarSyncKindWidth);
+            XCTAssertEqualObjects(n.userInfo[MPSidebarSyncRootKey], self.rootA);
+            [e fulfill];
+        }];
+    [c setSidebarWidth:321 forRoot:self.rootA source:token];
+    [self waitForExpectations:@[e] timeout:1.0];
+    [[NSNotificationCenter defaultCenter] removeObserver:obs];
+}
+
+- (void)testVisibleToggleNotifiesOnlyOnChange
+{
+    MPSidebarSyncCoordinator *c = [MPSidebarSyncCoordinator sharedCoordinator];
+    XCTAssertTrue([c sidebarVisibleForRoot:self.rootA], @"defaults to visible");
+    __block NSInteger count = 0;
+    id obs = [[NSNotificationCenter defaultCenter]
+        addObserverForName:MPSidebarSyncDidChangeNotification object:nil
+                     queue:nil usingBlock:^(NSNotification *n) {
+            if ([n.userInfo[MPSidebarSyncKindKey]
+                    isEqualToString:MPSidebarSyncKindVisible])
+                count++;
+        }];
+    // no change → no notify
+    [c setSidebarVisible:YES forRoot:self.rootA source:self];
+    // change → notify
+    [c setSidebarVisible:NO forRoot:self.rootA source:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:obs];
+    XCTAssertEqual(count, 1);
+    XCTAssertFalse([c sidebarVisibleForRoot:self.rootA]);
+}
+
+#pragma mark - Per-workspace scoping
+
+- (void)testWidthIsScopedPerRoot
+{
+    MPSidebarSyncCoordinator *c = [MPSidebarSyncCoordinator sharedCoordinator];
+    [c setSidebarWidth:200 forRoot:self.rootA source:self];
+    [c setSidebarWidth:380 forRoot:self.rootB source:self];
+    XCTAssertEqualWithAccuracy([c sidebarWidthForRoot:self.rootA], 200.0, 0.5);
+    XCTAssertEqualWithAccuracy([c sidebarWidthForRoot:self.rootB], 380.0, 0.5,
+                               @"resizing one workspace must not resize another");
+}
+
+- (void)testVisibilityIsScopedPerRoot
+{
+    MPSidebarSyncCoordinator *c = [MPSidebarSyncCoordinator sharedCoordinator];
+    [c setSidebarVisible:NO forRoot:self.rootA source:self];
+    XCTAssertFalse([c sidebarVisibleForRoot:self.rootA]);
+    XCTAssertTrue([c sidebarVisibleForRoot:self.rootB],
+                  @"hiding one workspace's sidebar must not hide another's");
+}
+
+- (void)testWidthChangeOnlyNotifiesForItsOwnRoot
+{
+    MPSidebarSyncCoordinator *c = [MPSidebarSyncCoordinator sharedCoordinator];
+    [c setSidebarWidth:200 forRoot:self.rootA source:self];
+    __block NSInteger forA = 0, forB = 0;
+    id obs = [[NSNotificationCenter defaultCenter]
+        addObserverForName:MPSidebarSyncDidChangeNotification object:nil
+                     queue:nil usingBlock:^(NSNotification *n) {
+            if (![n.userInfo[MPSidebarSyncKindKey]
+                     isEqualToString:MPSidebarSyncKindWidth])
+                return;
+            NSURL *root = n.userInfo[MPSidebarSyncRootKey];
+            if ([root isEqual:self.rootA]) forA++;
+            if ([root isEqual:self.rootB]) forB++;
+        }];
+    [c setSidebarWidth:345 forRoot:self.rootA source:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:obs];
+    XCTAssertEqual(forA, 1);
+    XCTAssertEqual(forB, 0, @"an unrelated workspace must not be told to resize");
+}
+
+// An open workspace the user has never resized must keep its width when a
+// different workspace is dragged: it has its own entry from the first read, so
+// it stops tracking the global seed.
+- (void)testUntouchedWorkspaceDoesNotFollowAnotherResize
+{
+    MPSidebarSyncCoordinator *c = [MPSidebarSyncCoordinator sharedCoordinator];
+    // Both widths are stated outright rather than derived from whatever the
+    // last run persisted: near the 150-420 clamp a relative delta collapses to
+    // no change, and the assertion would then hold no matter what.
+    [c setSidebarWidth:200 forRoot:self.rootA source:self];
+    CGFloat before = [c sidebarWidthForRoot:self.rootB];   // never dragged
+    XCTAssertEqualWithAccuracy(before, 200.0, 0.5,
+                               @"a fresh workspace starts at the last width used");
+
+    [c setSidebarWidth:400 forRoot:self.rootA source:self];
+    XCTAssertEqualWithAccuracy([c sidebarWidthForRoot:self.rootB], 200.0, 0.5,
+                               @"resizing one workspace must not move another "
+                               @"that the user has not touched");
+}
+
+// A workspace seen for the first time opens at the last width the user chose,
+// so new windows don't jump back to the built-in default.
+- (void)testUnseenRootInheritsLastUsedWidth
+{
+    MPSidebarSyncCoordinator *c = [MPSidebarSyncCoordinator sharedCoordinator];
+    [c setSidebarWidth:295 forRoot:self.rootA source:self];
+    NSURL *fresh = [NSURL fileURLWithPath:
+        [NSString stringWithFormat:@"/tmp/sync-fresh-%@",
+            [NSProcessInfo processInfo].globallyUniqueString] isDirectory:YES];
+    XCTAssertEqualWithAccuracy([c sidebarWidthForRoot:fresh], 295.0, 0.5);
+}
+
+- (void)testExpansionIsPerRootAndOrderIndependent
+{
+    MPSidebarSyncCoordinator *c = [MPSidebarSyncCoordinator sharedCoordinator];
+    NSString *x = [self.rootA.path stringByAppendingPathComponent:@"x"];
+    NSString *y = [self.rootA.path stringByAppendingPathComponent:@"y"];
+    NSString *z = [self.rootB.path stringByAppendingPathComponent:@"z"];
+    [c setExpandedPaths:@[x, y] forRoot:self.rootA source:self];
+    [c setExpandedPaths:@[z] forRoot:self.rootB source:self];
+
+    XCTAssertEqualObjects([NSSet setWithArray:[c expandedPathsForRoot:self.rootA]],
+                          ([NSSet setWithObjects:x, y, nil]));
+    XCTAssertEqualObjects([c expandedPathsForRoot:self.rootB], @[z]);
+
+    // Same set, different order → treated as no change.
+    __block NSInteger count = 0;
+    id obs = [[NSNotificationCenter defaultCenter]
+        addObserverForName:MPSidebarSyncDidChangeNotification object:nil
+                     queue:nil usingBlock:^(NSNotification *n) {
+            if ([n.userInfo[MPSidebarSyncKindKey]
+                    isEqualToString:MPSidebarSyncKindExpansion])
+                count++;
+        }];
+    [c setExpandedPaths:@[y, x] forRoot:self.rootA source:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:obs];
+    XCTAssertEqual(count, 0);
+}
+
+#pragma mark - Tree change announcements
+
+- (void)testFileSavedNotificationCarriesURL
+{
+    MPSidebarSyncCoordinator *c = [MPSidebarSyncCoordinator sharedCoordinator];
+    NSURL *saved = [self.rootA URLByAppendingPathComponent:@"fresh.md"];
+    id token = [NSObject new];
+    XCTestExpectation *e = [self expectationWithDescription:@"notified"];
+    id obs = [[NSNotificationCenter defaultCenter]
+        addObserverForName:MPSidebarSyncDidChangeNotification object:token
+                     queue:nil usingBlock:^(NSNotification *n) {
+            XCTAssertEqualObjects(n.userInfo[MPSidebarSyncKindKey],
+                                  MPSidebarSyncKindTreeChanged);
+            XCTAssertEqualObjects(n.userInfo[MPSidebarSyncURLKey], saved);
+            [e fulfill];
+        }];
+    [c notifyFileSavedAtURL:saved source:token];
+    [self waitForExpectations:@[e] timeout:1.0];
+    [[NSNotificationCenter defaultCenter] removeObserver:obs];
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Code blocks get syntax highlighting via Prism, supporting numerous programming a
 - **Jekyll front-matter** for static site generators
 - **Export to HTML or PDF** with customizable styling
 
+### Folder Browsing
+
+Open an entire folder as a workspace with `macdown .` from the terminal or via **File › Open Folder…** in the menu. A sidebar lists subfolders and Markdown files in the chosen directory; double-click a file to open it as a tab in the same window, or, if it is already open elsewhere, to bring that window to the front. Press **⌘\\** to show or hide the sidebar. Right-click any item in the sidebar for quick access to **Reveal in Finder** or **Copy Path**.
+
 ### Editor Features
 
 - **Auto-completion**: Automatic bracket and quote pairing, list continuation, and formatting shortcuts (customizable or disable)

--- a/macdown-cmd/main.m
+++ b/macdown-cmd/main.m
@@ -45,6 +45,19 @@ void MPCollectForMacDown(NSOrderedSet<NSURL *> *urls)
     [defaults synchronize];
 }
 
+void MPCollectFoldersForMacDown(NSOrderedSet<NSURL *> *urls)
+{
+    NSUserDefaults *defaults =
+        [[NSUserDefaults alloc] initWithSuiteNamed:kMPApplicationSuiteName];
+    NSMutableArray<NSString *> *paths =
+        [[NSMutableArray alloc] initWithCapacity:urls.count];
+    for (NSURL *url in urls)
+        [paths addObject:url.path];
+    [defaults setObject:paths forKey:kMPFoldersToOpenKey
+           inSuiteNamed:kMPApplicationSuiteName];
+    [defaults synchronize];
+}
+
 /**
  * Data piped to macdown through stdin.
  * 
@@ -103,15 +116,25 @@ int main(int argc, const char * argv[])
         // be opened later.
         NSString *pwd = [NSFileManager defaultManager].currentDirectoryPath;
         NSURL *pwdUrl = [NSURL fileURLWithPath:pwd isDirectory:YES];
-        NSMutableOrderedSet<NSURL *> *urls = [NSMutableOrderedSet orderedSet];
+        NSFileManager *fm = [NSFileManager defaultManager];
+        NSMutableOrderedSet<NSURL *> *fileURLs = [NSMutableOrderedSet orderedSet];
+        NSMutableOrderedSet<NSURL *> *folderURLs = [NSMutableOrderedSet orderedSet];
         for (NSString *arg in argproc.arguments)
         {
             NSString *escaped =
                 [arg stringByAddingPercentEscapesUsingEncoding:kMPPathEncoding];
             NSURL *url = [NSURL URLWithString:escaped relativeToURL:pwdUrl];
-            [urls addObject:url];
+            BOOL isDir = NO;
+            if ([fm fileExistsAtPath:url.path isDirectory:&isDir] && isDir)
+                [folderURLs addObject:url];
+            else
+                [fileURLs addObject:url];
         }
-        MPCollectForMacDown(urls);
+        // Both run unconditionally: each overwrites its key, so an empty set
+        // clears whatever a previous invocation left behind. Skipping the empty
+        // one would leave that list to be opened on the next launch.
+        MPCollectForMacDown(fileURLs);
+        MPCollectFoldersForMacDown(folderURLs);
 
         // Launch MacDown.
         [[NSWorkspace sharedWorkspace] launchAppWithBundleIdentifier:kMPApplicationBundleIdentifier options:NSWorkspaceLaunchDefault additionalEventParamDescriptor:nil launchIdentifier:nil];


### PR DESCRIPTION
## Summary

Adds **folder workspaces** to MacDown 3000: browse a folder of Markdown files in a hideable sidebar and open them as **native macOS window tabs**, instead of only opening individual files. Reachable from a new **File → Open Folder…** command and from the command line with **`macdown .`**.

This is an additive feature — the editor/preview pipeline and existing single-file behaviour are untouched, and there are **no new dependencies**.

## What you get

- **Folder sidebar** (an `NSOutlineView` source list) showing subfolders and Markdown files (`.md` / `.markdown`), dotfiles excluded.
- **Open files as native tabs** — double-click (or Enter) opens a file in the same window as an OS tab; each file is its own document with its own undo/dirty state. Re-opening an already-open file just focuses its tab.
- **`macdown .`** — the CLI learns to accept a directory and opens it as a workspace (files still open as before; `macdown file.md` is unchanged).
- **Hide/show with ⌘\\**, **Reveal in Finder / Copy Path** context menu, and **live refresh** when the folder changes on disk.
- **Seamless tab switching** — sidebar width, visibility, and expanded folders stay in sync across a workspace's tabs (editor/preview split and per-file selection stay per-tab).

## How it works

MacDown is a standard `NSDocument` app (one document per window). Rather than refactor that, this leans into **native window tabbing** (`addTabbedWindow:`): each file stays its own `MPDocument`, and the OS merges their windows into one tabbed window. The sidebar is added per-window by nesting the existing editor/preview split inside an outer `NSSplitView`.

New components (all under `MacDown/Code/Sidebar/`):
- `MPFileNode` — filesystem-tree model (filtering + folders-first sort).
- `MPFolderWatcher` — recursive FSEvents watcher (respects the existing remote-volume guard).
- `MPFolderSidebarViewController` — the source list + open/activation + context menu.
- `MPSidebarSyncCoordinator` — shares sidebar state across tabs.

Wiring:
- `MPDocument` gains `workspaceRootURL`, sidebar install/toggle, and the open-as-tab flow.
- `MPMainController` gains `Open Folder…` and inserts its menu items by **member selector** (so they install in non-English locales too).
- `macdown-cmd` routes directory arguments to a new shared-defaults key.

## Testing

- New `XCTest` coverage for the model, watcher, sync coordinator, directory routing, menu installation, tab-reuse lookup, and workspace-root propagation. The full suite passes (the pre-existing `HGMarkdownHighlighterTests` theme failures are unrelated to this change).
- Window tabbing and the view nesting can't be exercised headlessly; those were verified manually in the running app: Open Folder… / `macdown .`, double-click-to-tab + tab reuse, ⌘\\ toggle, live refresh, Reveal/Copy Path, and cross-tab sync.

## Notes / design decisions

- **Per-tab sidebar, kept in sync.** Native tabs are separate windows, so each carries its own sidebar; the coordinator keeps width/visibility/expansion consistent (no-op updates are ignored to avoid feedback loops, and width only syncs on a real divider drag).
- **No persistence across launches** (start fresh), other than the sidebar's default width.
- Happy to split this into smaller commits, adjust scope, or iterate on anything.

Closes/relates to: _(feel free to link a folder-browsing feature request if one exists)_
