### PR TITLE
Fix Quick Look extension entitlements stripped by release signing

### DIFF
--- a/.github/actions/build-macdown/action.yml
+++ b/.github/actions/build-macdown/action.yml
@@ -51,7 +51,6 @@ runs:
             CODE_SIGN_STYLE="Manual" \
             DEVELOPMENT_TEAM="${{ inputs.team-id }}" \
             ENABLE_HARDENED_RUNTIME=YES \
-            CODE_SIGN_ENTITLEMENTS="MacDown/MacDown.entitlements" \
             $VERSION_ARGS \
             | tee build.log
         else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,16 +311,21 @@ jobs:
 
           echo "✅ CLI binary signed successfully"
 
-          # Re-sign the app bundle to update the seal after modifying nested component.
-          # --entitlements MUST be re-applied here: the Xcode build signs the app with
-          # CODE_SIGN_ENTITLEMENTS, but this re-sign replaces that signature. Without
-          # --entitlements the app ships with NO entitlements, breaking NSSavePanel
-          # (Move To / Save As…) with ViewBridge error 14 on macOS Sequoia and later.
-          # See issue #302.
+          # Re-sign nested components inside-out to preserve per-component
+          # entitlements. Using --deep would apply the app's entitlements to
+          # ALL nested components, stripping the QL extension's sandbox
+          # entitlement and preventing macOS from loading it (issue #284).
+          echo "🔐 Re-signing Quick Look extension..."
+          codesign --sign "$IDENTITY" \
+            --force \
+            --options runtime \
+            --entitlements "MacDownQuickLook/MacDownQuickLook.entitlements" \
+            --timestamp \
+            "build/MacDown 3000.app/Contents/PlugIns/MacDownQuickLook.appex"
+
           echo "🔐 Re-signing app bundle to update code signature seal..."
           codesign --sign "$IDENTITY" \
             --force \
-            --deep \
             --options runtime \
             --entitlements "MacDown/MacDown.entitlements" \
             --timestamp \
@@ -383,6 +388,23 @@ jobs:
             exit 1
           fi
           echo "✅ App bundle has the user-selected.read-write entitlement"
+
+          # Verify Quick Look extension has sandbox entitlement (issue #284)
+          echo "🔍 Verifying Quick Look extension entitlements..."
+          QL_APPEX="build/MacDown 3000.app/Contents/PlugIns/MacDownQuickLook.appex"
+          if [ ! -d "$QL_APPEX" ]; then
+            echo "::error::Quick Look extension not found at expected location: $QL_APPEX"
+            exit 1
+          fi
+          QL_ENTITLEMENTS=$(codesign -d --entitlements :- "$QL_APPEX" 2>/dev/null || true)
+          if [[ "$QL_ENTITLEMENTS" != *"com.apple.security.app-sandbox"* ]]; then
+            echo "::error::Quick Look extension is missing com.apple.security.app-sandbox entitlement"
+            echo "::error::Without sandbox, macOS will not load the extension. See issue #284."
+            echo "Entitlements found:"
+            echo "$QL_ENTITLEMENTS"
+            exit 1
+          fi
+          echo "✅ Quick Look extension has sandbox entitlement"
 
           echo "✅ Application bundle ready"
 
@@ -450,6 +472,25 @@ jobs:
             exit 1
           fi
           echo "✅ App inside DMG has the user-selected.read-write entitlement"
+
+          # Verify Quick Look extension entitlements inside DMG (issue #284)
+          echo "🔍 Verifying Quick Look extension entitlements inside DMG..."
+          QL_APPEX_IN_DMG="/tmp/dmg-verify/MacDown 3000.app/Contents/PlugIns/MacDownQuickLook.appex"
+          if [ ! -d "$QL_APPEX_IN_DMG" ]; then
+            echo "::error::Quick Look extension not found in DMG"
+            hdiutil detach /tmp/dmg-verify
+            exit 1
+          fi
+          QL_DMG_ENTITLEMENTS=$(codesign -d --entitlements :- "$QL_APPEX_IN_DMG" 2>/dev/null || true)
+          if [[ "$QL_DMG_ENTITLEMENTS" != *"com.apple.security.app-sandbox"* ]]; then
+            echo "::error::Quick Look extension in DMG is missing com.apple.security.app-sandbox entitlement"
+            echo "::error::Without sandbox, macOS will not load the extension. See issue #284."
+            echo "Entitlements found:"
+            echo "$QL_DMG_ENTITLEMENTS"
+            hdiutil detach /tmp/dmg-verify
+            exit 1
+          fi
+          echo "✅ Quick Look extension inside DMG has sandbox entitlement"
 
           # Verify CLI binary inside DMG
           echo "🔍 Verifying CLI binary inside DMG..."

--- a/.github/workflows/staple-release.yml
+++ b/.github/workflows/staple-release.yml
@@ -288,6 +288,25 @@ jobs:
           fi
           echo "    Entitlement present: com.apple.security.files.user-selected.read-write"
 
+          # Verify Quick Look extension entitlements (issue #284)
+          echo "  ✓ Checking Quick Look extension entitlements..."
+          QL_APPEX_FINAL="/tmp/final-verify/MacDown 3000.app/Contents/PlugIns/MacDownQuickLook.appex"
+          if [ ! -d "$QL_APPEX_FINAL" ]; then
+            echo "::error::Quick Look extension not found in final verification"
+            hdiutil detach /tmp/final-verify
+            exit 1
+          fi
+          QL_FINAL_ENTITLEMENTS=$(codesign -d --entitlements :- "$QL_APPEX_FINAL" 2>/dev/null || true)
+          if [[ "$QL_FINAL_ENTITLEMENTS" != *"com.apple.security.app-sandbox"* ]]; then
+            echo "::error::Published Quick Look extension is missing com.apple.security.app-sandbox entitlement"
+            echo "::error::Without sandbox, macOS will not load the extension. See issue #284."
+            echo "Entitlements found:"
+            echo "$QL_FINAL_ENTITLEMENTS"
+            hdiutil detach /tmp/final-verify
+            exit 1
+          fi
+          echo "    Entitlement present: com.apple.security.app-sandbox (Quick Look extension)"
+
           # Get app version for logging
           APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" \
                         "/tmp/final-verify/MacDown 3000.app/Contents/Info.plist" 2>/dev/null || echo "unknown")

--- a/MacDownQuickLook/MacDownQuickLook.entitlements
+++ b/MacDownQuickLook/MacDownQuickLook.entitlements
@@ -4,6 +4,8 @@
 <dict>
     <key>com.apple.security.app-sandbox</key>
     <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
 </dict>


### PR DESCRIPTION
## Summary

- Remove global `CODE_SIGN_ENTITLEMENTS` override from build action — each target now uses its own entitlements as declared in the Xcode project
- Replace `codesign --deep` with inside-out signing — QL extension signed with its own entitlements first, then outer app bundle
- Add `com.apple.security.network.client` to QL extension entitlements (WKWebView needs it for subprocess IPC in sandbox)
- Add sandbox entitlement verification gates in release and staple workflows

## Context

The Quick Look extension shipped in RC 3000.0.7-rc.2 without `com.apple.security.app-sandbox` because the release pipeline overwrote its entitlements in two places. macOS refused to load the unsandboxed extension. Additionally, the extension was missing `network.client`, causing WKWebView's subprocesses to crash inside the sandbox.

Verified locally: QL preview renders markdown after these changes.

Related to #284

## Test plan

- [x] 1026 tests pass (0 unexpected), matches baseline
- [x] Local QL preview confirmed working (Finder Space on .md file)
- [ ] CI release-build workflow passes with new entitlement gates
- [ ] Next RC: @caius confirms QL preview works in signed/notarized build