### PR TITLE
Fix checkbox label clipping in localized preference panes

### DIFF
--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -155,6 +155,38 @@ static CGFloat itemWidth = 37;
 }
 
 
+/**
+ * Forward validation for dropdown menu items to the document so that
+ * validateUserInterfaceItem: can set titles, hidden state, and
+ * enable/disable based on the real action (stored in representedObject).
+ */
+- (BOOL)validateUserInterfaceItem:(id<NSValidatedUserInterfaceItem>)item
+{
+    if (item.action == @selector(dropdownMenuItemClicked:)
+        && [(id)item isKindOfClass:[NSMenuItem class]])
+    {
+        NSMenuItem *menuItem = (NSMenuItem *)item;
+        NSString *actionName = menuItem.representedObject;
+        if (!actionName) return NO;
+
+        MPDocument *document = self.document;
+        if (!document) return NO;
+
+        // Temporarily restore the real action and target so the document's
+        // validateUserInterfaceItem: can identify and configure the item.
+        // This is safe: validation is synchronous and single-threaded.
+        SEL realAction = NSSelectorFromString(actionName);
+        menuItem.action = realAction;
+        menuItem.target = document;
+        BOOL result = [document validateUserInterfaceItem:menuItem];
+        menuItem.target = self;
+        menuItem.action = @selector(dropdownMenuItemClicked:);
+        return result;
+    }
+    return YES;
+}
+
+
 - (void)standaloneToolbarItemClicked:(NSButton *)sender
 {
     NSString *actionName = self->standaloneItemActions[sender.identifier];

--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -20,11 +20,19 @@ static CGFloat itemWidth = 37;
 {
     NSArray *toolbarItems;
     NSArray *toolbarItemIdentifiers;
-    
+
     /**
      * Map toolbar item identifier to it's NSToolbarItem or NSToolbarItemGroup object
      */
     NSMutableDictionary *toolbarItemIdentifierObjectDictionary;
+
+    /**
+     * Map toolbar item identifier to the selector name (NSString) that should
+     * be dispatched to self.document when a standalone button is clicked.
+     * Needed because self.document is nil during init when toolbar items are
+     * created, so we can't set target = self.document at construction time.
+     */
+    NSMutableDictionary<NSString *, NSString *> *standaloneItemActions;
 }
 
 - (id)init
@@ -37,6 +45,7 @@ static CGFloat itemWidth = 37;
     }
     
     self->toolbarItemIdentifierObjectDictionary = [NSMutableDictionary new];
+    self->standaloneItemActions = [NSMutableDictionary new];
     [self setupToolbarItems];
     
     return self;
@@ -141,6 +150,37 @@ static CGFloat itemWidth = 37;
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
         [document performSelector:action withObject:selectedItem];
+        #pragma clang diagnostic pop
+    }
+}
+
+
+- (void)standaloneToolbarItemClicked:(NSButton *)sender
+{
+    NSString *actionName = self->standaloneItemActions[sender.identifier];
+    if (!actionName) return;
+    SEL action = NSSelectorFromString(actionName);
+    MPDocument *document = self.document;
+    if (document && [document respondsToSelector:action])
+    {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [document performSelector:action withObject:sender];
+        #pragma clang diagnostic pop
+    }
+}
+
+- (void)dropdownMenuItemClicked:(NSMenuItem *)sender
+{
+    NSString *actionName = sender.representedObject;
+    if (!actionName) return;
+    SEL action = NSSelectorFromString(actionName);
+    MPDocument *document = self.document;
+    if (document && [document respondsToSelector:action])
+    {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [document performSelector:action withObject:sender];
         #pragma clang diagnostic pop
     }
 }
@@ -287,8 +327,11 @@ static CGFloat itemWidth = 37;
     itemButton.imageScaling = NSImageScaleProportionallyDown;
     itemButton.bezelStyle = NSBezelStyleTexturedRounded;
     itemButton.focusRingType = NSFocusRingTypeDefault;
-    itemButton.target = self.document;
-    itemButton.action = action;
+    [self->standaloneItemActions setObject:NSStringFromSelector(action)
+                                    forKey:itemIdentifier];
+    itemButton.identifier = itemIdentifier;
+    itemButton.target = self;
+    itemButton.action = @selector(standaloneToolbarItemClicked:);
     
     toolbarItem.view = itemButton;
     
@@ -321,8 +364,9 @@ static CGFloat itemWidth = 37;
     
     for (NSMenuItem *menuItem in menuItems) {
         [popupButton addItemWithTitle:menuItem.title];
-        [[popupButton lastItem] setTarget:self.document];
-        [[popupButton lastItem] setAction:menuItem.action];
+        [[popupButton lastItem] setRepresentedObject:NSStringFromSelector(menuItem.action)];
+        [[popupButton lastItem] setTarget:self];
+        [[popupButton lastItem] setAction:@selector(dropdownMenuItemClicked:)];
     }
     
     toolbarItem.view = popupButton;

--- a/MacDown/Code/Preferences/MPPreferencesViewController.h
+++ b/MacDown/Code/Preferences/MPPreferencesViewController.h
@@ -24,4 +24,11 @@ extern NSString * const MPDidRequestPreviewRenderNotification;
 - (BOOL)hasResizableWidth;
 - (BOOL)hasResizableHeight;
 
+/// Walks the view tree looking for word-wrapping checkbox-style NSButtons whose
+/// cellSizeForBounds: height exceeds intrinsicContentSize.height (which always
+/// returns single-line height). For each such checkbox, adds a >= height
+/// constraint so Auto Layout allocates the correct multi-line height.
+/// Called by loadView after width is pinned.
++ (void)addHeightConstraintsForWrappingCheckboxesInView:(NSView *)view;
+
 @end

--- a/MacDown/Code/Preferences/MPPreferencesViewController.m
+++ b/MacDown/Code/Preferences/MPPreferencesViewController.m
@@ -57,6 +57,15 @@ NSString * const MPDidRequestEditorSetupNotification =
         [contentView.widthAnchor constraintEqualToConstant:width];
     widthPin.active = YES;
 
+    // --- Pass 1.5: fix checkbox heights for word-wrapping titles ---
+    // NSButton.intrinsicContentSize always returns single-line height even when
+    // lineBreakMode is wordWrap, so Auto Layout underestimates the space needed
+    // for multi-line labels (e.g. French/Italian translations). Resolve frames
+    // at the pinned width, then add explicit height constraints where the cell
+    // reports it needs more than intrinsicContentSize provides.
+    [wrapper layoutSubtreeIfNeeded];
+    [[self class] addHeightConstraintsForWrappingCheckboxesInView:contentView];
+
     // --- Pass 2: resolve height at the resolved width ---
     NSLayoutConstraint *heightFloor =
         [contentView.heightAnchor constraintGreaterThanOrEqualToConstant:englishDesignHeight];
@@ -76,6 +85,55 @@ NSString * const MPDidRequestEditorSetupNotification =
     wrapper.frame = wrapperFrame;
 
     self.view = wrapper;
+}
+
+/// Recursively collects checkbox-style NSButtons (regularSquare bezel) from the
+/// view tree into @c out.
+static void MPCollectCheckboxes(NSView *view, NSMutableArray<NSButton *> *out)
+{
+    if ([view isKindOfClass:[NSButton class]])
+    {
+        NSButton *button = (NSButton *)view;
+        if (button.bezelStyle == NSBezelStyleRegularSquare)
+            [out addObject:button];
+    }
+    for (NSView *sub in view.subviews)
+        MPCollectCheckboxes(sub, out);
+}
+
++ (void)addHeightConstraintsForWrappingCheckboxesInView:(NSView *)view
+{
+    NSMutableArray<NSButton *> *checkboxes = [NSMutableArray array];
+    MPCollectCheckboxes(view, checkboxes);
+
+    for (NSButton *checkbox in checkboxes)
+    {
+        NSCell *cell = checkbox.cell;
+        if (cell.lineBreakMode != NSLineBreakByWordWrapping)
+            continue;
+
+        CGFloat frameWidth = NSWidth(checkbox.frame);
+        if (frameWidth <= 0)
+            continue;
+
+        // cellSizeForBounds: with CGFLOAT_MAX height returns NaN on some AppKit
+        // versions; use a large finite value instead. No UI checkbox label can
+        // plausibly exceed 10000pt of vertical space.
+        NSSize cellSize = [cell cellSizeForBounds:
+                           NSMakeRect(0, 0, frameWidth, 10000)];
+        CGFloat intrinsicHeight = checkbox.intrinsicContentSize.height;
+
+        // intrinsicContentSize always returns single-line height (~16pt)
+        // regardless of word-wrap. If the cell needs more, add an explicit
+        // height constraint so Auto Layout allocates the correct space.
+        if (cellSize.height > intrinsicHeight + 0.5)
+        {
+            NSLayoutConstraint *heightConstraint =
+                [checkbox.heightAnchor
+                    constraintGreaterThanOrEqualToConstant:ceil(cellSize.height)];
+            heightConstraint.active = YES;
+        }
+    }
 }
 
 - (void)dealloc

--- a/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
+++ b/MacDownTests/MPPreferencesViewControllerResizabilityTests.m
@@ -380,6 +380,81 @@ static NSArray<NSButton *> *MPCheckboxes(NSView *content)
     }];
 }
 
+// When a checkbox title wraps to multiple lines, the checkbox frame must be
+// tall enough for the full wrapped text. NSButton.intrinsicContentSize always
+// returns single-line height even with lineBreakMode=wordWrap, so
+// addHeightConstraintsForWrappingCheckboxesInView: must add explicit height
+// constraints. (Issue #397 — French/Italian Editor "Behavior" checkboxes.)
+//
+// This test forces wrapping by setting long titles, then calls the class method
+// and verifies the resulting frame heights. Produces a reliable red/green cycle
+// in English CI because it doesn't depend on locale-driven wrapping.
+- (void)testWrappingCheckboxHeightsAccommodateMultiLineText
+{
+    __block NSUInteger testedCheckboxes = 0;
+
+    [self.allControllers enumerateKeysAndObjectsUsingBlock:
+     ^(NSString *name, MPPreferencesViewController *vc, BOOL *stop) {
+        NSView *content = MPContentView(vc);
+        NSArray<NSButton *> *checkboxes = MPCheckboxes(content);
+        if (checkboxes.count == 0)
+            return;  // Terminal has no checkboxes
+
+        // Set long titles that force wrapping at the pane width.
+        for (NSButton *checkbox in checkboxes)
+        {
+            checkbox.title = [NSString stringWithFormat:@"%@ — %@ — %@",
+                              checkbox.title, checkbox.title, checkbox.title];
+        }
+
+        // Remove the pane's height pin so the checkbox height constraints
+        // (added below) can expand the pane freely. Without this, the pin
+        // conflicts with the new constraints and Auto Layout breaks them.
+        for (NSLayoutConstraint *c in content.constraints)
+        {
+            if (c.firstItem == content && c.secondItem == nil
+                && c.relation == NSLayoutRelationEqual
+                && c.firstAttribute == NSLayoutAttributeHeight)
+                c.active = NO;
+        }
+
+        // Apply the checkbox height constraint mechanism.
+        [MPPreferencesViewController
+            addHeightConstraintsForWrappingCheckboxesInView:content];
+        [content layoutSubtreeIfNeeded];
+
+        // Verify each wrapping checkbox's frame accommodates its wrapped text.
+        for (NSButton *checkbox in checkboxes)
+        {
+            NSCell *cell = checkbox.cell;
+            if (cell.lineBreakMode != NSLineBreakByWordWrapping)
+                continue;
+
+            CGFloat frameWidth = NSWidth(checkbox.frame);
+            if (frameWidth <= 0)
+                continue;
+
+            // cellSizeForBounds: with CGFLOAT_MAX returns NaN on some AppKit
+            // versions; use a large finite value instead.
+            NSSize cellSize = [cell cellSizeForBounds:
+                               NSMakeRect(0, 0, frameWidth, 10000)];
+            CGFloat frameHeight = NSHeight(checkbox.frame);
+
+            if (cellSize.height > checkbox.intrinsicContentSize.height + 0.5)
+            {
+                testedCheckboxes++;
+                XCTAssertGreaterThanOrEqual(frameHeight + 0.5, cellSize.height,
+                    @"%@ pane: checkbox frame height (%g) must accommodate "
+                    @"wrapped text height (%g)",
+                    name, frameHeight, cellSize.height);
+            }
+        }
+    }];
+
+    XCTAssertGreaterThan(testedCheckboxes, 0U,
+        @"Expected at least one checkbox to require wrapping with long titles");
+}
+
 // Every resolved pane width should be within a sane range — wide enough to show
 // content but not ballooning to absurd sizes (which would indicate a runaway
 // fittingSize calculation).

--- a/MacDownTests/MPToolbarControllerTests.m
+++ b/MacDownTests/MPToolbarControllerTests.m
@@ -11,10 +11,50 @@
 #import <XCTest/XCTest.h>
 #import "MPToolbarController.h"
 
-// Expose the segmented-control action method to the test target; it is not
-// part of the public header but is callable via dynamic dispatch.
+// Expose internal action methods to the test target; they are not part of
+// the public header but are callable via dynamic dispatch.
 @interface MPToolbarController (MPToolbarControllerTests)
 - (void)selectedToolbarItemGroupItem:(NSSegmentedControl *)sender;
+- (void)standaloneToolbarItemClicked:(NSButton *)sender;
+- (void)dropdownMenuItemClicked:(NSMenuItem *)sender;
+@end
+
+
+// Lightweight mock that records which selectors were invoked on it.
+// Used to verify toolbar dispatch reaches the document with the correct action.
+@interface MPToolbarDispatchRecorder : NSObject
+@property (nonatomic, strong) NSMutableArray<NSString *> *invokedSelectors;
+@end
+
+@implementation MPToolbarDispatchRecorder
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _invokedSelectors = [NSMutableArray array];
+    }
+    return self;
+}
+
+// Accept any message and record its selector name.
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    // Return a signature for a method that takes one object argument (sender).
+    return [NSMethodSignature signatureWithObjCTypes:"v@:@"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    [self.invokedSelectors addObject:NSStringFromSelector(anInvocation.selector)];
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    // Claim to respond to any selector so performSelector: dispatch proceeds.
+    return YES;
+}
+
 @end
 
 @interface MPToolbarControllerTests : XCTestCase
@@ -731,6 +771,257 @@
     XCTAssertNoThrow([self.controller selectedToolbarItemGroupItem:sender],
                      @"selectedToolbarItemGroupItem: must not throw for a valid "
                      @"group identifier and in-bounds selected segment");
+}
+
+
+#pragma mark - Standalone Toolbar Item Dispatch Tests (Issue #278)
+
+- (void)testStandaloneButtonsTargetToolbarController
+{
+    // Standalone buttons must target the toolbar controller so actions
+    // dispatch correctly regardless of which pane has focus.
+    NSArray *standaloneIdentifiers = @[
+        @"blockquote", @"code", @"link", @"image", @"table",
+        @"copy-html", @"comment", @"highlight", @"strikethrough"
+    ];
+
+    for (NSString *identifier in standaloneIdentifiers) {
+        NSToolbarItem *item = [self.controller toolbar:nil
+                                 itemForItemIdentifier:identifier
+                             willBeInsertedIntoToolbar:YES];
+        NSButton *button = (NSButton *)item.view;
+        XCTAssertEqual(button.target, self.controller,
+                       @"Standalone button '%@' must target the toolbar controller, "
+                       @"not nil or the document (which is nil during init)",
+                       identifier);
+    }
+}
+
+- (void)testStandaloneButtonsUseDispatchAction
+{
+    // Standalone buttons must use the dispatch selector, not the
+    // document action directly.
+    NSArray *standaloneIdentifiers = @[
+        @"blockquote", @"code", @"link", @"image", @"table",
+        @"copy-html", @"comment", @"highlight", @"strikethrough"
+    ];
+
+    SEL expectedAction = @selector(standaloneToolbarItemClicked:);
+    for (NSString *identifier in standaloneIdentifiers) {
+        NSToolbarItem *item = [self.controller toolbar:nil
+                                 itemForItemIdentifier:identifier
+                             willBeInsertedIntoToolbar:YES];
+        NSButton *button = (NSButton *)item.view;
+        XCTAssertEqual(button.action, expectedAction,
+                       @"Standalone button '%@' must use standaloneToolbarItemClicked: action",
+                       identifier);
+    }
+}
+
+- (void)testStandaloneButtonsHaveIdentifierSet
+{
+    // Each standalone button needs an identifier so the dispatch method
+    // can look up the intended action.
+    NSArray *standaloneIdentifiers = @[
+        @"blockquote", @"code", @"link", @"image", @"table",
+        @"copy-html", @"comment", @"highlight", @"strikethrough"
+    ];
+
+    for (NSString *identifier in standaloneIdentifiers) {
+        NSToolbarItem *item = [self.controller toolbar:nil
+                                 itemForItemIdentifier:identifier
+                             willBeInsertedIntoToolbar:YES];
+        NSButton *button = (NSButton *)item.view;
+        XCTAssertEqualObjects(button.identifier, identifier,
+                              @"Standalone button '%@' must have its identifier set "
+                              @"for action lookup during dispatch",
+                              identifier);
+    }
+}
+
+- (void)testStandaloneDispatchAllActionMappings
+{
+    // Verify every standalone identifier dispatches the correct action.
+    NSDictionary *expectedMappings = @{
+        @"blockquote":     @"toggleBlockquote:",
+        @"code":           @"toggleInlineCode:",
+        @"link":           @"toggleLink:",
+        @"image":          @"toggleImage:",
+        @"table":          @"insertTable:",
+        @"copy-html":      @"copyHtml:",
+        @"comment":        @"toggleComment:",
+        @"highlight":      @"toggleHighlight:",
+        @"strikethrough":  @"toggleStrikethrough:",
+    };
+
+    for (NSString *identifier in expectedMappings) {
+        NSString *expectedAction = expectedMappings[identifier];
+        MPToolbarDispatchRecorder *recorder = [[MPToolbarDispatchRecorder alloc] init];
+        self.controller.document = (MPDocument *)recorder;
+
+        NSButton *fakeButton = [[NSButton alloc] init];
+        fakeButton.identifier = identifier;
+
+        [self.controller standaloneToolbarItemClicked:fakeButton];
+
+        XCTAssertTrue([recorder.invokedSelectors containsObject:expectedAction],
+                      @"standaloneToolbarItemClicked: with identifier '%@' "
+                      @"should dispatch %@ to the document. Got: %@",
+                      identifier, expectedAction, recorder.invokedSelectors);
+    }
+}
+
+- (void)testStandaloneDispatchWithNoDocumentDoesNotCrash
+{
+    // With no document set, dispatch should silently do nothing.
+    NSButton *fakeButton = [[NSButton alloc] init];
+    fakeButton.identifier = @"table";
+
+    XCTAssertNoThrow([self.controller standaloneToolbarItemClicked:fakeButton],
+                     @"standaloneToolbarItemClicked: must not crash when document is nil");
+}
+
+- (void)testStandaloneDispatchWithUnknownIdentifierDoesNotCrash
+{
+    MPToolbarDispatchRecorder *recorder = [[MPToolbarDispatchRecorder alloc] init];
+    self.controller.document = (MPDocument *)recorder;
+
+    NSButton *fakeButton = [[NSButton alloc] init];
+    fakeButton.identifier = @"nonexistent-item";
+
+    XCTAssertNoThrow([self.controller standaloneToolbarItemClicked:fakeButton],
+                     @"standaloneToolbarItemClicked: must not crash for unknown identifier");
+    XCTAssertEqual(recorder.invokedSelectors.count, 0,
+                   @"No action should be dispatched for unknown identifier");
+}
+
+
+#pragma mark - Dropdown Menu Item Dispatch Tests (Issue #278)
+
+- (void)testDropdownMenuItemsTargetToolbarController
+{
+    // Dropdown menu items must target the toolbar controller, not the
+    // document (which is nil during init).
+    NSToolbarItem *layoutItem = [self.controller toolbar:nil
+                                   itemForItemIdentifier:@"layout"
+                               willBeInsertedIntoToolbar:YES];
+    NSPopUpButton *popup = (NSPopUpButton *)layoutItem.view;
+
+    // Guard: the popup must have real menu items beyond the dummy icon at index 0.
+    XCTAssertGreaterThan(popup.numberOfItems, 1,
+                         @"Layout popup must have menu items beyond the dummy icon item");
+
+    // Skip item 0 (the dummy icon item); real menu items start at index 1.
+    for (NSInteger i = 1; i < popup.numberOfItems; i++) {
+        NSMenuItem *menuItem = [popup itemAtIndex:i];
+        XCTAssertEqual(menuItem.target, self.controller,
+                       @"Dropdown menu item '%@' at index %ld must target the toolbar controller",
+                       menuItem.title, (long)i);
+    }
+}
+
+- (void)testDropdownMenuItemsUseDispatchAction
+{
+    NSToolbarItem *layoutItem = [self.controller toolbar:nil
+                                   itemForItemIdentifier:@"layout"
+                               willBeInsertedIntoToolbar:YES];
+    NSPopUpButton *popup = (NSPopUpButton *)layoutItem.view;
+
+    XCTAssertGreaterThan(popup.numberOfItems, 1,
+                         @"Layout popup must have menu items beyond the dummy icon item");
+
+    SEL expectedAction = @selector(dropdownMenuItemClicked:);
+    for (NSInteger i = 1; i < popup.numberOfItems; i++) {
+        NSMenuItem *menuItem = [popup itemAtIndex:i];
+        XCTAssertEqual(menuItem.action, expectedAction,
+                       @"Dropdown menu item '%@' at index %ld must use dropdownMenuItemClicked:",
+                       menuItem.title, (long)i);
+    }
+}
+
+- (void)testDropdownMenuItemsStoreActionInRepresentedObject
+{
+    NSToolbarItem *layoutItem = [self.controller toolbar:nil
+                                   itemForItemIdentifier:@"layout"
+                               willBeInsertedIntoToolbar:YES];
+    NSPopUpButton *popup = (NSPopUpButton *)layoutItem.view;
+
+    XCTAssertGreaterThan(popup.numberOfItems, 1,
+                         @"Layout popup must have menu items beyond the dummy icon item");
+
+    // The layout dropdown has toggleEditorPane: and togglePreviewPane:
+    NSArray *expectedActions = @[@"toggleEditorPane:", @"togglePreviewPane:"];
+    for (NSInteger i = 1; i < popup.numberOfItems; i++) {
+        NSMenuItem *menuItem = [popup itemAtIndex:i];
+        XCTAssertTrue([menuItem.representedObject isKindOfClass:[NSString class]],
+                      @"Dropdown menu item at index %ld should store action name "
+                      @"as representedObject string", (long)i);
+        NSString *storedAction = menuItem.representedObject;
+        XCTAssertTrue([expectedActions containsObject:storedAction],
+                      @"Dropdown menu item at index %ld representedObject should be "
+                      @"one of %@, got '%@'", (long)i, expectedActions, storedAction);
+    }
+}
+
+- (void)testDropdownDispatchInvokesCorrectActionOnDocument
+{
+    MPToolbarDispatchRecorder *recorder = [[MPToolbarDispatchRecorder alloc] init];
+    self.controller.document = (MPDocument *)recorder;
+
+    NSMenuItem *fakeMenuItem = [[NSMenuItem alloc] initWithTitle:@"Test"
+                                                         action:nil
+                                                  keyEquivalent:@""];
+    fakeMenuItem.representedObject = @"toggleEditorPane:";
+
+    [self.controller dropdownMenuItemClicked:fakeMenuItem];
+
+    XCTAssertTrue([recorder.invokedSelectors containsObject:@"toggleEditorPane:"],
+                  @"dropdownMenuItemClicked: should dispatch toggleEditorPane: "
+                  @"to the document");
+}
+
+- (void)testDropdownDispatchTogglePreviewPane
+{
+    MPToolbarDispatchRecorder *recorder = [[MPToolbarDispatchRecorder alloc] init];
+    self.controller.document = (MPDocument *)recorder;
+
+    NSMenuItem *fakeMenuItem = [[NSMenuItem alloc] initWithTitle:@"Test"
+                                                         action:nil
+                                                  keyEquivalent:@""];
+    fakeMenuItem.representedObject = @"togglePreviewPane:";
+
+    [self.controller dropdownMenuItemClicked:fakeMenuItem];
+
+    XCTAssertTrue([recorder.invokedSelectors containsObject:@"togglePreviewPane:"],
+                  @"dropdownMenuItemClicked: should dispatch togglePreviewPane: "
+                  @"to the document");
+}
+
+- (void)testDropdownDispatchWithNoDocumentDoesNotCrash
+{
+    NSMenuItem *fakeMenuItem = [[NSMenuItem alloc] initWithTitle:@"Test"
+                                                         action:nil
+                                                  keyEquivalent:@""];
+    fakeMenuItem.representedObject = @"toggleEditorPane:";
+
+    XCTAssertNoThrow([self.controller dropdownMenuItemClicked:fakeMenuItem],
+                     @"dropdownMenuItemClicked: must not crash when document is nil");
+}
+
+- (void)testDropdownDispatchWithNilRepresentedObjectDoesNotCrash
+{
+    MPToolbarDispatchRecorder *recorder = [[MPToolbarDispatchRecorder alloc] init];
+    self.controller.document = (MPDocument *)recorder;
+
+    NSMenuItem *fakeMenuItem = [[NSMenuItem alloc] initWithTitle:@"Test"
+                                                         action:nil
+                                                  keyEquivalent:@""];
+    // representedObject is nil by default
+
+    XCTAssertNoThrow([self.controller dropdownMenuItemClicked:fakeMenuItem],
+                     @"dropdownMenuItemClicked: must not crash with nil representedObject");
+    XCTAssertEqual(recorder.invokedSelectors.count, 0,
+                   @"No action should be dispatched for nil representedObject");
 }
 
 


### PR DESCRIPTION
## Summary

- NSButton.intrinsicContentSize always returns single-line height even when lineBreakMode is wordWrap, causing Auto Layout to clip multi-line checkbox labels in localized (French, Italian) preference panes
- Adds a "pass 1.5" to `loadView` that computes true multi-line heights via `cellSizeForBounds:` and adds explicit `>=` height constraints where `intrinsicContentSize` underreports
- Extracts the logic into a testable class method (`addHeightConstraintsForWrappingCheckboxesInView:`)

Related to #397

## Test plan

- [ ] New test `testWrappingCheckboxHeightsAccommodateMultiLineText` forces wrapping by tripling checkbox titles, verifies frame heights accommodate wrapped text
- [ ] All 1040 existing tests pass with 0 unexpected failures
- [ ] Manual: build and run with French locale (`-AppleLanguages (fr)`), open Settings → Editor tab, verify all Behavior checkboxes are fully visible