### PR TITLE
Add localized selection count strings to all locale files

### DIFF
--- a/MacDown/Localization/ar.lproj/Localizable.strings
+++ b/MacDown/Localization/ar.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ حرف (بدون مسافات);%@ أحرف (بدون مسافات)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ كلمة محددة;%@ كلمات محددة";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ حرف محدد;%@ أحرف محددة";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ حرف محدد (بدون مسافات);%@ أحرف محددة (بدون مسافات)";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ حرف;%@ أحرف";
 

--- a/MacDown/Localization/cs.lproj/Localizable.strings
+++ b/MacDown/Localization/cs.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ znak (bez mezer);%@ znaků (bez mezer)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ vybrané slovo;%@ vybraných slov";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ vybraný znak;%@ vybraných znaků";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ vybraný znak (bez mezer);%@ vybraných znaků (bez mezer)";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ znak;%@ znaků";
 

--- a/MacDown/Localization/da-DK.lproj/Localizable.strings
+++ b/MacDown/Localization/da-DK.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ tegn (uden mellemrum);%@ tegn (uden mellemrum)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ ord markeret;%@ ord markeret";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ tegn markeret;%@ tegn markeret";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ tegn (uden mellemrum) markeret;%@ tegn (uden mellemrum) markeret";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ tegn;%@ tegn";
 

--- a/MacDown/Localization/da.lproj/Localizable.strings
+++ b/MacDown/Localization/da.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ tegn (uden mellemrum);%@ tegn (uden mellemrum)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ ord markeret;%@ ord markeret";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ tegn markeret;%@ tegn markeret";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ tegn (uden mellemrum) markeret;%@ tegn (uden mellemrum) markeret";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ tegn;%@ tegn";
 

--- a/MacDown/Localization/de.lproj/Localizable.strings
+++ b/MacDown/Localization/de.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ Zeichen (ohne Leerzeichen);%@ Zeichen (ohne Leerzeichen)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ Wort ausgewählt;%@ Wörter ausgewählt";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ Zeichen ausgewählt;%@ Zeichen ausgewählt";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ Zeichen (ohne Leerzeichen) ausgewählt;%@ Zeichen (ohne Leerzeichen) ausgewählt";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ Zeichen;%@ Zeichen";
 

--- a/MacDown/Localization/es.lproj/Localizable.strings
+++ b/MacDown/Localization/es.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ carácter (sin espacios);%@ caracteres (sin espacios)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ palabra seleccionada;%@ palabras seleccionadas";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ carácter seleccionado;%@ caracteres seleccionados";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ carácter (sin espacios) seleccionado;%@ caracteres (sin espacios) seleccionados";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ carácter;%@ caracteres";
 

--- a/MacDown/Localization/et.lproj/Localizable.strings
+++ b/MacDown/Localization/et.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ märki (ilma tühikuteta);%@ märki (ilma tühikuteta)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ valitud sõna;%@ valitud sõna";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ valitud märki;%@ valitud märki";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ valitud märki (ilma tühikuteta);%@ valitud märki (ilma tühikuteta)";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ märki;%@ märki";
 

--- a/MacDown/Localization/fi.lproj/Localizable.strings
+++ b/MacDown/Localization/fi.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ merkki (ilman välilyöntejä);%@ merkkiä (ilman välilyöntejä)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ valittu sana;%@ valittua sanaa";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ valittu merkki;%@ valittua merkkiä";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ valittu merkki (ilman välilyöntejä);%@ valittua merkkiä (ilman välilyöntejä)";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ merkki;%@ merkkiä";
 

--- a/MacDown/Localization/fr.lproj/Localizable.strings
+++ b/MacDown/Localization/fr.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ caractère (sans espaces);%@ caractères (sans espaces)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ mot sélectionné;%@ mots sélectionnés";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ caractère sélectionné;%@ caractères sélectionnés";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ caractère (sans espaces) sélectionné;%@ caractères (sans espaces) sélectionnés";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ caractère;%@ caractères";
 

--- a/MacDown/Localization/he.lproj/Localizable.strings
+++ b/MacDown/Localization/he.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ תו (ללא רווחים);%@ תווים (ללא רווחים)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ מילה מסומנת;%@ מילים מסומנות";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ תו מסומן;%@ תווים מסומנים";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ תו מסומן (ללא רווחים);%@ תווים מסומנים (ללא רווחים)";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ תו;%@ תווים";
 

--- a/MacDown/Localization/hi.lproj/Localizable.strings
+++ b/MacDown/Localization/hi.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ अक्षर (बिना स्पेस);%@ अक्षर (बिना स्पेस)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ चयनित शब्द;%@ चयनित शब्द";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ चयनित अक्षर;%@ चयनित अक्षर";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ चयनित अक्षर (बिना स्पेस);%@ चयनित अक्षर (बिना स्पेस)";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ अक्षर;%@ अक्षर";
 

--- a/MacDown/Localization/is.lproj/Localizable.strings
+++ b/MacDown/Localization/is.lproj/Localizable.strings
@@ -7,6 +7,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ stafur (án bila);%@ stafir (án bila)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ orð valið;%@ orð valin";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ stafur valinn;%@ stafir valdir";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ stafur (án bila) valinn;%@ stafir (án bila) valdir";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ stafur;%@ stafir";
 

--- a/MacDown/Localization/it-IT.lproj/Localizable.strings
+++ b/MacDown/Localization/it-IT.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ carattere (senza spazi);%@ caratteri (senza spazi)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ parola selezionata;%@ parole selezionate";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ carattere selezionato;%@ caratteri selezionati";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ carattere (senza spazi) selezionato;%@ caratteri (senza spazi) selezionati";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ carattere;%@ caratteri";
 

--- a/MacDown/Localization/ja.lproj/Localizable.strings
+++ b/MacDown/Localization/ja.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ 文字 (スペースなし);%@ 文字 (スペースなし)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ 語を選択中;%@ 語を選択中";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ 文字を選択中;%@ 文字を選択中";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ 文字 (スペースなし) を選択中;%@ 文字 (スペースなし) を選択中";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ 文字;%@ 文字";
 

--- a/MacDown/Localization/ko-KR.lproj/Localizable.strings
+++ b/MacDown/Localization/ko-KR.lproj/Localizable.strings
@@ -95,6 +95,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ 문자 (공백 제외);%@ 문자 (공백 제외)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ 단어 선택됨;%@ 단어 선택됨";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ 문자 선택됨;%@ 문자 선택됨";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ 문자 (공백 제외) 선택됨;%@ 문자 (공백 제외) 선택됨";
+
 /* Shell utility installation (Issue #38) */
 "Installation Failed" = "설치 실패";
 "Installation Successful" = "설치 성공";

--- a/MacDown/Localization/nb-NO.lproj/Localizable.strings
+++ b/MacDown/Localization/nb-NO.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ tegn (uten mellomrom);%@ tegn (uten mellomrom)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ ord merket;%@ ord merket";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ tegn merket;%@ tegn merket";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ tegn (uten mellomrom) merket;%@ tegn (uten mellomrom) merket";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ tegn;%@ tegn";
 

--- a/MacDown/Localization/nl-NL.lproj/Localizable.strings
+++ b/MacDown/Localization/nl-NL.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@-teken (geen spaties);%@-tekens (geen spaties)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ woord geselecteerd;%@ woorden geselecteerd";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@-teken geselecteerd;%@-tekens geselecteerd";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@-teken (geen spaties) geselecteerd;%@-tekens (geen spaties) geselecteerd";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@-teken;%@-tekens";
 

--- a/MacDown/Localization/pt-BR.lproj/Localizable.strings
+++ b/MacDown/Localization/pt-BR.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ caractere (sem espaços);%@ caracteres (sem espaços)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ palavra selecionada;%@ palavras selecionadas";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ caractere selecionado;%@ caracteres selecionados";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ caractere (sem espaços) selecionado;%@ caracteres (sem espaços) selecionados";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ caractere;%@ caracteres";
 

--- a/MacDown/Localization/ru-RU.lproj/Localizable.strings
+++ b/MacDown/Localization/ru-RU.lproj/Localizable.strings
@@ -37,6 +37,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ символ (без пробелов);%@ символов (без пробелов)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ выделенное слово;%@ выделенных слов";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ выделенный символ;%@ выделенных символов";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ выделенный символ (без пробелов);%@ выделенных символов (без пробелов)";
+
 /* Shell utility installation (Issue #38) */
 "Installation Failed" = "Ошибка установки";
 "Installation Successful" = "Установка успешна";

--- a/MacDown/Localization/sk.lproj/Localizable.strings
+++ b/MacDown/Localization/sk.lproj/Localizable.strings
@@ -4,6 +4,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ znak (bez medzier);%@ znakov (bez medzier)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ vybrané slovo;%@ vybraných slov";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ vybraný znak;%@ vybraných znakov";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ vybraný znak (bez medzier);%@ vybraných znakov (bez medzier)";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ znak;%@ znakov";
 

--- a/MacDown/Localization/sv.lproj/Localizable.strings
+++ b/MacDown/Localization/sv.lproj/Localizable.strings
@@ -1,6 +1,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ tecken (inga mellanslag);%@ tecken (inga mellanslag)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ ord markerat;%@ ord markerade";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ tecken markerat;%@ tecken markerade";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ tecken (inga mellanslag) markerat;%@ tecken (inga mellanslag) markerade";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ tecken;%@ tecken";
 

--- a/MacDown/Localization/tr.lproj/Localizable.strings
+++ b/MacDown/Localization/tr.lproj/Localizable.strings
@@ -71,6 +71,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ karakter (boşluksuz);%@ karakter (boşluksuz)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ seçili kelime;%@ seçili kelime";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ seçili karakter;%@ seçili karakter";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ seçili karakter (boşluksuz);%@ seçili karakter (boşluksuz)";
+
 /* Shell utility installation (Issue #38) */
 "Installation Failed" = "Yükleme Başarısız";
 "Installation Successful" = "Yükleme Başarılı";

--- a/MacDown/Localization/uk.lproj/Localizable.strings
+++ b/MacDown/Localization/uk.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ символ (без пробілів);%@ символів (без пробілів)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ виділене слово;%@ виділених слів";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ виділений символ;%@ виділених символів";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ виділений символ (без пробілів);%@ виділених символів (без пробілів)";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ символ;%@ символів";
 

--- a/MacDown/Localization/zh-Hans.lproj/Localizable.strings
+++ b/MacDown/Localization/zh-Hans.lproj/Localizable.strings
@@ -10,6 +10,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ 个字符（不含空白）;%@ 个字符（不含空白）";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ 个词已选择;%@ 个词已选择";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ 个字符已选择;%@ 个字符已选择";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ 个字符（不含空白）已选择;%@ 个字符（不含空白）已选择";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ 个字符;%@ 个字符";
 

--- a/MacDown/Localization/zh-Hant.lproj/Localizable.strings
+++ b/MacDown/Localization/zh-Hant.lproj/Localizable.strings
@@ -7,6 +7,13 @@
 /* (No Comment) */
 "CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ 字數 (不含空白);%@ 字數 (不含空白)";
 
+/* Selection counts (Issue #452) */
+"WORDS_SELECTED_PLURAL_STRING" = "%@ 個字已選取;%@ 個字已選取";
+
+"CHARACTERS_SELECTED_PLURAL_STRING" = "%@ 個字元已選取;%@ 個字元已選取";
+
+"CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING" = "%@ 字數 (不含空白) 已選取;%@ 字數 (不含空白) 已選取";
+
 /* (No Comment) */
 "CHARACTERS_PLURAL_STRING" = "%@ 個字元;%@ 個字元";
 


### PR DESCRIPTION
## Summary

PR #460 added a selection character-count feature to the word-count widget and introduced three new plural string keys, but only in `en.lproj`. In any other locale, `NSLocalizedString` returns the **key name** (not an English fallback) when the key is absent, so `JJPluralForm` can't parse it and the widget shows **"ERR"** when text is selected. Reported by rcuisnier in French during rc.1 testing.

This adds the three keys to all 25 non-English locales:

- `WORDS_SELECTED_PLURAL_STRING`
- `CHARACTERS_SELECTED_PLURAL_STRING`
- `CHARACTERS_NO_SPACES_SELECTED_PLURAL_STRING`

## Approach

Each locale's translation was built from its **existing** base plural vocabulary (`WORDS_PLURAL_STRING`, etc.) plus the word for "selected," with grammatical agreement matched per language — gender/number in Romance, Slavic, Hebrew, Arabic, Icelandic; case agreement in Finnish; invariant participles where appropriate (German, Dutch, Turkish, Hindi, CJK). The two-form `"%@ singular;%@ plural"` structure and `JJ_PLURAL_FORM_RULE = "1"` convention are preserved.

A few forms were refined after review:
- **Japanese** uses the state form `選択中` ("currently selected") rather than a verb reading as a command.
- **Arabic / Hebrew** place the participle adjacent to the noun; Hebrew uses `מסומן` ("marked/selected") with correct final-vs-medial nun across gender/number.

## Verification

- `grep -L` confirms all 25 non-English files now contain the keys; none missing.
- `en.lproj` unchanged; no existing keys altered; only the three additions per file (`25 files changed, 175 insertions`).
- Non-Latin strings decoded to Unicode codepoints to confirm correct letters and logical byte order (independent of terminal shaping/BiDi).

Related to #452
