### PR TITLE
Address issue #371: bypass atomic safe-save on remote volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Fix spurious "changed by another application" save conflicts and save failures on remote/FUSE-mounted volumes (e.g. SSHFS) by bypassing NSDocument's atomic temp-file-swap save for non-local destinations and writing directly instead; this also stops the "does not support permanent version storage" prompt from appearing for those documents (#371) -- thanks @gurple for the report!
 - Fix the Insert Table toolbar button doing nothing when the editor pane had focus, and corrupting the document when clicked repeatedly (a second table was inserted inside the first table's cell); every click now inserts a clean, well-separated table regardless of which pane has focus (#278) -- thanks @rcuisnier for the report!
 - Fix auto-reload silently breaking after an external editor's atomic save by making the local-volume watcher check fall back to the parent directory when the file is transiently missing; also guard resource-file watchers against remote volumes and tear down any prior watcher before re-arming (#478)
 - Fix the Preview pane still auto-scrolling toward the editor when typing after Sync Panes was turned off mid-session; toggling Sync Panes now takes effect immediately (settling the panes on disable, re-syncing on enable) without needing to reopen the document (#441) -- thanks @gregwillits!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- Fix spurious "changed by another application" save conflicts and save failures on remote/FUSE-mounted volumes (e.g. SSHFS) by bypassing NSDocument's atomic temp-file-swap save for non-local destinations and writing directly instead; this also stops the "does not support permanent version storage" prompt from appearing for those documents (#371) -- thanks @gurple for the report!
+- Fix spurious "changed by another application" save conflicts and save failures on remote/FUSE-mounted volumes (e.g. SSHFS) by bypassing NSDocument's atomic temp-file-swap save for non-local destinations and writing directly instead; this should also stop the "does not support permanent version storage" prompt from appearing for those documents, since it's raised from the same code path (#371) -- thanks @gurple for the report!
 - Fix the Insert Table toolbar button doing nothing when the editor pane had focus, and corrupting the document when clicked repeatedly (a second table was inserted inside the first table's cell); every click now inserts a clean, well-separated table regardless of which pane has focus (#278) -- thanks @rcuisnier for the report!
 - Fix auto-reload silently breaking after an external editor's atomic save by making the local-volume watcher check fall back to the parent directory when the file is transiently missing; also guard resource-file watchers against remote volumes and tear down any prior watcher before re-arming (#478)
 - Fix the Preview pane still auto-scrolling toward the editor when typing after Sync Panes was turned off mid-session; toggling Sync Panes now takes effect immediately (settling the panes on disable, re-syncing on enable) without needing to reopen the document (#441) -- thanks @gregwillits!

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -848,6 +848,38 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     return result;
 }
 
+- (BOOL)writeSafelyToURL:(NSURL *)url ofType:(NSString *)typeName
+         forSaveOperation:(NSSaveOperationType)saveOperation
+                    error:(NSError *__autoreleasing *)outError
+{
+    // Issue #371: NSDocument's default "safe save" writes to a temp file and
+    // swaps it into place, plus checks the destination's on-disk modification
+    // date for conflicts. Both are unreliable on FUSE/network volumes (mtime
+    // semantics are inconsistent, and the temp-file swap can fail outright),
+    // producing a spurious "changed by another application" conflict dialog
+    // followed by a hard save failure. It's also what raises the "volume does
+    // not support permanent version storage" prompt. Bypass all of that for
+    // non-local destinations and write directly instead. Checked against
+    // `url` (the destination), not self.fileURL, so a Save As across volumes
+    // is classified by where the file is going, not where it came from.
+    if ([self shouldBypassSafeSaveForURL:url])
+    {
+        return [self writeToURL:url ofType:typeName
+                forSaveOperation:saveOperation
+             originalContentsURL:self.fileURL error:outError];
+    }
+    return [super writeSafelyToURL:url ofType:typeName
+                   forSaveOperation:saveOperation error:outError];
+}
+
+// Issue #371: Split out for test exposure. Checks `url` (the save
+// destination) rather than self.fileURL, so Save As across volumes is
+// classified by where the file is going, not where it came from.
+- (BOOL)shouldBypassSafeSaveForURL:(NSURL *)url
+{
+    return url.isFileURL && ![MPFileWatcher pathIsOnLocalVolume:url.path];
+}
+
 - (NSData *)dataOfType:(NSString *)typeName error:(NSError **)outError
 {
     return [self.editor.string dataUsingEncoding:NSUTF8StringEncoding];

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -268,6 +268,11 @@ typedef NS_ENUM(NSInteger, MPReferenceKind) {
 @property (strong) MPFileWatcher *fileWatcher;
 @property (nonatomic) BOOL isSelfSaving;
 
+// Issue #371: Injection seam so tests can simulate a non-local save
+// destination without a real network mount. Defaults to
+// +[MPFileWatcher pathIsOnLocalVolume:].
+@property (nonatomic, copy) BOOL (^volumeLocalityChecker)(NSString *path);
+
 // Issue #320: Block-based observer token for main-thread-safe defaults notification
 @property (strong) id userDefaultsObserverToken;
 
@@ -553,6 +558,12 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     // first NSUserDefaultsDidChangeNotification (which fires for any default) is not
     // misread as a transition.
     _lastKnownSyncScrolling = [MPPreferences sharedInstance].editorSyncScrolling;
+
+    // Issue #371: Default locality checker; tests may override this to
+    // simulate a non-local destination.
+    self.volumeLocalityChecker = ^BOOL(NSString *path) {
+        return [MPFileWatcher pathIsOnLocalVolume:path];
+    };
 
     return self;
 }
@@ -853,15 +864,27 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
                     error:(NSError *__autoreleasing *)outError
 {
     // Issue #371: NSDocument's default "safe save" writes to a temp file and
-    // swaps it into place, plus checks the destination's on-disk modification
-    // date for conflicts. Both are unreliable on FUSE/network volumes (mtime
-    // semantics are inconsistent, and the temp-file swap can fail outright),
-    // producing a spurious "changed by another application" conflict dialog
-    // followed by a hard save failure. It's also what raises the "volume does
-    // not support permanent version storage" prompt. Bypass all of that for
-    // non-local destinations and write directly instead. Checked against
-    // `url` (the destination), not self.fileURL, so a Save As across volumes
-    // is classified by where the file is going, not where it came from.
+    // swaps it into place via NSFileCoordinator, plus checks the destination's
+    // on-disk modification date for conflicts. Both are unreliable on
+    // FUSE/network volumes (mtime semantics are inconsistent, and the
+    // temp-file swap can fail outright), producing a spurious "changed by
+    // another application" conflict dialog followed by a hard save failure.
+    // The "volume does not support permanent version storage" prompt is also
+    // raised from within this same call chain, so it should no longer appear
+    // for these documents either — confirmed by code inspection, but as with
+    // the rest of this method, real-world behavior on an actual network mount
+    // has not been (and cannot be, in CI) directly observed.
+    //
+    // For non-local destinations, skip NSFileCoordinator-mediated coordination
+    // entirely and write directly. This is a deliberate trade-off: the
+    // coordinated temp-file dance is itself what's unreliable on these
+    // volumes, and MPFileWatcher already declines to watch (i.e. act as a
+    // file presenter for) non-local paths, so there's no in-process presenter
+    // left to race with here.
+    //
+    // Checked against `url` (the destination), not self.fileURL, so a Save As
+    // across volumes is classified by where the file is going, not where it
+    // came from.
     if ([self shouldBypassSafeSaveForURL:url])
     {
         return [self writeToURL:url ofType:typeName
@@ -874,10 +897,12 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
 // Issue #371: Split out for test exposure. Checks `url` (the save
 // destination) rather than self.fileURL, so Save As across volumes is
-// classified by where the file is going, not where it came from.
+// classified by where the file is going, not where it came from. Goes
+// through volumeLocalityChecker (rather than calling MPFileWatcher directly)
+// so tests can simulate a non-local destination without a real network mount.
 - (BOOL)shouldBypassSafeSaveForURL:(NSURL *)url
 {
-    return url.isFileURL && ![MPFileWatcher pathIsOnLocalVolume:url.path];
+    return url.isFileURL && !self.volumeLocalityChecker(url.path);
 }
 
 - (NSData *)dataOfType:(NSString *)typeName error:(NSError **)outError

--- a/MacDown/Code/Utility/MPFileWatcher.h
+++ b/MacDown/Code/Utility/MPFileWatcher.h
@@ -23,6 +23,11 @@
 /// otherwise unresolvable paths.
 + (BOOL)canWatchPath:(NSString *)path;
 
+/// YES if the given path resolves to a local (non-network, non-FUSE) volume.
+/// Uses the same existence-fallback-to-parent-directory logic as
+/// canWatchPath:. Related to #371.
++ (BOOL)pathIsOnLocalVolume:(NSString *)path;
+
 /// Create a watcher for the given path. Calls handler on the main queue
 /// when the file is written to. Calls cancelHandler when the file is
 /// deleted, renamed, or stopWatching is called.

--- a/MacDown/Code/Utility/MPFileWatcher.m
+++ b/MacDown/Code/Utility/MPFileWatcher.m
@@ -18,6 +18,11 @@
 
 + (BOOL)canWatchPath:(NSString *)path
 {
+    return path.length && [self pathIsOnLocalVolume:path];
+}
+
++ (BOOL)pathIsOnLocalVolume:(NSString *)path
+{
     if (!path.length)
         return NO;
 

--- a/MacDownTests/MPDocumentIOTests.m
+++ b/MacDownTests/MPDocumentIOTests.m
@@ -15,6 +15,7 @@
 - (BOOL)canAutomaticallyCreateLinkedFileAtURL:(NSURL *)url;
 - (NSURL *)previewSafeBaseURL:(NSURL *)baseURL;
 - (IBAction)toggleAutoSave:(id)sender;
+- (BOOL)shouldBypassSafeSaveForURL:(NSURL *)url;
 @end
 
 @interface MPDocumentIOTests : XCTestCase
@@ -656,5 +657,30 @@
     XCTAssertFalse([self.document canAutomaticallyCreateLinkedFileAtURL:targetURL],
                    @"Symlink escapes must not be auto-created");
 }
+
+#pragma mark - Remote Volume Save Tests (Issue #371)
+
+- (void)testShouldBypassSafeSaveForURLIsNoForLocalFile
+{
+    // On a local volume, NSDocument's normal atomic "safe save" (with its
+    // conflict check and versioning support) must keep working exactly as
+    // before.
+    XCTAssertFalse([self.document shouldBypassSafeSaveForURL:self.testFileURL],
+        @"Local destinations must use NSDocument's default safe-save path");
+}
+
+- (void)testShouldBypassSafeSaveForURLIsNoForNonFileURL
+{
+    NSURL *httpURL = [NSURL URLWithString:@"https://example.com/page.html"];
+    XCTAssertFalse([self.document shouldBypassSafeSaveForURL:httpURL],
+        @"Non-file URLs are not eligible for the direct-write bypass");
+}
+
+// NOTE: Exercising the "YES" branch (a genuinely non-local/FUSE-mounted
+// destination) requires a real network mount that CI does not have
+// available. [MPFileWatcher pathIsOnLocalVolume:] is covered directly in
+// MPFileWatcherTests.m; the "changed by another application" dialog and the
+// "couldn't be saved in folder tmp" failure it works around require manual
+// verification against a real SSHFS/SMB/NFS mount. Related to #371.
 
 @end

--- a/MacDownTests/MPDocumentIOTests.m
+++ b/MacDownTests/MPDocumentIOTests.m
@@ -16,6 +16,7 @@
 - (NSURL *)previewSafeBaseURL:(NSURL *)baseURL;
 - (IBAction)toggleAutoSave:(id)sender;
 - (BOOL)shouldBypassSafeSaveForURL:(NSURL *)url;
+@property (nonatomic, copy) BOOL (^volumeLocalityChecker)(NSString *path);
 @end
 
 @interface MPDocumentIOTests : XCTestCase
@@ -676,11 +677,34 @@
         @"Non-file URLs are not eligible for the direct-write bypass");
 }
 
-// NOTE: Exercising the "YES" branch (a genuinely non-local/FUSE-mounted
-// destination) requires a real network mount that CI does not have
-// available. [MPFileWatcher pathIsOnLocalVolume:] is covered directly in
-// MPFileWatcherTests.m; the "changed by another application" dialog and the
-// "couldn't be saved in folder tmp" failure it works around require manual
-// verification against a real SSHFS/SMB/NFS mount. Related to #371.
+- (void)testShouldBypassSafeSaveForURLIsYesForSimulatedNonLocalVolume
+{
+    // A real FUSE/network mount isn't available in CI, so simulate one via
+    // the volumeLocalityChecker injection seam rather than skipping coverage
+    // of the actual bug-fix branch entirely.
+    self.document.volumeLocalityChecker = ^BOOL(NSString *path) {
+        return NO;
+    };
+
+    XCTAssertTrue([self.document shouldBypassSafeSaveForURL:self.testFileURL],
+        @"Non-local destinations must bypass NSDocument's atomic safe-save");
+}
+
+- (void)testShouldBypassSafeSaveForURLDefaultCheckerMatchesFileWatcher
+{
+    // The default (non-test-injected) checker should be wired to
+    // MPFileWatcher's locality check, not some other logic.
+    XCTAssertTrue(self.document.volumeLocalityChecker(self.testFileURL.path),
+        @"Default volumeLocalityChecker should report the local test directory as local");
+}
+
+// NOTE: The bypass decision itself (shouldBypassSafeSaveForURL:) is now
+// exercised for both branches above via dependency injection. What remains
+// untestable in CI is the real-world trigger for the "YES" branch — an
+// actual non-local volume, per [MPFileWatcher pathIsOnLocalVolume:] (covered
+// directly in MPFileWatcherTests.m) — and the resulting absence of the
+// "changed by another application" dialog and the "couldn't be saved in
+// folder tmp" failure, which require manual verification against a real
+// SSHFS/SMB/NFS mount. Related to #371.
 
 @end

--- a/MacDownTests/MPFileWatcherTests.m
+++ b/MacDownTests/MPFileWatcherTests.m
@@ -113,6 +113,46 @@
     XCTAssertFalse([MPFileWatcher canWatchPath:path]);
 }
 
+#pragma mark - Volume Locality (Issue #371)
+
+- (void)testPathIsOnLocalVolumeForLocalFile
+{
+    NSString *path = [self createTestFileWithName:@"local.txt" content:@"hello"];
+    XCTAssertTrue([MPFileWatcher pathIsOnLocalVolume:path]);
+}
+
+- (void)testPathIsOnLocalVolumeForNonexistentLocalPath
+{
+    // Same parent-directory fallback as canWatchPath:. Related to #478.
+    NSString *path = [self.testDirectory stringByAppendingPathComponent:@"gone.txt"];
+    XCTAssertFalse([self.fileManager fileExistsAtPath:path]);
+    XCTAssertTrue([MPFileWatcher pathIsOnLocalVolume:path]);
+}
+
+- (void)testPathIsOnLocalVolumeForNilPath
+{
+    XCTAssertFalse([MPFileWatcher pathIsOnLocalVolume:nil]);
+}
+
+- (void)testPathIsOnLocalVolumeForEmptyPath
+{
+    XCTAssertFalse([MPFileWatcher pathIsOnLocalVolume:@""]);
+}
+
+- (void)testPathIsOnLocalVolumeForPathWithNonexistentParent
+{
+    NSString *path = [[self.testDirectory
+                       stringByAppendingPathComponent:@"missing-dir"]
+                      stringByAppendingPathComponent:@"file.txt"];
+    XCTAssertFalse([MPFileWatcher pathIsOnLocalVolume:path]);
+}
+
+// NOTE: pathIsOnLocalVolume: returning NO for genuinely remote/FUSE-mounted
+// volumes (SSHFS, SMB, NFS) cannot be exercised in CI, which has no such
+// mount available. That branch (and the MPDocument save-path behavior that
+// depends on it) requires manual verification against a real network mount.
+// Related to #371.
+
 #pragma mark - Event Handling
 
 - (void)testHandlerCalledOnFileWrite


### PR DESCRIPTION
## Summary

Follow-up fix for issue #371. The original "spinning out of control" bug (mount collapse during vnode watching on remote/FUSE volumes) was already fixed in a prior PR by having `MPFileWatcher` skip watching non-local volumes. After validating that fix in an RC build, the reporter found a remaining problem: saving a markdown file on a remote/FUSE-mounted volume (e.g. SSHFS) triggers a spurious "The document could not be saved. The file has been changed by another application." conflict dialog, and choosing "Save Anyway" then hard-fails with "The file couldn't be saved in the folder 'tmp'." "Save As" also shows the "volume does not support permanent version storage" prompt.

Root cause: `NSDocument`'s default "safe save" (`writeSafelyToURL:ofType:forSaveOperation:error:`) writes to a temp file and swaps it into place via `NSFileCoordinator`, plus checks the destination's on-disk modification date for conflicts. Both are unreliable on FUSE/network volumes — mtime semantics are inconsistent (false conflict positives), and the temp-file swap can fail outright.

This PR:
- Extracts the existing `NSURLVolumeIsLocalKey`-based locality probe out of `MPFileWatcher`'s `+canWatchPath:` into a new, reusable `+ (BOOL)pathIsOnLocalVolume:(NSString *)path` class method.
- Overrides `MPDocument`'s `writeSafelyToURL:ofType:forSaveOperation:error:` to bypass NSDocument's atomic safe-save for non-local destinations (checked against the save destination, not the document's current URL, so cross-volume Save As is classified correctly) and write directly instead via the existing `writeToURL:ofType:forSaveOperation:originalContentsURL:error:` → `writeToURL:ofType:error:` path. This should also stop the "volume does not support permanent version storage" prompt, since it's raised from the same call chain being bypassed.
- Adds a `volumeLocalityChecker` injection seam on `MPDocument` so the actual bypass-decision logic can be exercised in CI without a real network mount.
- Local-volume saves are completely unaffected (fall through to `[super writeSafelyToURL:...]` unchanged).

## Files Changed

- `MacDown/Code/Utility/MPFileWatcher.h` / `.m` — new `+pathIsOnLocalVolume:` class method.
- `MacDown/Code/Document/MPDocument.m` — new `writeSafelyToURL:ofType:forSaveOperation:error:` override, `shouldBypassSafeSaveForURL:` helper, `volumeLocalityChecker` injection seam.
- `MacDownTests/MPFileWatcherTests.m` — tests for `pathIsOnLocalVolume:`.
- `MacDownTests/MPDocumentIOTests.m` — tests for the save-path bypass decision (including the true bypass branch, via the injection seam).
- `CHANGELOG.md` — Unreleased/Fixed entry.

## Related Issue

Related to #371

## Manual Testing Plan

A real FUSE/network mount isn't available in CI, so the following should be verified manually before/while validating this fix:

1. **Setup:** Mount a network/FUSE volume to reproduce the original bug conditions — SSHFS via macFUSE (`brew install --cask macfuse && brew install sshfs`), or an SMB/AFP share if macFUSE's system-extension approval is impractical (the fix uses a generic "is local volume" check, not SSHFS-specific detection, so SMB/AFP should behave the same way).
2. **Remote-volume fix:**
   - Open and edit a `.md` file on the mounted volume, save repeatedly (Cmd+S). Expected: no "changed by another application" dialog, no "couldn't be saved in folder tmp" error.
   - "Save As" a new document to the mounted volume. Expected: no "volume does not support permanent version storage" prompt.
3. **Local-volume regression:**
   - Normal open/edit/save on a local file: behavior unchanged, Versions/autosave still work (check via Finder "Browse All Versions").
   - Genuine external-modification conflict on a **local** file (edit externally via Terminal while open in MacDown, then save): the "changed by another application" dialog should still appear — confirms the bypass is correctly scoped to non-local volumes only.
4. **Save As across volumes:** local → remote and remote → local, confirming each takes the correct path (direct write vs. atomic safe-save) based on the destination.
5. **Autosave-in-place:** confirm the fix holds when autosave triggers the save, not just manual Cmd+S.

## Review Notes

- Reviewed by an architectural consult before implementation (confirmed `writeSafelyToURL:ofType:forSaveOperation:error:` is the correct override point, and that a locality check on the save destination — not `self.fileURL` — is required for correct Save As handling).
- Reviewed by a code-review pass after initial implementation; feedback addressed by adding the `volumeLocalityChecker` injection seam (so the actual bypass branch has real test coverage, not just the local/no-op branches) and softening comments/changelog wording around the versioning-prompt suppression, which is inferred from the code path rather than directly observed (no real network mount available in CI).
- A documentation pass found nothing in `plans/` that needed updating as a result of this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PxTBTWM3vQyy5bW8zu8YaG)_