### PR TITLE
Align heading slug algorithm with GitHub's github-slugger

### DIFF
--- a/MacDown/Code/Extension/hoedown_html_patch.c
+++ b/MacDown/Code/Extension/hoedown_html_patch.c
@@ -172,22 +172,85 @@ void hoedown_patch_render_listitem(
 	HOEDOWN_BUFPUTSL(ob, "</li>\n");
 }
 
-// Build a stable text-derived slug from a heading's HTML content.
-// Strips HTML tags and skips HTML entities (&amp; / &lt; / &#39; ...),
-// lowercases ASCII, converts spaces to hyphens, drops ASCII punctuation,
-// preserves UTF-8 multi-byte sequences so accented characters survive
-// (e.g. "Introducción" -> "introducción"). Anchors keep their raw UTF-8
-// bytes (no percent-encoding): browsers match the URL fragment against
-// the id literally, so encoding would break navigation.
+// Decode the UTF-8 codepoint starting at data[i] (i < size). Returns the
+// number of bytes consumed (1-4) and stores the codepoint in *codepoint, or
+// returns 0 if the sequence is malformed / truncated, in which case the
+// caller should pass the raw byte through unchanged.
+static size_t decode_utf8_codepoint(const uint8_t *data, size_t size, size_t i,
+                                     uint32_t *codepoint)
+{
+    uint8_t c = data[i];
+    size_t len;
+    uint32_t cp;
+
+    if ((c & 0x80) == 0x00)      { cp = c;        len = 1; }
+    else if ((c & 0xE0) == 0xC0) { cp = c & 0x1F; len = 2; }
+    else if ((c & 0xF0) == 0xE0) { cp = c & 0x0F; len = 3; }
+    else if ((c & 0xF8) == 0xF0) { cp = c & 0x07; len = 4; }
+    else return 0;
+
+    if (i + len > size)
+        return 0;
+
+    for (size_t k = 1; k < len; k++)
+    {
+        uint8_t cc = data[i + k];
+        if ((cc & 0xC0) != 0x80)
+            return 0;
+        cp = (cp << 6) | (cc & 0x3F);
+    }
+
+    *codepoint = cp;
+    return len;
+}
+
+// Encode a codepoint <= 0x7FF (used only for lowercased Latin-1 letters) as
+// two UTF-8 bytes.
+static void encode_utf8_2byte(uint32_t cp, uint8_t out[2])
+{
+    out[0] = (uint8_t)(0xC0 | (cp >> 6));
+    out[1] = (uint8_t)(0x80 | (cp & 0x3F));
+}
+
+// Build a stable text-derived slug from a heading's HTML content, matching
+// GitHub's heading-anchor slug algorithm (github-slugger semantics) so
+// [text](#slug) links copied from GitHub-rendered Markdown keep working.
+// Strips HTML tags and skips HTML entities (&amp; / &lt; / &#39; ...), then
+// trims leading/trailing whitespace from the heading text. ASCII letters are
+// lowercased; digits, '_' and literal '-' are kept as-is; each remaining
+// ASCII space/tab maps to exactly one hyphen (runs are NOT collapsed, e.g.
+// "Foo --- Bar" -> "foo-----bar"); other ASCII punctuation is dropped.
+// Non-ASCII text is decoded as UTF-8: Latin-1 uppercase letters
+// (U+00C0-U+00DE, excluding the multiplication sign U+00D7) are lowercased
+// and re-encoded; the Latin-1 punctuation/symbol block (U+00A1-U+00BF), the
+// multiplication/division signs (U+00D7, U+00F7), and the General
+// Punctuation block (U+2000-U+206F, which covers em/en dashes, curly quotes,
+// ellipsis, ...) are dropped entirely; every other codepoint passes through
+// unchanged as raw UTF-8 bytes (e.g. "Introducción" -> "introducción").
+// Malformed UTF-8 bytes are passed through unchanged rather than dropped.
+// Anchors keep their raw UTF-8 bytes (no percent-encoding): browsers match
+// the URL fragment against the id literally, so encoding would break
+// navigation.
 static void slugify(hoedown_buffer *out, const hoedown_buffer *content)
 {
     if (!content || !content->size)
         return;
 
-    int in_tag = 0;
-    int last_was_dash = 1;
+    size_t start = 0, end = content->size;
+    while (start < end && (content->data[start] == ' ' ||
+                            content->data[start] == '\t' ||
+                            content->data[start] == '\n' ||
+                            content->data[start] == '\r'))
+        start++;
+    while (end > start && (content->data[end - 1] == ' ' ||
+                            content->data[end - 1] == '\t' ||
+                            content->data[end - 1] == '\n' ||
+                            content->data[end - 1] == '\r'))
+        end--;
 
-    for (size_t i = 0; i < content->size; i++)
+    int in_tag = 0;
+
+    for (size_t i = start; i < end; i++)
     {
         uint8_t c = content->data[i];
 
@@ -203,7 +266,7 @@ static void slugify(hoedown_buffer *out, const hoedown_buffer *content)
         }
         if (c == '&')
         {            // skip an HTML entity like &amp; / &lt; / &#39;
-            while (i + 1 < content->size && content->data[i + 1] != ';')
+            while (i + 1 < end && content->data[i + 1] != ';')
                 i++;
             i++;                    // consume the ';'
             continue;
@@ -211,31 +274,49 @@ static void slugify(hoedown_buffer *out, const hoedown_buffer *content)
 
         if (c >= 0x80)
         {
-            hoedown_buffer_putc(out, c);
-            last_was_dash = 0;
+            uint32_t cp;
+            size_t len = decode_utf8_codepoint(content->data, end, i, &cp);
+
+            if (len == 0)
+            {
+                // Malformed / truncated sequence: pass the raw byte through.
+                hoedown_buffer_putc(out, c);
+                continue;
+            }
+
+            if ((cp >= 0x00A1 && cp <= 0x00BF) || cp == 0x00D7 ||
+                cp == 0x00F7 || (cp >= 0x2000 && cp <= 0x206F))
+            {
+                // Dropped punctuation/symbol codepoint: emit nothing.
+            }
+            else if (cp >= 0x00C0 && cp <= 0x00DE && cp != 0x00D7)
+            {
+                uint8_t enc[2];
+                encode_utf8_2byte(cp + 0x20, enc);
+                hoedown_buffer_put(out, enc, 2);
+            }
+            else
+            {
+                hoedown_buffer_put(out, content->data + i, len);
+            }
+
+            i += len - 1;
             continue;
         }
 
         if (c >= 'A' && c <= 'Z')
             c += 32;
 
-        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_')
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+            c == '_' || c == '-')
         {
             hoedown_buffer_putc(out, c);
-            last_was_dash = 0;
         }
-        else if (c == ' ' || c == '\t' || c == '-')
+        else if (c == ' ' || c == '\t')
         {
-            if (!last_was_dash)
-            {
-                hoedown_buffer_putc(out, '-');
-                last_was_dash = 1;
-            }
+            hoedown_buffer_putc(out, '-');
         }
     }
-
-    while (out->size > 0 && out->data[out->size - 1] == '-')
-        out->size--;
 }
 
 // rndr_header replacement that always emits a text-derived id, independent

--- a/MacDownCore/MPQuickLookRenderer.m
+++ b/MacDownCore/MPQuickLookRenderer.m
@@ -180,24 +180,87 @@ NS_INLINE NSString *MPQuickLookContentSecurityPolicy(void)
 
 #pragma mark - Hoedown Renderer Callbacks
 
-// Build a stable text-derived slug from a heading's HTML content.
+// Decode the UTF-8 codepoint starting at data[i] (i < size). Returns the
+// number of bytes consumed (1-4) and stores the codepoint in *codepoint, or
+// returns 0 if the sequence is malformed / truncated, in which case the
+// caller should pass the raw byte through unchanged.
+static size_t decode_utf8_codepoint(const uint8_t *data, size_t size, size_t i,
+                                     uint32_t *codepoint)
+{
+    uint8_t c = data[i];
+    size_t len;
+    uint32_t cp;
+
+    if ((c & 0x80) == 0x00)      { cp = c;        len = 1; }
+    else if ((c & 0xE0) == 0xC0) { cp = c & 0x1F; len = 2; }
+    else if ((c & 0xF0) == 0xE0) { cp = c & 0x0F; len = 3; }
+    else if ((c & 0xF8) == 0xF0) { cp = c & 0x07; len = 4; }
+    else return 0;
+
+    if (i + len > size)
+        return 0;
+
+    for (size_t k = 1; k < len; k++)
+    {
+        uint8_t cc = data[i + k];
+        if ((cc & 0xC0) != 0x80)
+            return 0;
+        cp = (cp << 6) | (cc & 0x3F);
+    }
+
+    *codepoint = cp;
+    return len;
+}
+
+// Encode a codepoint <= 0x7FF (used only for lowercased Latin-1 letters) as
+// two UTF-8 bytes.
+static void encode_utf8_2byte(uint32_t cp, uint8_t out[2])
+{
+    out[0] = (uint8_t)(0xC0 | (cp >> 6));
+    out[1] = (uint8_t)(0x80 | (cp & 0x3F));
+}
+
+// Build a stable text-derived slug from a heading's HTML content, matching
+// GitHub's heading-anchor slug algorithm (github-slugger semantics) so
+// [text](#slug) links copied from GitHub-rendered Markdown keep working.
 // Mirrors slugify() in MacDown/Code/Extension/hoedown_html_patch.c so the
 // preview and Quick Look render identical heading ids.
-// Strips HTML tags and skips HTML entities (&amp; / &lt; / &#39; ...),
-// lowercases ASCII, converts spaces to hyphens, drops ASCII punctuation,
-// preserves UTF-8 multi-byte sequences so accented characters survive
-// (e.g. "Introducción" -> "introducción"). Anchors keep their raw UTF-8
-// bytes (no percent-encoding): browsers match the URL fragment against
-// the id literally, so encoding would break navigation.
+// Strips HTML tags and skips HTML entities (&amp; / &lt; / &#39; ...), then
+// trims leading/trailing whitespace from the heading text. ASCII letters are
+// lowercased; digits, '_' and literal '-' are kept as-is; each remaining
+// ASCII space/tab maps to exactly one hyphen (runs are NOT collapsed, e.g.
+// "Foo --- Bar" -> "foo-----bar"); other ASCII punctuation is dropped.
+// Non-ASCII text is decoded as UTF-8: Latin-1 uppercase letters
+// (U+00C0-U+00DE, excluding the multiplication sign U+00D7) are lowercased
+// and re-encoded; the Latin-1 punctuation/symbol block (U+00A1-U+00BF), the
+// multiplication/division signs (U+00D7, U+00F7), and the General
+// Punctuation block (U+2000-U+206F, which covers em/en dashes, curly quotes,
+// ellipsis, ...) are dropped entirely; every other codepoint passes through
+// unchanged as raw UTF-8 bytes (e.g. "Introducción" -> "introducción").
+// Malformed UTF-8 bytes are passed through unchanged rather than dropped.
+// Anchors keep their raw UTF-8 bytes (no percent-encoding): browsers match
+// the URL fragment against the id literally, so encoding would break
+// navigation.
 static void mp_quicklook_slugify(hoedown_buffer *out, const hoedown_buffer *content)
 {
     if (!content || !content->size)
         return;
 
-    int in_tag = 0;
-    int last_was_dash = 1;
+    size_t start = 0, end = content->size;
+    while (start < end && (content->data[start] == ' ' ||
+                            content->data[start] == '\t' ||
+                            content->data[start] == '\n' ||
+                            content->data[start] == '\r'))
+        start++;
+    while (end > start && (content->data[end - 1] == ' ' ||
+                            content->data[end - 1] == '\t' ||
+                            content->data[end - 1] == '\n' ||
+                            content->data[end - 1] == '\r'))
+        end--;
 
-    for (size_t i = 0; i < content->size; i++)
+    int in_tag = 0;
+
+    for (size_t i = start; i < end; i++)
     {
         uint8_t c = content->data[i];
 
@@ -213,7 +276,7 @@ static void mp_quicklook_slugify(hoedown_buffer *out, const hoedown_buffer *cont
         }
         if (c == '&')
         {            // skip an HTML entity like &amp; / &lt; / &#39;
-            while (i + 1 < content->size && content->data[i + 1] != ';')
+            while (i + 1 < end && content->data[i + 1] != ';')
                 i++;
             i++;                    // consume the ';'
             continue;
@@ -221,31 +284,49 @@ static void mp_quicklook_slugify(hoedown_buffer *out, const hoedown_buffer *cont
 
         if (c >= 0x80)
         {
-            hoedown_buffer_putc(out, c);
-            last_was_dash = 0;
+            uint32_t cp;
+            size_t len = decode_utf8_codepoint(content->data, end, i, &cp);
+
+            if (len == 0)
+            {
+                // Malformed / truncated sequence: pass the raw byte through.
+                hoedown_buffer_putc(out, c);
+                continue;
+            }
+
+            if ((cp >= 0x00A1 && cp <= 0x00BF) || cp == 0x00D7 ||
+                cp == 0x00F7 || (cp >= 0x2000 && cp <= 0x206F))
+            {
+                // Dropped punctuation/symbol codepoint: emit nothing.
+            }
+            else if (cp >= 0x00C0 && cp <= 0x00DE && cp != 0x00D7)
+            {
+                uint8_t enc[2];
+                encode_utf8_2byte(cp + 0x20, enc);
+                hoedown_buffer_put(out, enc, 2);
+            }
+            else
+            {
+                hoedown_buffer_put(out, content->data + i, len);
+            }
+
+            i += len - 1;
             continue;
         }
 
         if (c >= 'A' && c <= 'Z')
             c += 32;
 
-        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_')
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+            c == '_' || c == '-')
         {
             hoedown_buffer_putc(out, c);
-            last_was_dash = 0;
         }
-        else if (c == ' ' || c == '\t' || c == '-')
+        else if (c == ' ' || c == '\t')
         {
-            if (!last_was_dash)
-            {
-                hoedown_buffer_putc(out, '-');
-                last_was_dash = 1;
-            }
+            hoedown_buffer_putc(out, '-');
         }
     }
-
-    while (out->size > 0 && out->data[out->size - 1] == '-')
-        out->size--;
 }
 
 // hoedown_buffer_new() stores its argument as the buffer's growth "unit", and

--- a/MacDownTests/MPMarkdownRenderingTests.m
+++ b/MacDownTests/MPMarkdownRenderingTests.m
@@ -872,22 +872,27 @@
 
 - (void)testHeadingAnchorIdSkipsLtGtEntity
 {
-    // "A < B" renders as "A &lt; B"; the slug must be "a-b", not "a-lt-b".
+    // "A < B" renders as "A &lt; B"; the entity is skipped like GitHub drops
+    // the raw "<", but (matching GitHub's no-collapse behavior) the two
+    // spaces surrounding it each become their own hyphen: "a--b", not "a-b"
+    // or "a-lt-b".
     NSString *html = [self renderMarkdown:@"## A < B"
                            withExtensions:0
                             rendererFlags:0];
-    XCTAssertTrue([html containsString:@"id=\"a-b\""],
+    XCTAssertTrue([html containsString:@"id=\"a--b\""],
                   @"Heading id must skip the &lt; entity. Got: %@", html);
 }
 
 - (void)testHeadingAnchorIdSkipsMultipleEntities
 {
-    // "Tips & Tricks" renders as "Tips &amp; Tricks"; the slug must be
-    // "tips-tricks", not "tips-amp-tricks".
+    // "Tips & Tricks" renders as "Tips &amp; Tricks"; the entity is skipped
+    // like GitHub drops the raw "&", but (matching GitHub's no-collapse
+    // behavior) the two spaces surrounding it each become their own hyphen:
+    // "tips--tricks", not "tips-tricks" or "tips-amp-tricks".
     NSString *html = [self renderMarkdown:@"## Tips & Tricks"
                            withExtensions:0
                             rendererFlags:0];
-    XCTAssertTrue([html containsString:@"id=\"tips-tricks\""],
+    XCTAssertTrue([html containsString:@"id=\"tips--tricks\""],
                   @"Heading id must skip every HTML entity. Got: %@", html);
 }
 
@@ -923,6 +928,88 @@
                   @"TOC entry must link to the heading slug. Got: %@", html);
     XCTAssertTrue([html containsString:@"id=\"foo-bar\""],
                   @"Heading must carry the matching id. Got: %@", html);
+}
+
+// GitHub-slugger parity (github-slugger semantics). Unicode punctuation and
+// symbols (em/en dashes, curly quotes, ellipsis, the Latin-1 ¡-¿ block, etc.)
+// are dropped rather than passed through raw, Latin-1 uppercase letters are
+// lowercased, and each space/tab maps to exactly one hyphen without
+// collapsing runs. Context: #471.
+
+- (void)testHeadingAnchorIdDropsEmDash
+{
+    NSString *html = [self renderMarkdown:@"## Pregunta 5 — Cobro de AWS Lambda"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"pregunta-5--cobro-de-aws-lambda\""],
+                  @"Em dash must be dropped, not passed through raw. Got: %@", html);
+}
+
+- (void)testHeadingAnchorIdLowercasesLatin1Uppercase
+{
+    NSString *html = [self renderMarkdown:@"## Índice"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"índice\""],
+                  @"Latin-1 uppercase letters must be lowercased. Got: %@", html);
+}
+
+- (void)testHeadingAnchorIdDropsInvertedQuestionMark
+{
+    NSString *html = [self renderMarkdown:@"## ¿Qué es AWS?"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"qué-es-aws\""],
+                  @"Inverted question mark and trailing '?' must be dropped. Got: %@", html);
+}
+
+- (void)testHeadingAnchorIdDropsEnDashBetweenWords
+{
+    NSString *html = [self renderMarkdown:@"## Conexión on-premises–AWS"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"conexión-on-premisesaws\""],
+                  @"En dash between words must be dropped with no hyphen left behind. Got: %@", html);
+}
+
+- (void)testHeadingAnchorIdDoesNotCollapseHyphenRuns
+{
+    NSString *html = [self renderMarkdown:@"## Foo --- Bar"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"foo-----bar\""],
+                  @"Consecutive spaces/hyphens must not collapse. Got: %@", html);
+}
+
+- (void)testHeadingAnchorIdKeepsUnchangedForOrdinaryUnicode
+{
+    NSString *html = [self renderMarkdown:@"## Introducción"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"introducción\""],
+                  @"Ordinary accented letters must pass through unchanged. Got: %@", html);
+}
+
+// Sanity check against a real-world heading (verbatim, not modified) from the
+// AWS certification study notes that originally surfaced this mismatch with
+// GitHub's slug algorithm.
+
+- (void)testHeadingAnchorIdMatchesGitHubForRealWorldHeading
+{
+    NSString *html = [self renderMarkdown:@"### Pregunta 16 — Conexión privada y consistente on-premises–AWS"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"pregunta-16--conexión-privada-y-consistente-on-premisesaws\""],
+                  @"Heading id must match GitHub's slug for real-world content. Got: %@", html);
+}
+
+- (void)testHeadingAnchorIdFallsBackToSectionForPunctuationOnlyHeading
+{
+    NSString *html = [self renderMarkdown:@"## ¡¿?!"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"section\""],
+                  @"A punctuation-only heading must fall back to the 'section' id. Got: %@", html);
 }
 
 #pragma mark - Empty Heading Crash Regression (#479)

--- a/MacDownTests/MPQuickLookRendererTests.m
+++ b/MacDownTests/MPQuickLookRendererTests.m
@@ -686,9 +686,12 @@
 
 - (void)testQuickLookHeadingAnchorIdSkipsMultipleEntities
 {
-    // "Tips & Tricks" renders as "Tips &amp; Tricks"; slug must be "tips-tricks".
+    // "Tips & Tricks" renders as "Tips &amp; Tricks"; the entity is skipped
+    // like GitHub drops the raw "&", but (matching GitHub's no-collapse
+    // behavior) the two spaces surrounding it each become their own hyphen:
+    // slug must be "tips--tricks".
     NSString *html = [self.renderer renderMarkdown:@"## Tips & Tricks"];
-    XCTAssertTrue([html containsString:@"id=\"tips-tricks\""],
+    XCTAssertTrue([html containsString:@"id=\"tips--tricks\""],
                   @"Quick Look heading id must skip every HTML entity. Got: %@", html);
 }
 
@@ -698,6 +701,58 @@
     NSString *html = [self.renderer renderMarkdown:@"# Hello, World!"];
     XCTAssertTrue([html containsString:@"id=\"hello-world\""],
                   @"Quick Look heading id should drop ASCII punctuation. Got: %@", html);
+}
+
+// GitHub-slugger parity (github-slugger semantics). Mirrors the acceptance
+// coverage in MPMarkdownRenderingTests. Context: #471.
+
+- (void)testQuickLookHeadingAnchorIdDropsEmDash
+{
+    NSString *html = [self.renderer renderMarkdown:@"## Pregunta 5 — Cobro de AWS Lambda"];
+    XCTAssertTrue([html containsString:@"id=\"pregunta-5--cobro-de-aws-lambda\""],
+                  @"Quick Look em dash must be dropped, not passed through raw. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdLowercasesLatin1Uppercase
+{
+    NSString *html = [self.renderer renderMarkdown:@"## Índice"];
+    XCTAssertTrue([html containsString:@"id=\"índice\""],
+                  @"Quick Look Latin-1 uppercase letters must be lowercased. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdDropsInvertedQuestionMark
+{
+    NSString *html = [self.renderer renderMarkdown:@"## ¿Qué es AWS?"];
+    XCTAssertTrue([html containsString:@"id=\"qué-es-aws\""],
+                  @"Quick Look inverted question mark and trailing '?' must be dropped. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdDropsEnDashBetweenWords
+{
+    NSString *html = [self.renderer renderMarkdown:@"## Conexión on-premises–AWS"];
+    XCTAssertTrue([html containsString:@"id=\"conexión-on-premisesaws\""],
+                  @"Quick Look en dash between words must be dropped with no hyphen left behind. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdDoesNotCollapseHyphenRuns
+{
+    NSString *html = [self.renderer renderMarkdown:@"## Foo --- Bar"];
+    XCTAssertTrue([html containsString:@"id=\"foo-----bar\""],
+                  @"Quick Look consecutive spaces/hyphens must not collapse. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdKeepsUnchangedForOrdinaryUnicode
+{
+    NSString *html = [self.renderer renderMarkdown:@"## Introducción"];
+    XCTAssertTrue([html containsString:@"id=\"introducción\""],
+                  @"Quick Look ordinary accented letters must pass through unchanged. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdFallsBackToSectionForPunctuationOnlyHeading
+{
+    NSString *html = [self.renderer renderMarkdown:@"## ¡¿?!"];
+    XCTAssertTrue([html containsString:@"id=\"section\""],
+                  @"Quick Look punctuation-only heading must fall back to the 'section' id. Got: %@", html);
 }
 
 // A bare setext underline ('-' or '=') makes Hoedown emit a heading with empty


### PR DESCRIPTION
## What

Align the heading-anchor slug algorithm with GitHub's `github-slugger`, so
`[text](#slug)` links copied from GitHub-rendered Markdown keep working in the
MacDown preview, exported HTML, and Quick Look.

## Why

Follow-up to #430 (which introduced text-derived heading ids). Using the
feature on a real-world GitHub-style TOC surfaced a functional gap (#503): the
previous `slugify()` let every byte `>= 0x80` pass through raw and only
lowercased ASCII, so Unicode punctuation survived into ids and the anchors
silently did nothing. It also collapsed hyphen runs, which GitHub does not do.

Concretely, before this change:

| Heading | Before | After (= GitHub) |
|---|---|---|
| `Chapter 2 — Getting Started` | `chapter-2-—-getting-started` ❌ | `chapter-2--getting-started` ✅ |
| `Überblick` | `Überblick` ❌ | `überblick` ✅ |
| `Foo --- Bar` | `foo-bar` ❌ | `foo-----bar` ✅ |
| `Introducción` | `introducción` ✅ | `introducción` ✅ (unchanged) |

## How

In the slug loop, decode UTF-8 codepoints instead of treating high bytes as
opaque:

- drop the Latin-1 punctuation/symbol block (U+00A1–U+00BF), the
  multiplication/division signs (U+00D7, U+00F7), and General Punctuation
  (U+2000–U+206F: em/en dashes, curly quotes, ellipsis, …);
- lowercase and re-encode Latin-1 uppercase letters (U+00C0–U+00DE, excluding
  U+00D7);
- pass every other codepoint through unchanged as raw UTF-8;
- malformed UTF-8 falls back to passing the raw byte through, as before.

On the ASCII side, map each space/tab to exactly one hyphen without collapsing
runs, and trim leading/trailing whitespace from the heading text.

The two byte-for-byte identical copies
(`MacDown/Code/Extension/hoedown_html_patch.c` and
`MacDownCore/MPQuickLookRenderer.m`) are kept in sync; consolidating them into
a shared unit is tracked separately in #471.

## Testing

- New parity tests mirrored across the preview (`MPMarkdownRenderingTests`) and
  Quick Look (`MPQuickLookRendererTests`) suites: em/en dash dropping, inverted
  punctuation, Latin-1 lowercasing, no hyphen-run collapse, ordinary-Unicode
  passthrough, punctuation-only `section` fallback, and a verbatim real-world
  heading.
- Full suite green locally (`109` tests, `0` failures), including the golden
  fixture comparison (no fixtures needed regeneration — their headings are
  plain ASCII).
- Verified navigation empirically in a real browser: clicking each rendered TOC
  anchor scrolls to its heading and updates `location.hash`, including the
  raw-UTF-8 ids (`#índice`, `#qué-es-aws`, `#conexión-on-premisesaws`),
  confirming the no-percent-encoding convention works.

## Known limitations (out of scope, tracked in #471)

- **Non-Latin-1 uppercase** (Cyrillic, Greek, Latin Extended — Turkish/Polish/
  Czech/…) is not lowercased; GitHub does. Symbols outside the covered blocks
  (CJK punctuation, arrows, emoji, …) are not dropped.
- **Duplicate-heading disambiguation** (`-1`/`-2` suffixes): identical headings
  still collapse to the same id (only the first is reachable by anchor). This
  is an open product decision in #471, not addressed here.
- **Code consolidation** of the two duplicated slug copies remains in #471.

Related to #503, #430, #471, #429.
