### PR TITLE
Add heading-slug parity tests and fix decoder comments (#503 review follow-up)

### DIFF
--- a/MacDown/Code/Extension/hoedown_html_patch.c
+++ b/MacDown/Code/Extension/hoedown_html_patch.c
@@ -173,9 +173,13 @@ void hoedown_patch_render_listitem(
 }
 
 // Decode the UTF-8 codepoint starting at data[i] (i < size). Returns the
-// number of bytes consumed (1-4) and stores the codepoint in *codepoint, or
-// returns 0 if the sequence is malformed / truncated, in which case the
-// caller should pass the raw byte through unchanged.
+// number of bytes consumed (1-4) and stores the codepoint in *codepoint.
+// Returns 0 when the lead byte is not a valid UTF-8 start byte, when the
+// sequence is truncated (fewer bytes remain than the lead byte promises), or
+// when a continuation byte is malformed; the caller then passes the raw byte
+// through unchanged. This is a lenient decoder: it recovers the codepoint but
+// does NOT reject overlong encodings or surrogate-range (U+D800-U+DFFF)
+// values, so it does not fully validate the sequence.
 static size_t decode_utf8_codepoint(const uint8_t *data, size_t size, size_t i,
                                      uint32_t *codepoint)
 {
@@ -228,9 +232,9 @@ static void encode_utf8_2byte(uint32_t cp, uint8_t out[2])
 // ellipsis, ...) are dropped entirely; every other codepoint passes through
 // unchanged as raw UTF-8 bytes (e.g. "Introducción" -> "introducción").
 // Malformed UTF-8 bytes are passed through unchanged rather than dropped.
-// Anchors keep their raw UTF-8 bytes (no percent-encoding): browsers match
-// the URL fragment against the id literally, so encoding would break
-// navigation.
+// Anchors keep their raw UTF-8 bytes (no percent-encoding), matching the id
+// convention GitHub emits so fragment links copied from GitHub-rendered
+// Markdown keep working.
 static void slugify(hoedown_buffer *out, const hoedown_buffer *content)
 {
     if (!content || !content->size)

--- a/MacDownCore/MPQuickLookRenderer.m
+++ b/MacDownCore/MPQuickLookRenderer.m
@@ -181,9 +181,13 @@ NS_INLINE NSString *MPQuickLookContentSecurityPolicy(void)
 #pragma mark - Hoedown Renderer Callbacks
 
 // Decode the UTF-8 codepoint starting at data[i] (i < size). Returns the
-// number of bytes consumed (1-4) and stores the codepoint in *codepoint, or
-// returns 0 if the sequence is malformed / truncated, in which case the
-// caller should pass the raw byte through unchanged.
+// number of bytes consumed (1-4) and stores the codepoint in *codepoint.
+// Returns 0 when the lead byte is not a valid UTF-8 start byte, when the
+// sequence is truncated (fewer bytes remain than the lead byte promises), or
+// when a continuation byte is malformed; the caller then passes the raw byte
+// through unchanged. This is a lenient decoder: it recovers the codepoint but
+// does NOT reject overlong encodings or surrogate-range (U+D800-U+DFFF)
+// values, so it does not fully validate the sequence.
 static size_t decode_utf8_codepoint(const uint8_t *data, size_t size, size_t i,
                                      uint32_t *codepoint)
 {
@@ -238,9 +242,9 @@ static void encode_utf8_2byte(uint32_t cp, uint8_t out[2])
 // ellipsis, ...) are dropped entirely; every other codepoint passes through
 // unchanged as raw UTF-8 bytes (e.g. "Introducción" -> "introducción").
 // Malformed UTF-8 bytes are passed through unchanged rather than dropped.
-// Anchors keep their raw UTF-8 bytes (no percent-encoding): browsers match
-// the URL fragment against the id literally, so encoding would break
-// navigation.
+// Anchors keep their raw UTF-8 bytes (no percent-encoding), matching the id
+// convention GitHub emits so fragment links copied from GitHub-rendered
+// Markdown keep working.
 static void mp_quicklook_slugify(hoedown_buffer *out, const hoedown_buffer *content)
 {
     if (!content || !content->size)

--- a/MacDownTests/MPMarkdownRenderingTests.m
+++ b/MacDownTests/MPMarkdownRenderingTests.m
@@ -1012,6 +1012,113 @@
                   @"A punctuation-only heading must fall back to the 'section' id. Got: %@", html);
 }
 
+#pragma mark - GitHub-slugger Parity: UTF-8 Decoder Coverage (#503)
+
+// These exercise decode_utf8_codepoint through the render path -- the newest
+// and most intricate code in the slug algorithm. Ground truth for every parity
+// assertion was captured by running github-slugger on the same input.
+// Related to #503, #471.
+
+// Valid 3-byte UTF-8 (CJK): decoded and, as ordinary letters, passed through
+// unchanged -- github-slugger parity ("日本語" -> "日本語").
+- (void)testHeadingAnchorIdPassesThroughThreeByteCJK
+{
+    NSString *html = [self renderMarkdown:@"## 日本語"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"日本語\""],
+                  @"Three-byte CJK codepoints must pass through unchanged. Got: %@", html);
+}
+
+// The U+00D7 (×) / U+00DE (Þ) boundary, symbol side: the multiplication sign is
+// dropped while surrounding text stays -- "3×4 Grid" -> "34-grid".
+- (void)testHeadingAnchorIdDropsMultiplicationSignAtBoundary
+{
+    NSString *html = [self renderMarkdown:@"## 3×4 Grid"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"34-grid\""],
+                  @"The U+00D7 multiplication sign must be dropped. Got: %@", html);
+}
+
+// The same boundary, letter side: Þ (U+00DE) and Ð (U+00D0) both lowercase to
+// their two-byte forms -- "Þorn Ðeth" -> "þorn-ðeth".
+- (void)testHeadingAnchorIdLowercasesLatin1BoundaryLetters
+{
+    NSString *html = [self renderMarkdown:@"## Þorn Ðeth"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"þorn-ðeth\""],
+                  @"Þ and Ð must lowercase to þ and ð. Got: %@", html);
+}
+
+// Back-to-back dropped codepoints (em dash, en dash, ellipsis) collapse to
+// nothing, leaving no stray hyphens -- "Foo—–…Bar" -> "foobar".
+- (void)testHeadingAnchorIdDropsConsecutivePunctuationCodepoints
+{
+    NSString *html = [self renderMarkdown:@"## Foo—–…Bar"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"foobar\""],
+                  @"Consecutive dropped punctuation must leave no hyphens. Got: %@", html);
+}
+
+// Valid 4-byte UTF-8 (emoji) is decoded and passed through raw. This is a
+// documented scope boundary, NOT github-slugger parity: github-slugger drops
+// emoji ("😀 Hi" -> "-hi"), but our algorithm only classifies the Latin-1 and
+// General Punctuation ranges and passes every other codepoint through, so the
+// emoji survives. The test pins today's behavior.
+- (void)testHeadingAnchorIdPassesThroughFourByteEmoji
+{
+    NSString *html = [self renderMarkdown:@"## 😀 Hi"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"😀-hi\""],
+                  @"Four-byte emoji must be decoded and passed through raw. Got: %@", html);
+}
+
+#pragma mark - GitHub-slugger Parity: Leading Hyphen (#503)
+
+// A heading that starts with dropped punctuation followed by a space yields a
+// leading hyphen. Verified against github-slugger ("— Título" -> "-título"),
+// so the leading hyphen is intentional GitHub parity, not a bug. Related to
+// #503.
+- (void)testHeadingAnchorIdKeepsLeadingHyphenFromDroppedPunctuation
+{
+    NSString *html = [self renderMarkdown:@"## — Título"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"-título\""],
+                  @"A leading dropped em dash + space must yield a leading hyphen. Got: %@", html);
+}
+
+#pragma mark - GitHub-slugger Parity: Scope Boundary (#503)
+
+// Documented divergence: github-slugger lowercases every script via
+// String.toLowerCase() ("Привет Мир" -> "привет-мир"), but our algorithm only
+// lowercases the Latin-1 range and passes every other letter through raw, so
+// Cyrillic keeps its original case. This pins today's behavior to make the
+// scope boundary explicit for future readers. Related to #503, #471.
+- (void)testHeadingAnchorIdDoesNotLowercaseCyrillic
+{
+    NSString *html = [self renderMarkdown:@"## Привет Мир"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"Привет-Мир\""],
+                  @"Cyrillic is passed through without lowercasing (scope boundary). Got: %@", html);
+}
+
+// Same scope boundary for Greek: github-slugger gives "καλημέρα-κόσμε"; we keep
+// the original case.
+- (void)testHeadingAnchorIdDoesNotLowercaseGreek
+{
+    NSString *html = [self renderMarkdown:@"## Καλημέρα Κόσμε"
+                           withExtensions:0
+                            rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"Καλημέρα-Κόσμε\""],
+                  @"Greek is passed through without lowercasing (scope boundary). Got: %@", html);
+}
+
 #pragma mark - Empty Heading Crash Regression (#479)
 
 // A lone setext underline ('-' or '=') with no preceding text makes Hoedown

--- a/MacDownTests/MPQuickLookRendererTests.m
+++ b/MacDownTests/MPQuickLookRendererTests.m
@@ -755,6 +755,81 @@
                   @"Quick Look punctuation-only heading must fall back to the 'section' id. Got: %@", html);
 }
 
+// Sanity check against a real-world heading (verbatim) mirroring the preview's
+// coverage, so the two hand-synced slug copies cannot drift. Related to #503.
+
+- (void)testQuickLookHeadingAnchorIdMatchesGitHubForRealWorldHeading
+{
+    NSString *html = [self.renderer renderMarkdown:@"### Pregunta 16 — Conexión privada y consistente on-premises–AWS"];
+    XCTAssertTrue([html containsString:@"id=\"pregunta-16--conexión-privada-y-consistente-on-premisesaws\""],
+                  @"Quick Look heading id must match GitHub's slug for real-world content. Got: %@", html);
+}
+
+// UTF-8 decoder coverage mirroring MPMarkdownRenderingTests. Ground truth
+// captured from github-slugger. Related to #503, #471.
+
+- (void)testQuickLookHeadingAnchorIdPassesThroughThreeByteCJK
+{
+    NSString *html = [self.renderer renderMarkdown:@"## 日本語"];
+    XCTAssertTrue([html containsString:@"id=\"日本語\""],
+                  @"Quick Look three-byte CJK codepoints must pass through unchanged. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdDropsMultiplicationSignAtBoundary
+{
+    NSString *html = [self.renderer renderMarkdown:@"## 3×4 Grid"];
+    XCTAssertTrue([html containsString:@"id=\"34-grid\""],
+                  @"Quick Look U+00D7 multiplication sign must be dropped. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdLowercasesLatin1BoundaryLetters
+{
+    NSString *html = [self.renderer renderMarkdown:@"## Þorn Ðeth"];
+    XCTAssertTrue([html containsString:@"id=\"þorn-ðeth\""],
+                  @"Quick Look Þ and Ð must lowercase to þ and ð. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdDropsConsecutivePunctuationCodepoints
+{
+    NSString *html = [self.renderer renderMarkdown:@"## Foo—–…Bar"];
+    XCTAssertTrue([html containsString:@"id=\"foobar\""],
+                  @"Quick Look consecutive dropped punctuation must leave no hyphens. Got: %@", html);
+}
+
+// Documented scope boundary, not github-slugger parity: github-slugger drops
+// emoji ("😀 Hi" -> "-hi"); our algorithm passes the 4-byte codepoint through.
+- (void)testQuickLookHeadingAnchorIdPassesThroughFourByteEmoji
+{
+    NSString *html = [self.renderer renderMarkdown:@"## 😀 Hi"];
+    XCTAssertTrue([html containsString:@"id=\"😀-hi\""],
+                  @"Quick Look four-byte emoji must be decoded and passed through raw. Got: %@", html);
+}
+
+// Verified against github-slugger ("— Título" -> "-título"): the leading hyphen
+// is intentional GitHub parity. Related to #503.
+- (void)testQuickLookHeadingAnchorIdKeepsLeadingHyphenFromDroppedPunctuation
+{
+    NSString *html = [self.renderer renderMarkdown:@"## — Título"];
+    XCTAssertTrue([html containsString:@"id=\"-título\""],
+                  @"Quick Look leading dropped em dash + space must yield a leading hyphen. Got: %@", html);
+}
+
+// Documented scope boundary: github-slugger lowercases every script; our
+// algorithm only lowercases Latin-1, so Cyrillic and Greek keep their case.
+- (void)testQuickLookHeadingAnchorIdDoesNotLowercaseCyrillic
+{
+    NSString *html = [self.renderer renderMarkdown:@"## Привет Мир"];
+    XCTAssertTrue([html containsString:@"id=\"Привет-Мир\""],
+                  @"Quick Look Cyrillic is passed through without lowercasing. Got: %@", html);
+}
+
+- (void)testQuickLookHeadingAnchorIdDoesNotLowercaseGreek
+{
+    NSString *html = [self.renderer renderMarkdown:@"## Καλημέρα Κόσμε"];
+    XCTAssertTrue([html containsString:@"id=\"Καλημέρα-Κόσμε\""],
+                  @"Quick Look Greek is passed through without lowercasing. Got: %@", html);
+}
+
 // A bare setext underline ('-' or '=') makes Hoedown emit a heading with empty
 // content. The Quick Look renderer mirrors the preview's slug logic, so it has
 // the same zero-unit buffer hazard and must also survive empty headings without


### PR DESCRIPTION
Follow-up to the merged PR #512, addressing the review suggestions left on #503. **No change to the slug algorithm itself** — each divergence was verified against `github-slugger` before being pinned in a test.

## Review suggestions addressed

| # | Suggestion | What changed |
|---|---|---|
| 1 | QuickLook test parity | Ported the missing `RealWorldHeading` mirror and mirrored every new test into `MPQuickLookRendererTests` |
| 2 | Decoder unit tests | Added `decode_utf8_codepoint` coverage through the render path (3-byte CJK, U+00D7/U+00DE boundary, back-to-back drops, 4-byte emoji) |
| 3 | Leading-hyphen edge case | Verified against github-slugger (`— Título` → `-título`) and pinned it — the leading hyphen is intentional GitHub parity |
| 4 | Scope-limitation guardrail | Negative tests documenting that Cyrillic/Greek are **not** lowercased (github-slugger lowercases them; we deliberately scope to Latin-1) |
| 5 | Comment accuracy on the decoder | Rewrote `decode_utf8_codepoint`'s doc comment to state what it actually validates and that it does not reject overlong / surrogate-range values |
| 6 | Stale comment line | Dropped the inaccurate "encoding would break navigation" clause in both `slugify` copies |

## Notes

- The malformed/truncated UTF-8 branch of the decoder is unreachable through the `NSString` render entry point (an `NSString` is always valid Unicode), so it is covered by reasoning rather than an integration test. The reachable branches (valid multi-byte + range boundaries) are tested.
- All parity expectations were captured by running `github-slugger` locally on the same inputs.

## Verification

`xcodebuild test` on macOS — 17 new tests pass across both suites (8 preview + 9 Quick Look, the latter with `ENABLE_QUICKLOOK_TESTS=1`).

Related to #503, #512, #471.