### PR TITLE
Unify editor and preview zoom

### DIFF
--- a/MacDown 3000.xcodeproj/project.pbxproj
+++ b/MacDown 3000.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		BA2B9EC2E95175092A97B41E /* MPResourceWatcherSet.m in Sources */ = {isa = PBXBuildFile; fileRef = E6D070A6E080254A17B3B197 /* MPResourceWatcherSet.m */; };
 		CCD97578A2886FFE73BD96F7 /* MPMathJaxRenderingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6811F39B13C649FC86C4CE5B /* MPMathJaxRenderingTests.m */; };
 		CHKBOXTGL0001BUILDFILER /* MPCheckboxToggleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CHKBOXTGL0001FILEREFID /* MPCheckboxToggleTests.m */; };
+		PRVZMTST0001BUILDFILER /* MPPreviewZoomTests.m in Sources */ = {isa = PBXBuildFile; fileRef = PRVZMTST0001FILEREFID /* MPPreviewZoomTests.m */; };
 		D29776CC6E7EB5B4AA2E0537 /* MPFileWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = A81247E840EB5C07669FF165 /* MPFileWatcher.m */; };
 		D3877A6637DE48017448C8DB /* MPRendererTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E2FC4B9389A012264DC6214 /* MPRendererTestHelpers.m */; };
 		DCD310373F0CCB56C7DFD720 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FEC7D0105F2CD0464F4B6AA /* Quartz.framework */; };
@@ -626,6 +627,7 @@
 		CHKBOXTGL0001FILEREFID /* MPCheckboxToggleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPCheckboxToggleTests.m; sourceTree = "<group>"; };
 		D30FDB4BDFBD13C1577ECFB4 /* MacDownCore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MacDownCore/MacDownCore.h; sourceTree = SOURCE_ROOT; };
 		D80F0F27E815934603CB0A05 /* MacDownQuickLook.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MacDownQuickLook.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		PRVZMTST0001FILEREFID /* MPPreviewZoomTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPPreviewZoomTests.m; sourceTree = "<group>"; };
 		DDDB87873110C02114439C2C /* MPFileWatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPFileWatcher.h; sourceTree = "<group>"; };
 		E64879065D20A4124AD56945 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = MacDownQuickLook/Info.plist; sourceTree = SOURCE_ROOT; };
 		E6D070A6E080254A17B3B197 /* MPResourceWatcherSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPResourceWatcherSet.m; sourceTree = "<group>"; };
@@ -1086,6 +1088,7 @@
 				197TESTS0F00000000197RSTF /* MPRendererStateTests.m */,
 				C2B84BF8A8BC4F4B871646F8 /* MPScrollSyncTests.m */,
 				CHKBOXTGL0001FILEREFID /* MPCheckboxToggleTests.m */,
+				PRVZMTST0001FILEREFID /* MPPreviewZoomTests.m */,
 				ISSUE285SMARTQTFILEREF /* MPSmartQuoteTests.m */,
 				1FFEB3261972DAB400B2254F /* MPHTMLTabularizeTests.m */,
 				1FFEB32F19ABCD1500B2254F /* MPMarkdownRenderingTests.m */,
@@ -1779,6 +1782,7 @@
 				03224E1B02E36783D5307F4A /* MPDocumentIOTests.m in Sources */,
 				B9A8DE030E3748EB899BD45E /* MPScrollSyncTests.m in Sources */,
 				CHKBOXTGL0001BUILDFILER /* MPCheckboxToggleTests.m in Sources */,
+				PRVZMTST0001BUILDFILER /* MPPreviewZoomTests.m in Sources */,
 				ISSUE285SMARTQTBUILDFILE /* MPSmartQuoteTests.m in Sources */,
 				1F51C9A5194565050015A96F /* MPPreferencesTests.m in Sources */,
 				1FF1420419A8A24800CF8A6A /* MPUtilityTests.m in Sources */,

--- a/MacDown 3000.xcodeproj/project.pbxproj
+++ b/MacDown 3000.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		03224E1B02E36783D5307F4A /* MPDocumentIOTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35FB5AC5D9A67BFB58A9430F /* MPDocumentIOTests.m */; };
 		0A33AF1E979F50E868FEE7DC /* libPods-MacDownCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F2375876A05ADEB6544CB4EB /* libPods-MacDownCore.a */; };
 		1457815B1A710E4C40F07FCA /* MPPaneToggleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E44CF1BD72E49A99DA6A4C1 /* MPPaneToggleTests.m */; };
+		A1B2C3D4E5F67890ABCDEF12 /* MPZoomTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F67890ABCDEF1234 /* MPZoomTests.m */; };
 		197TESTS0B00000000197RSTB /* MPRendererStateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 197TESTS0F00000000197RSTF /* MPRendererStateTests.m */; };
 		1F002A23195B3DAE008B8D93 /* MPRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F002A22195B3DAE008B8D93 /* MPRenderer.m */; };
 		1F0D9D65194AC7CF008E1856 /* NSString+Lookup.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0D9D5F194AC7CF008E1856 /* NSString+Lookup.m */; };
@@ -591,6 +592,7 @@
 		5C2E23A49DBCCD5CFA3B8104 /* libPods-MacDownQuickLook.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MacDownQuickLook.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CE5C37476A61D05FCC741F9 /* MPQuickLookPreferences.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MacDownCore/MPQuickLookPreferences.h; sourceTree = SOURCE_ROOT; };
 		5E44CF1BD72E49A99DA6A4C1 /* MPPaneToggleTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPPaneToggleTests.m; sourceTree = "<group>"; };
+		B2C3D4E5F67890ABCDEF1234 /* MPZoomTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MPZoomTests.m; sourceTree = "<group>"; };
 		5F23020AD4494E700E72C264 /* MPRendererTestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPRendererTestHelpers.h; sourceTree = "<group>"; };
 		615588251EB35DEE6204B94E /* MPResourceWatcherSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPResourceWatcherSet.h; sourceTree = "<group>"; };
 		6811F39B13C649FC86C4CE5B /* MPMathJaxRenderingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPMathJaxRenderingTests.m; sourceTree = "<group>"; };
@@ -1122,6 +1124,7 @@
 				QLTST00002PREF00000M /* MPQuickLookPreferencesTests.m */,
 				QLTST00003PVCT00000M /* MPPreviewViewControllerTests.m */,
 				5E44CF1BD72E49A99DA6A4C1 /* MPPaneToggleTests.m */,
+				B2C3D4E5F67890ABCDEF1234 /* MPZoomTests.m */,
 			);
 			path = MacDownTests;
 			sourceTree = "<group>";
@@ -1824,6 +1827,7 @@
 				QLBLD00005PREFTESTSRC /* MPQuickLookPreferencesTests.m in Sources */,
 				QLBLD00006PVCTESTSRC0 /* MPPreviewViewControllerTests.m in Sources */,
 				1457815B1A710E4C40F07FCA /* MPPaneToggleTests.m in Sources */,
+				A1B2C3D4E5F67890ABCDEF12 /* MPZoomTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -7,6 +7,7 @@
 //
 
 #import "MPToolbarController.h"
+#import "MPPreferences.h"
 
 // Because we're creating selectors for methods which aren't in this class
 #pragma GCC diagnostic ignored "-Wundeclared-selector"
@@ -14,6 +15,16 @@
 
 
 static CGFloat itemWidth = 37;
+// Preview-zoom presets must match MPPreviewZoomLevels() in MPDocument.m.
+static NSArray<NSNumber *> *MPToolbarPreviewZoomLevels(void)
+{
+    static NSArray *levels = nil;
+    static dispatch_once_t token;
+    dispatch_once(&token, ^{
+        levels = @[@0.5, @0.75, @0.9, @1.0, @1.1, @1.25, @1.5, @2.0];
+    });
+    return levels;
+}
 
 
 @implementation MPToolbarController
@@ -33,22 +44,58 @@ static CGFloat itemWidth = 37;
      * created, so we can't set target = self.document at construction time.
      */
     NSMutableDictionary<NSString *, NSString *> *standaloneItemActions;
+
+    /**
+     * Weak reference to the zoom popup so we can re-sync its selected item
+     * when the preference changes from elsewhere (menu, keyboard shortcut).
+     */
+    __weak NSPopUpButton *_zoomPopUp;
 }
 
 - (id)init
 {
     self = [super init];
-    
+
     if (!self)
     {
         return nil;
     }
-    
+
     self->toolbarItemIdentifierObjectDictionary = [NSMutableDictionary new];
     self->standaloneItemActions = [NSMutableDictionary new];
     [self setupToolbarItems];
-    
+
+    // Observe NSUserDefaults so the popup's selection reflects external
+    // changes (View menu actions, ⌘+/⌘-/⌘0). Using KVO on the standard
+    // defaults avoids threading a sync callback through MPDocument.
+    [[NSUserDefaults standardUserDefaults]
+        addObserver:self
+         forKeyPath:@"previewZoomLevel"
+            options:NSKeyValueObservingOptionNew
+            context:NULL];
+
     return self;
+}
+
+- (void)dealloc
+{
+    @try {
+        [[NSUserDefaults standardUserDefaults]
+            removeObserver:self forKeyPath:@"previewZoomLevel"];
+    } @catch (NSException *exception) {
+        // removeObserver may throw if not registered; ignore on teardown.
+    }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey,id> *)change
+                       context:(void *)context
+{
+    if ([keyPath isEqualToString:@"previewZoomLevel"])
+    {
+        [self syncPreviewZoomDisplay];
+    }
 }
 
 
@@ -97,10 +144,14 @@ static CGFloat itemWidth = 37;
             @[
               toggleEditorMenuItem, togglePreviewMenuItem
             ]
-        ]
+        ],
+        [self toolbarItemZoomPopUpWithIdentifier:@"preview-zoom" label:NSLocalizedString(@"Preview Zoom", @"Preview pane zoom toolbar item")]
     ];
-    
+
     self->toolbarItemIdentifiers = [self toolbarItemIdentifiersFromItemsArray:self->toolbarItems];
+
+    // Reflect the persisted preference once everything is wired up.
+    [self syncPreviewZoomDisplay];
 }
 
 /**
@@ -400,12 +451,79 @@ static CGFloat itemWidth = 37;
         [[popupButton lastItem] setTarget:self];
         [[popupButton lastItem] setAction:@selector(dropdownMenuItemClicked:)];
     }
-    
+
     toolbarItem.view = popupButton;
-    
+
     [self->toolbarItemIdentifierObjectDictionary setObject:toolbarItem forKey:itemIdentifier];
-    
+
     return toolbarItem;
+}
+
+/**
+ * Factory method for the preview-zoom popup. Unlike the layout dropdown
+ * this is a regular (non-pull-down) NSPopUpButton: the currently selected
+ * item is shown as the button label so the user sees the active zoom
+ * percentage at a glance. Each menu item is wired to
+ * -selectPreviewZoom: on the document, with the target zoom level
+ * (NSNumber) attached as the item's representedObject.
+ */
+- (NSToolbarItem *)toolbarItemZoomPopUpWithIdentifier:(NSString *)itemIdentifier label:(NSString *)label
+{
+    NSToolbarItem *toolbarItem = [[NSToolbarItem alloc] initWithItemIdentifier:itemIdentifier];
+    toolbarItem.label = label;
+    toolbarItem.paletteLabel = label;
+    toolbarItem.toolTip = label;
+
+    NSPopUpButton *popupButton = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 70, 27) pullsDown:NO];
+    popupButton.bezelStyle = NSBezelStyleTexturedRounded;
+    popupButton.focusRingType = NSFocusRingTypeDefault;
+
+    NSArray<NSNumber *> *levels = MPToolbarPreviewZoomLevels();
+    for (NSNumber *level in levels)
+    {
+        NSString *title = [NSString stringWithFormat:@"%.0f%%", level.doubleValue * 100.0];
+        [popupButton addItemWithTitle:title];
+        NSMenuItem *added = [popupButton lastItem];
+        added.representedObject = level;
+        added.target = self.document;
+        added.action = @selector(selectPreviewZoom:);
+    }
+
+    toolbarItem.view = popupButton;
+
+    [self->toolbarItemIdentifierObjectDictionary setObject:toolbarItem forKey:itemIdentifier];
+    _zoomPopUp = popupButton;
+
+    return toolbarItem;
+}
+
+/**
+ * Update the popup's selection to match the current preview-zoom
+ * preference. If the current preference matches a preset (within
+ * epsilon), that item is selected. Otherwise the popup falls back to
+ * the closest preset so the button always shows a sensible label.
+ */
+- (void)syncPreviewZoomDisplay
+{
+    NSPopUpButton *popup = _zoomPopUp;
+    if (!popup)
+        return;
+
+    CGFloat current = [MPPreferences sharedInstance].previewZoomLevel;
+    NSArray<NSNumber *> *levels = MPToolbarPreviewZoomLevels();
+
+    NSUInteger nearestIdx = 0;
+    CGFloat bestDiff = CGFLOAT_MAX;
+    for (NSUInteger i = 0; i < levels.count; i++)
+    {
+        CGFloat diff = fabs(levels[i].doubleValue - current);
+        if (diff < bestDiff)
+        {
+            bestDiff = diff;
+            nearestIdx = i;
+        }
+    }
+    [popup selectItemAtIndex:(NSInteger)nearestIdx];
 }
 
 

--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -15,13 +15,13 @@
 
 
 static CGFloat itemWidth = 37;
-// Preview-zoom presets must match MPPreviewZoomLevels() in MPDocument.m.
-static NSArray<NSNumber *> *MPToolbarPreviewZoomLevels(void)
+// Document-zoom presets must match MPDocumentZoomLevels() in MPDocument.m.
+static NSArray<NSNumber *> *MPToolbarDocumentZoomLevels(void)
 {
     static NSArray *levels = nil;
     static dispatch_once_t token;
     dispatch_once(&token, ^{
-        levels = @[@0.5, @0.75, @0.9, @1.0, @1.1, @1.25, @1.5, @2.0];
+        levels = @[@0.5, @0.75, @0.9, @1.0, @1.1, @1.25, @1.5, @2.0, @3.0];
     });
     return levels;
 }
@@ -70,7 +70,7 @@ static NSArray<NSNumber *> *MPToolbarPreviewZoomLevels(void)
     // defaults avoids threading a sync callback through MPDocument.
     [[NSUserDefaults standardUserDefaults]
         addObserver:self
-         forKeyPath:@"previewZoomLevel"
+         forKeyPath:@"documentZoomLevel"
             options:NSKeyValueObservingOptionNew
             context:NULL];
 
@@ -81,7 +81,7 @@ static NSArray<NSNumber *> *MPToolbarPreviewZoomLevels(void)
 {
     @try {
         [[NSUserDefaults standardUserDefaults]
-            removeObserver:self forKeyPath:@"previewZoomLevel"];
+            removeObserver:self forKeyPath:@"documentZoomLevel"];
     } @catch (NSException *exception) {
         // removeObserver may throw if not registered; ignore on teardown.
     }
@@ -92,9 +92,9 @@ static NSArray<NSNumber *> *MPToolbarPreviewZoomLevels(void)
                         change:(NSDictionary<NSKeyValueChangeKey,id> *)change
                        context:(void *)context
 {
-    if ([keyPath isEqualToString:@"previewZoomLevel"])
+    if ([keyPath isEqualToString:@"documentZoomLevel"])
     {
-        [self syncPreviewZoomDisplay];
+        [self syncDocumentZoomDisplay];
     }
 }
 
@@ -145,13 +145,13 @@ static NSArray<NSNumber *> *MPToolbarPreviewZoomLevels(void)
               toggleEditorMenuItem, togglePreviewMenuItem
             ]
         ],
-        [self toolbarItemZoomPopUpWithIdentifier:@"preview-zoom" label:NSLocalizedString(@"Preview Zoom", @"Preview pane zoom toolbar item")]
+        [self toolbarItemDocumentZoomPopUpWithIdentifier:@"document-zoom" label:NSLocalizedString(@"Zoom", @"Preview pane zoom toolbar item")]
     ];
 
     self->toolbarItemIdentifiers = [self toolbarItemIdentifiersFromItemsArray:self->toolbarItems];
 
     // Reflect the persisted preference once everything is wired up.
-    [self syncPreviewZoomDisplay];
+    [self syncDocumentZoomDisplay];
 }
 
 /**
@@ -460,14 +460,14 @@ static NSArray<NSNumber *> *MPToolbarPreviewZoomLevels(void)
 }
 
 /**
- * Factory method for the preview-zoom popup. Unlike the layout dropdown
+ * Factory method for the document-zoom popup. Unlike the layout dropdown
  * this is a regular (non-pull-down) NSPopUpButton: the currently selected
  * item is shown as the button label so the user sees the active zoom
  * percentage at a glance. Each menu item is wired to
- * -selectPreviewZoom: on the document, with the target zoom level
+ * -selectDocumentZoom: on the document, with the target zoom level
  * (NSNumber) attached as the item's representedObject.
  */
-- (NSToolbarItem *)toolbarItemZoomPopUpWithIdentifier:(NSString *)itemIdentifier label:(NSString *)label
+- (NSToolbarItem *)toolbarItemDocumentZoomPopUpWithIdentifier:(NSString *)itemIdentifier label:(NSString *)label
 {
     NSToolbarItem *toolbarItem = [[NSToolbarItem alloc] initWithItemIdentifier:itemIdentifier];
     toolbarItem.label = label;
@@ -478,7 +478,7 @@ static NSArray<NSNumber *> *MPToolbarPreviewZoomLevels(void)
     popupButton.bezelStyle = NSBezelStyleTexturedRounded;
     popupButton.focusRingType = NSFocusRingTypeDefault;
 
-    NSArray<NSNumber *> *levels = MPToolbarPreviewZoomLevels();
+    NSArray<NSNumber *> *levels = MPToolbarDocumentZoomLevels();
     for (NSNumber *level in levels)
     {
         NSString *title = [NSString stringWithFormat:@"%.0f%%", level.doubleValue * 100.0];
@@ -486,7 +486,7 @@ static NSArray<NSNumber *> *MPToolbarPreviewZoomLevels(void)
         NSMenuItem *added = [popupButton lastItem];
         added.representedObject = level;
         added.target = self.document;
-        added.action = @selector(selectPreviewZoom:);
+        added.action = @selector(selectDocumentZoom:);
     }
 
     toolbarItem.view = popupButton;
@@ -498,19 +498,19 @@ static NSArray<NSNumber *> *MPToolbarPreviewZoomLevels(void)
 }
 
 /**
- * Update the popup's selection to match the current preview-zoom
+ * Update the popup's selection to match the current document-zoom
  * preference. If the current preference matches a preset (within
  * epsilon), that item is selected. Otherwise the popup falls back to
  * the closest preset so the button always shows a sensible label.
  */
-- (void)syncPreviewZoomDisplay
+- (void)syncDocumentZoomDisplay
 {
     NSPopUpButton *popup = _zoomPopUp;
     if (!popup)
         return;
 
-    CGFloat current = [MPPreferences sharedInstance].previewZoomLevel;
-    NSArray<NSNumber *> *levels = MPToolbarPreviewZoomLevels();
+    CGFloat current = [MPPreferences sharedInstance].documentZoomLevel;
+    NSArray<NSNumber *> *levels = MPToolbarDocumentZoomLevels();
 
     NSUInteger nearestIdx = 0;
     CGFloat bestDiff = CGFLOAT_MAX;

--- a/MacDown/Code/Document/MPDocument.h
+++ b/MacDown/Code/Document/MPDocument.h
@@ -27,4 +27,31 @@
  */
 + (NSString *)toggleCheckboxAtIndex:(NSUInteger)index inMarkdown:(NSString *)markdown;
 
+/**
+ * Step the preview pane zoom level up to the next preset.
+ * Snaps to the next preset > current; beeps if already at the maximum.
+ * Bound to View > Zoom In (Command-+).
+ */
+- (IBAction)zoomPreviewIn:(id)sender;
+
+/**
+ * Step the preview pane zoom level down to the previous preset.
+ * Snaps to the next preset < current; beeps if already at the minimum.
+ * Bound to View > Zoom Out (Command--).
+ */
+- (IBAction)zoomPreviewOut:(id)sender;
+
+/**
+ * Reset the preview pane zoom level to 100%.
+ * Bound to View > Actual Size (Command-0).
+ */
+- (IBAction)actualPreviewSize:(id)sender;
+
+/**
+ * Set the preview pane zoom to the level represented by the sender's
+ * representedObject (NSNumber). Sender may be an NSMenuItem or
+ * NSPopUpButton; the toolbar dropdown uses this entry point.
+ */
+- (IBAction)selectPreviewZoom:(id)sender;
+
 @end

--- a/MacDown/Code/Document/MPDocument.h
+++ b/MacDown/Code/Document/MPDocument.h
@@ -28,30 +28,13 @@
 + (NSString *)toggleCheckboxAtIndex:(NSUInteger)index inMarkdown:(NSString *)markdown;
 
 /**
- * Step the preview pane zoom level up to the next preset.
- * Snaps to the next preset > current; beeps if already at the maximum.
- * Bound to View > Zoom In (Command-+).
- */
-- (IBAction)zoomPreviewIn:(id)sender;
-
-/**
- * Step the preview pane zoom level down to the previous preset.
- * Snaps to the next preset < current; beeps if already at the minimum.
- * Bound to View > Zoom Out (Command--).
- */
-- (IBAction)zoomPreviewOut:(id)sender;
-
-/**
- * Reset the preview pane zoom level to 100%.
- * Bound to View > Actual Size (Command-0).
- */
-- (IBAction)actualPreviewSize:(id)sender;
-
-/**
  * Set the preview pane zoom to the level represented by the sender's
  * representedObject (NSNumber). Sender may be an NSMenuItem or
  * NSPopUpButton; the toolbar dropdown uses this entry point.
  */
 - (IBAction)selectPreviewZoom:(id)sender;
+- (IBAction)zoomIn:(id)sender;
+- (IBAction)zoomOut:(id)sender;
+- (IBAction)resetZoom:(id)sender;
 
 @end

--- a/MacDown/Code/Document/MPDocument.h
+++ b/MacDown/Code/Document/MPDocument.h
@@ -28,11 +28,11 @@
 + (NSString *)toggleCheckboxAtIndex:(NSUInteger)index inMarkdown:(NSString *)markdown;
 
 /**
- * Set the preview pane zoom to the level represented by the sender's
+ * Set the shared document zoom to the level represented by the sender's
  * representedObject (NSNumber). Sender may be an NSMenuItem or
  * NSPopUpButton; the toolbar dropdown uses this entry point.
  */
-- (IBAction)selectPreviewZoom:(id)sender;
+- (IBAction)selectDocumentZoom:(id)sender;
 - (IBAction)zoomIn:(id)sender;
 - (IBAction)zoomOut:(id)sender;
 - (IBAction)resetZoom:(id)sender;

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2510,7 +2510,10 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
 - (IBAction)toggleEditorPane:(id)sender
 {
+    BOOL wasVisible = self.editorVisible;
     [self toggleSplitterCollapsingEditorPane:YES];
+    if (self.editorVisible != wasVisible)
+        self.preferences.editorStartInPreviewMode = !self.editorVisible;
 }
 
 - (IBAction)toggleAutoSave:(id)sender

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -301,6 +301,9 @@ typedef NS_ENUM(NSInteger, MPReferenceKind) {
 // Store file content in initializer until nib is loaded.
 @property (copy) NSString *loadedString;
 
+// Transient per-document zoom level (not saved to preferences)
+@property CGFloat zoomMultiplier;
+
 - (void)scaleWebview;
 - (void)syncScrollers;
 - (void)syncScrollersReverse;
@@ -583,6 +586,7 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     self.volumeLocalityChecker = ^BOOL(NSString *path) {
         return [MPFileWatcher pathIsOnLocalVolume:path];
     };
+    self.zoomMultiplier = 1.0;
 
     return self;
 }
@@ -1051,7 +1055,23 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 {
     BOOL result = [super validateUserInterfaceItem:item];
     SEL action = item.action;
-    if (action == @selector(toggleToolbar:))
+    
+    // Zoom menu validation
+    if (action == @selector(zoomIn:))
+    {
+        static const CGFloat kMaxZoom = 3.0;
+        return self.zoomMultiplier < kMaxZoom;
+    }
+    else if (action == @selector(zoomOut:))
+    {
+        static const CGFloat kMinZoom = 0.5;
+        return self.zoomMultiplier > kMinZoom;
+    }
+    else if (action == @selector(resetZoom:))
+    {
+        return self.zoomMultiplier != 1.0;
+    }
+    else if (action == @selector(toggleToolbar:))
     {
         NSMenuItem *it = ((NSMenuItem *)item);
         it.title = self.toolbarVisible ?
@@ -2892,7 +2912,7 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
         return;
 
     static const CGFloat defaultSize = 14.0;
-    CGFloat scale = fontSize / defaultSize;
+    CGFloat scale = (fontSize / defaultSize) * self.zoomMultiplier;
     
 #if 0
     // Sadly, this doesn’t work correctly.
@@ -2906,6 +2926,45 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     // Warning: this is private webkit API and NOT App Store-safe!
     [self.preview setPageSizeMultiplier:scale];
 #endif
+}
+
+- (IBAction)zoomIn:(id)sender
+{
+    static const CGFloat kMaxZoom = 3.0;
+    if (self.zoomMultiplier >= kMaxZoom)
+        return;
+    
+    self.zoomMultiplier = MIN(self.zoomMultiplier + 0.1, kMaxZoom);
+    [self applyCurrentZoom];
+}
+
+- (IBAction)zoomOut:(id)sender
+{
+    static const CGFloat kMinZoom = 0.5;
+    if (self.zoomMultiplier <= kMinZoom)
+        return;
+    
+    self.zoomMultiplier = MAX(self.zoomMultiplier - 0.1, kMinZoom);
+    [self applyCurrentZoom];
+}
+
+- (IBAction)resetZoom:(id)sender
+{
+    self.zoomMultiplier = 1.0;
+    [self applyCurrentZoom];
+}
+
+- (void)applyCurrentZoom
+{
+    NSFont *baseFont = self.preferences.editorBaseFont;
+    CGFloat zoomedSize = baseFont.pointSize * self.zoomMultiplier;
+    
+    // Apply zoom to editor (transient, not saved to preferences)
+    [self.editor setFont:[NSFont fontWithName:baseFont.fontName
+                                         size:zoomedSize]];
+    
+    // Apply zoom to preview
+    [self scaleWebview];
 }
 
 /**

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -304,7 +304,6 @@ typedef NS_ENUM(NSInteger, MPReferenceKind) {
 // Store file content in initializer until nib is loaded.
 @property (copy) NSString *loadedString;
 
-// Transient per-document zoom level (not saved to preferences)
 @property CGFloat zoomMultiplier;
 
 - (void)scaleWebview;
@@ -2729,32 +2728,7 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
             || [changedKey isEqualToString:@"editorStyleName"]
             || [changedKey isEqualToString:@"editorLineSpacing"])
     {
-        NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
-        style.lineSpacing = self.preferences.editorLineSpacing;
-
-        // Configure tab stops to match 4-space tab width (fixes #195)
-        NSFont *font = [[self zoomedEditorFont] copy];
-        if (font)
-        {
-            NSDictionary *attrs = @{NSFontAttributeName: font};
-            CGFloat spaceWidth = [@" " sizeWithAttributes:attrs].width;
-            CGFloat tabInterval = spaceWidth * 4;
-
-            NSMutableArray *tabStops = [NSMutableArray array];
-            for (NSInteger i = 1; i <= 100; i++)
-            {
-                NSTextTab *tab = [[NSTextTab alloc]
-                    initWithTextAlignment:NSTextAlignmentLeft
-                                 location:tabInterval * i
-                                  options:@{}];
-                [tabStops addObject:tab];
-            }
-            style.tabStops = tabStops;
-        }
-
-        self.editor.defaultParagraphStyle = [style copy];
-        if (font)
-            self.editor.font = font;
+        [self applyEditorFontAndParagraphStyle];
         self.editor.textColor = nil;
         self.editor.backgroundColor = [NSColor clearColor];
         self.highlighter.styles = nil;
@@ -2941,6 +2915,37 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     return [NSFont fontWithName:baseFont.fontName size:zoomedSize];
 }
 
+- (void)applyEditorFontAndParagraphStyle
+{
+    NSFont *font = [[self zoomedEditorFont] copy];
+
+    NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
+    style.lineSpacing = self.preferences.editorLineSpacing;
+
+    // Configure tab stops to match 4-space tab width (fixes #195)
+    if (font)
+    {
+        NSDictionary *attrs = @{NSFontAttributeName: font};
+        CGFloat spaceWidth = [@" " sizeWithAttributes:attrs].width;
+        CGFloat tabInterval = spaceWidth * 4;
+
+        NSMutableArray *tabStops = [NSMutableArray array];
+        for (NSInteger i = 1; i <= 100; i++)
+        {
+            NSTextTab *tab = [[NSTextTab alloc]
+                initWithTextAlignment:NSTextAlignmentLeft
+                             location:tabInterval * i
+                              options:@{}];
+            [tabStops addObject:tab];
+        }
+        style.tabStops = tabStops;
+    }
+
+    self.editor.defaultParagraphStyle = [style copy];
+    if (font)
+        self.editor.font = font;
+}
+
 - (IBAction)zoomIn:(id)sender
 {
     if (self.zoomMultiplier >= kMPMaxZoom)
@@ -2967,7 +2972,8 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
 - (void)applyCurrentZoom
 {
-    [self setupEditor:@"editorBaseFontInfo"];
+    [self applyEditorFontAndParagraphStyle];
+    [self scaleWebview];
 }
 
 /**

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2877,20 +2877,23 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     }
 }
 
-- (void)scaleWebview
+- (CGFloat)previewScale
 {
-    CGFloat scale = self.zoomMultiplier;
-
     if (self.preferences.previewZoomRelativeToBaseFontSize)
     {
         CGFloat fontSize = self.preferences.editorBaseFontSize;
         if (fontSize > 0.0)
         {
             static const CGFloat defaultSize = 14.0;
-            scale = (fontSize / defaultSize)
-                    * self.zoomMultiplier;
+            return (fontSize / defaultSize) * self.zoomMultiplier;
         }
     }
+    return self.zoomMultiplier;
+}
+
+- (void)scaleWebview
+{
+    CGFloat scale = [self previewScale];
 
 #if 0
     // Sadly, this doesn’t work correctly.

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -38,6 +38,9 @@
 
 static NSString * const kMPDefaultAutosaveName = @"Untitled";
 
+static const CGFloat kMPMinZoom = 0.5;
+static const CGFloat kMPMaxZoom = 3.0;
+
 
 NS_INLINE NSString *MPEditorPreferenceKeyWithValueKey(NSString *key)
 {
@@ -1059,17 +1062,15 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     // Zoom menu validation
     if (action == @selector(zoomIn:))
     {
-        static const CGFloat kMaxZoom = 3.0;
-        return self.zoomMultiplier < kMaxZoom;
+        return self.zoomMultiplier < kMPMaxZoom;
     }
     else if (action == @selector(zoomOut:))
     {
-        static const CGFloat kMinZoom = 0.5;
-        return self.zoomMultiplier > kMinZoom;
+        return self.zoomMultiplier > kMPMinZoom;
     }
     else if (action == @selector(resetZoom:))
     {
-        return self.zoomMultiplier != 1.0;
+        return fabs(self.zoomMultiplier - 1.0) > 0.001;
     }
     else if (action == @selector(toggleToolbar:))
     {
@@ -2904,16 +2905,19 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
 - (void)scaleWebview
 {
-    if (!self.preferences.previewZoomRelativeToBaseFontSize)
-        return;
+    CGFloat scale = self.zoomMultiplier;
 
-    CGFloat fontSize = self.preferences.editorBaseFontSize;
-    if (fontSize <= 0.0)
-        return;
+    if (self.preferences.previewZoomRelativeToBaseFontSize)
+    {
+        CGFloat fontSize = self.preferences.editorBaseFontSize;
+        if (fontSize > 0.0)
+        {
+            static const CGFloat defaultSize = 14.0;
+            scale = (fontSize / defaultSize)
+                    * self.zoomMultiplier;
+        }
+    }
 
-    static const CGFloat defaultSize = 14.0;
-    CGFloat scale = (fontSize / defaultSize) * self.zoomMultiplier;
-    
 #if 0
     // Sadly, this doesn’t work correctly.
     // It looks fine, but selections are offset relative to the mouse cursor.
@@ -2930,21 +2934,19 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
 - (IBAction)zoomIn:(id)sender
 {
-    static const CGFloat kMaxZoom = 3.0;
-    if (self.zoomMultiplier >= kMaxZoom)
+    if (self.zoomMultiplier >= kMPMaxZoom)
         return;
     
-    self.zoomMultiplier = MIN(self.zoomMultiplier + 0.1, kMaxZoom);
+    self.zoomMultiplier = MIN(self.zoomMultiplier + 0.1, kMPMaxZoom);
     [self applyCurrentZoom];
 }
 
 - (IBAction)zoomOut:(id)sender
 {
-    static const CGFloat kMinZoom = 0.5;
-    if (self.zoomMultiplier <= kMinZoom)
+    if (self.zoomMultiplier <= kMPMinZoom)
         return;
     
-    self.zoomMultiplier = MAX(self.zoomMultiplier - 0.1, kMinZoom);
+    self.zoomMultiplier = MAX(self.zoomMultiplier - 0.1, kMPMinZoom);
     [self applyCurrentZoom];
 }
 

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -77,10 +77,26 @@ NS_INLINE NSSet *MPEditorPreferencesToObserve()
             @"editorWidthLimited", @"editorMaximumWidth", @"editorLineSpacing",
             @"editorOnRight", @"editorStyleName", @"editorShowWordCount",
             @"editorScrollsPastEnd", @"editorShowsInvisibleCharacters",
-            @"htmlMathJax", @"htmlMathJaxInlineDollar", nil
+            @"htmlMathJax", @"htmlMathJaxInlineDollar",
+            @"previewZoomLevel", nil
         ];
     });
     return keys;
+}
+
+/**
+ * Ordered list of preset preview zoom multipliers used by ⌘+/⌘- and the
+ * toolbar dropdown. Kept as a single source of truth so the popup and the
+ * snap-step helper cannot drift apart.
+ */
+NS_INLINE NSArray<NSNumber *> *MPPreviewZoomLevels()
+{
+    static NSArray *levels = nil;
+    static dispatch_once_t token;
+    dispatch_once(&token, ^{
+        levels = @[@0.5, @0.75, @0.9, @1.0, @1.1, @1.25, @1.5, @2.0];
+    });
+    return levels;
 }
 
 NS_INLINE NSString *MPRectStringForAutosaveName(NSString *name)
@@ -310,6 +326,9 @@ typedef NS_ENUM(NSInteger, MPReferenceKind) {
 // Issue #441: Settle / re-sync the panes when Sync Panes is toggled mid-session.
 - (void)handleSyncScrollingEnabled;
 - (void)handleSyncScrollingDisabled;
+// Preview zoom helpers
+- (void)applyPreviewZoom;
+- (void)stepPreviewZoomDirection:(NSInteger)direction;
 // Commit 8 (gap 9): MathJax generation counter accessor (used by tests via category)
 - (NSUInteger)mathJaxRenderGeneration;
 
@@ -1088,6 +1107,25 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
             ? NSControlStateValueOn : NSControlStateValueOff;
         return self.editor != nil;
     }
+    else if (action == @selector(zoomPreviewIn:))
+    {
+        // Grey out ⌘+ once we are already at the maximum preset.
+        NSArray<NSNumber *> *levels = MPPreviewZoomLevels();
+        CGFloat max = levels.lastObject.doubleValue;
+        return (self.preferences.previewZoomLevel < max - 1e-6);
+    }
+    else if (action == @selector(zoomPreviewOut:))
+    {
+        // Grey out ⌘- once we are already at the minimum preset.
+        NSArray<NSNumber *> *levels = MPPreviewZoomLevels();
+        CGFloat min = levels.firstObject.doubleValue;
+        return (self.preferences.previewZoomLevel > min + 1e-6);
+    }
+    else if (action == @selector(actualPreviewSize:) ||
+             action == @selector(selectPreviewZoom:))
+    {
+        return YES;
+    }
     return result;
 }
 
@@ -1330,6 +1368,13 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
     // Issue #16: Invoke deferred operation handlers after render completes
     [self invokeRenderCompletionHandlers];
+
+    // Re-apply the preview pane page-size multiplier. WebKit resets the
+    // multiplier when a new document loads, so each finished mainFrame load
+    // needs to restore the user's preference. Restrict to mainFrame so
+    // subframe (e.g. iframe) loads do not stomp the top-level zoom.
+    if (frame == sender.mainFrame)
+        [self applyPreviewZoom];
 }
 
 - (void)webView:(WebView *)sender didFailLoadWithError:(NSError *)error
@@ -1718,6 +1763,12 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
     // Fall back to full reload
     [self.preview.mainFrame loadHTMLString:html baseURL:baseUrl];
+    // Re-apply preview zoom immediately. The WebKit page-size multiplier
+    // is reset by a fresh load; calling it now (in addition to the
+    // didFinishLoadForFrame callback) shortens the visible window where
+    // the preview could briefly render at 100% before our preference
+    // takes effect.
+    [self applyPreviewZoom];
     self.currentBaseUrl = baseUrl;
     self.currentStyleName = newStyleName;
     self.currentHighlightingThemeName = newHighlightingTheme;
@@ -2061,6 +2112,14 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     }
     else if (object == [NSUserDefaults standardUserDefaults])
     {
+        // Preview zoom changes only need to push a new page-size multiplier
+        // to the WebView; the rendered HTML is unaffected, so skip the
+        // editor setup / divider redraw path that other preferences need.
+        if ([keyPath isEqualToString:@"previewZoomLevel"])
+        {
+            [self applyPreviewZoom];
+            return;
+        }
         if (self.highlighter.isActive)
             [self setupEditor:keyPath];
         [self redrawDivider];
@@ -4056,6 +4115,123 @@ to link outside that scope.", \
 
     // Restart file watching (descriptor may have become stale)
     [self startFileWatching];
+}
+
+
+#pragma mark - Preview zoom
+
+/**
+ * Push the user's preview-zoom preference into the underlying WebView.
+ * Clamps the value to the supported [0.5, 2.0] range so a corrupt or
+ * out-of-range preference cannot blank the preview pane. Silently does
+ * nothing when the preview outlet is not yet wired (early launch / unit
+ * tests instantiating MPDocument without the nib).
+ */
+- (void)applyPreviewZoom
+{
+    if (!self.preview)
+        return;
+
+    CGFloat level = self.preferences.previewZoomLevel;
+    NSArray<NSNumber *> *levels = MPPreviewZoomLevels();
+    CGFloat min = levels.firstObject.doubleValue;
+    CGFloat max = levels.lastObject.doubleValue;
+    if (level < min) level = min;
+    if (level > max) level = max;
+
+    [self.preview setPageSizeMultiplier:(float)level];
+}
+
+/**
+ * Step the preview zoom by one preset in the requested direction.
+ * @param direction +1 to zoom in, -1 to zoom out.
+ *
+ * If the current zoom matches a preset (within epsilon), step from that
+ * preset. Otherwise snap to the nearest preset on the requested side:
+ * zooming in snaps up to the smallest preset greater than the current
+ * value; zooming out snaps down to the largest preset less than current.
+ * Beeps when already at the bound.
+ */
+- (void)stepPreviewZoomDirection:(NSInteger)direction
+{
+    NSArray<NSNumber *> *levels = MPPreviewZoomLevels();
+    CGFloat current = self.preferences.previewZoomLevel;
+    if (current <= 0) current = 1.0;
+
+    // Find index of nearest preset to the current zoom.
+    NSUInteger nearestIdx = 0;
+    CGFloat bestDiff = CGFLOAT_MAX;
+    for (NSUInteger i = 0; i < levels.count; i++)
+    {
+        CGFloat diff = fabs(levels[i].doubleValue - current);
+        if (diff < bestDiff)
+        {
+            bestDiff = diff;
+            nearestIdx = i;
+        }
+    }
+
+    NSInteger targetIdx;
+    const CGFloat eps = 1e-6;
+    if (fabs(levels[nearestIdx].doubleValue - current) < eps)
+    {
+        targetIdx = (NSInteger)nearestIdx + direction;
+    }
+    else if (direction > 0)
+    {
+        // Snap up to the smallest preset > current.
+        targetIdx = (NSInteger)nearestIdx;
+        if (levels[nearestIdx].doubleValue < current)
+            targetIdx++;
+    }
+    else
+    {
+        // Snap down to the largest preset < current.
+        targetIdx = (NSInteger)nearestIdx;
+        if (levels[nearestIdx].doubleValue > current)
+            targetIdx--;
+    }
+
+    if (targetIdx < 0 || targetIdx >= (NSInteger)levels.count)
+    {
+        NSBeep();
+        return;
+    }
+    self.preferences.previewZoomLevel = levels[(NSUInteger)targetIdx].doubleValue;
+}
+
+- (IBAction)zoomPreviewIn:(id)sender
+{
+    [self stepPreviewZoomDirection:+1];
+}
+
+- (IBAction)zoomPreviewOut:(id)sender
+{
+    [self stepPreviewZoomDirection:-1];
+}
+
+- (IBAction)actualPreviewSize:(id)sender
+{
+    self.preferences.previewZoomLevel = 1.0;
+}
+
+- (IBAction)selectPreviewZoom:(id)sender
+{
+    // Sender is an NSPopUpButton (toolbar) or NSMenuItem (future menu).
+    // Both carry the target level as an NSNumber in representedObject.
+    NSNumber *level = nil;
+    if ([sender isKindOfClass:[NSMenuItem class]])
+    {
+        level = [(NSMenuItem *)sender representedObject];
+    }
+    else if ([sender isKindOfClass:[NSPopUpButton class]])
+    {
+        level = [[(NSPopUpButton *)sender selectedItem] representedObject];
+    }
+    if ([level isKindOfClass:[NSNumber class]])
+    {
+        self.preferences.previewZoomLevel = level.doubleValue;
+    }
 }
 
 @end

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -81,23 +81,23 @@ NS_INLINE NSSet *MPEditorPreferencesToObserve()
             @"editorOnRight", @"editorStyleName", @"editorShowWordCount",
             @"editorScrollsPastEnd", @"editorShowsInvisibleCharacters",
             @"htmlMathJax", @"htmlMathJaxInlineDollar",
-            @"previewZoomLevel", nil
+            @"documentZoomLevel", nil
         ];
     });
     return keys;
 }
 
 /**
- * Ordered list of preset preview zoom multipliers used by ⌘+/⌘- and the
+ * Ordered list of document zoom multipliers used by ⌘+/⌘- and the
  * toolbar dropdown. Kept as a single source of truth so the popup and the
  * snap-step helper cannot drift apart.
  */
-NS_INLINE NSArray<NSNumber *> *MPPreviewZoomLevels()
+NS_INLINE NSArray<NSNumber *> *MPDocumentZoomLevels()
 {
     static NSArray *levels = nil;
     static dispatch_once_t token;
     dispatch_once(&token, ^{
-        levels = @[@0.5, @0.75, @0.9, @1.0, @1.1, @1.25, @1.5, @2.0];
+        levels = @[@0.5, @0.75, @0.9, @1.0, @1.1, @1.25, @1.5, @2.0, @3.0];
     });
     return levels;
 }
@@ -333,7 +333,7 @@ typedef NS_ENUM(NSInteger, MPReferenceKind) {
 - (void)handleSyncScrollingDisabled;
 // Preview zoom helpers
 - (void)applyPreviewZoom;
-- (void)stepPreviewZoomDirection:(NSInteger)direction;
+- (void)stepDocumentZoomDirection:(NSInteger)direction;
 // Commit 8 (gap 9): MathJax generation counter accessor (used by tests via category)
 - (NSUInteger)mathJaxRenderGeneration;
 
@@ -588,8 +588,6 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     self.volumeLocalityChecker = ^BOOL(NSString *path) {
         return [MPFileWatcher pathIsOnLocalVolume:path];
     };
-    self.zoomMultiplier = 1.0;
-
     return self;
 }
 
@@ -1127,22 +1125,7 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
             ? NSControlStateValueOn : NSControlStateValueOff;
         return self.editor != nil;
     }
-    else if (action == @selector(zoomPreviewIn:))
-    {
-        // Grey out ⌘+ once we are already at the maximum preset.
-        NSArray<NSNumber *> *levels = MPPreviewZoomLevels();
-        CGFloat max = levels.lastObject.doubleValue;
-        return (self.preferences.previewZoomLevel < max - 1e-6);
-    }
-    else if (action == @selector(zoomPreviewOut:))
-    {
-        // Grey out ⌘- once we are already at the minimum preset.
-        NSArray<NSNumber *> *levels = MPPreviewZoomLevels();
-        CGFloat min = levels.firstObject.doubleValue;
-        return (self.preferences.previewZoomLevel > min + 1e-6);
-    }
-    else if (action == @selector(actualPreviewSize:) ||
-             action == @selector(selectPreviewZoom:))
+    else if (action == @selector(selectDocumentZoom:))
     {
         return YES;
     }
@@ -2132,12 +2115,10 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     }
     else if (object == [NSUserDefaults standardUserDefaults])
     {
-        // Preview zoom changes only need to push a new page-size multiplier
-        // to the WebView; the rendered HTML is unaffected, so skip the
-        // editor setup / divider redraw path that other preferences need.
-        if ([keyPath isEqualToString:@"previewZoomLevel"])
+        // Document zoom is shared by every open window and drives both panes.
+        if ([keyPath isEqualToString:@"documentZoomLevel"])
         {
-            [self applyPreviewZoom];
+            [self applyCurrentZoom];
             return;
         }
         if (self.highlighter.isActive)
@@ -2891,22 +2872,25 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     return self.zoomMultiplier;
 }
 
+- (CGFloat)zoomMultiplier
+{
+    CGFloat level = self.preferences.documentZoomLevel;
+    return level > 0.0 ? level : 1.0;
+}
+
+- (void)setZoomMultiplier:(CGFloat)zoomMultiplier
+{
+    self.preferences.documentZoomLevel =
+        MIN(MAX(zoomMultiplier, kMPMinZoom), kMPMaxZoom);
+}
+
 - (void)scaleWebview
 {
-    CGFloat scale = [self previewScale];
+    if (!self.preview)
+        return;
 
-#if 0
-    // Sadly, this doesn’t work correctly.
-    // It looks fine, but selections are offset relative to the mouse cursor.
-    NSScrollView *previewScrollView =
-    self.preview.mainFrame.frameView.documentView.enclosingScrollView;
-    NSClipView *previewContentView = previewScrollView.contentView;
-    [previewContentView scaleUnitSquareToSize:NSMakeSize(scale, scale)];
-    [previewContentView setNeedsDisplay:YES];
-#else
-    // Warning: this is private webkit API and NOT App Store-safe!
-    [self.preview setPageSizeMultiplier:scale];
-#endif
+    CGFloat scale = [self previewScale];
+    [self.preview setPageSizeMultiplier:(float)scale];
 }
 
 - (NSFont *)zoomedEditorFont
@@ -2915,7 +2899,7 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     if (!baseFont)
         return nil;
     CGFloat zoomedSize = baseFont.pointSize * self.zoomMultiplier;
-    return [NSFont fontWithName:baseFont.fontName size:zoomedSize];
+    return [NSFont fontWithDescriptor:baseFont.fontDescriptor size:zoomedSize];
 }
 
 - (void)applyEditorFontAndParagraphStyle
@@ -2951,26 +2935,17 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
 - (IBAction)zoomIn:(id)sender
 {
-    if (self.zoomMultiplier >= kMPMaxZoom)
-        return;
-
-    self.zoomMultiplier = MIN(self.zoomMultiplier + 0.1, kMPMaxZoom);
-    [self applyCurrentZoom];
+    [self stepDocumentZoomDirection:+1];
 }
 
 - (IBAction)zoomOut:(id)sender
 {
-    if (self.zoomMultiplier <= kMPMinZoom)
-        return;
-    
-    self.zoomMultiplier = MAX(self.zoomMultiplier - 0.1, kMPMinZoom);
-    [self applyCurrentZoom];
+    [self stepDocumentZoomDirection:-1];
 }
 
 - (IBAction)resetZoom:(id)sender
 {
-    self.zoomMultiplier = 1.0;
-    [self applyCurrentZoom];
+    self.preferences.documentZoomLevel = 1.0;
 }
 
 - (void)applyCurrentZoom
@@ -4189,32 +4164,18 @@ to link outside that scope.", \
 }
 
 
-#pragma mark - Preview zoom
+#pragma mark - Document zoom
 
 /**
- * Push the user's preview-zoom preference into the underlying WebView.
- * Clamps the value to the supported [0.5, 2.0] range so a corrupt or
- * out-of-range preference cannot blank the preview pane. Silently does
- * nothing when the preview outlet is not yet wired (early launch / unit
- * tests instantiating MPDocument without the nib).
+ * Re-apply preview page zoom after WebKit reloads its main frame.
  */
 - (void)applyPreviewZoom
 {
-    if (!self.preview)
-        return;
-
-    CGFloat level = self.preferences.previewZoomLevel;
-    NSArray<NSNumber *> *levels = MPPreviewZoomLevels();
-    CGFloat min = levels.firstObject.doubleValue;
-    CGFloat max = levels.lastObject.doubleValue;
-    if (level < min) level = min;
-    if (level > max) level = max;
-
-    [self.preview setPageSizeMultiplier:(float)level];
+    [self scaleWebview];
 }
 
 /**
- * Step the preview zoom by one preset in the requested direction.
+ * Step the shared document zoom by one preset in the requested direction.
  * @param direction +1 to zoom in, -1 to zoom out.
  *
  * If the current zoom matches a preset (within epsilon), step from that
@@ -4223,10 +4184,10 @@ to link outside that scope.", \
  * value; zooming out snaps down to the largest preset less than current.
  * Beeps when already at the bound.
  */
-- (void)stepPreviewZoomDirection:(NSInteger)direction
+- (void)stepDocumentZoomDirection:(NSInteger)direction
 {
-    NSArray<NSNumber *> *levels = MPPreviewZoomLevels();
-    CGFloat current = self.preferences.previewZoomLevel;
+    NSArray<NSNumber *> *levels = MPDocumentZoomLevels();
+    CGFloat current = self.preferences.documentZoomLevel;
     if (current <= 0) current = 1.0;
 
     // Find index of nearest preset to the current zoom.
@@ -4268,25 +4229,10 @@ to link outside that scope.", \
         NSBeep();
         return;
     }
-    self.preferences.previewZoomLevel = levels[(NSUInteger)targetIdx].doubleValue;
+    self.preferences.documentZoomLevel = levels[(NSUInteger)targetIdx].doubleValue;
 }
 
-- (IBAction)zoomPreviewIn:(id)sender
-{
-    [self stepPreviewZoomDirection:+1];
-}
-
-- (IBAction)zoomPreviewOut:(id)sender
-{
-    [self stepPreviewZoomDirection:-1];
-}
-
-- (IBAction)actualPreviewSize:(id)sender
-{
-    self.preferences.previewZoomLevel = 1.0;
-}
-
-- (IBAction)selectPreviewZoom:(id)sender
+- (IBAction)selectDocumentZoom:(id)sender
 {
     // Sender is an NSPopUpButton (toolbar) or NSMenuItem (future menu).
     // Both carry the target level as an NSNumber in representedObject.
@@ -4301,7 +4247,7 @@ to link outside that scope.", \
     }
     if ([level isKindOfClass:[NSNumber class]])
     {
-        self.preferences.previewZoomLevel = level.doubleValue;
+        self.preferences.documentZoomLevel = level.doubleValue;
     }
 }
 

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2733,7 +2733,7 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
         style.lineSpacing = self.preferences.editorLineSpacing;
 
         // Configure tab stops to match 4-space tab width (fixes #195)
-        NSFont *font = [self.preferences.editorBaseFont copy];
+        NSFont *font = [[self zoomedEditorFont] copy];
         if (font)
         {
             NSDictionary *attrs = @{NSFontAttributeName: font};
@@ -2932,11 +2932,20 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 #endif
 }
 
+- (NSFont *)zoomedEditorFont
+{
+    NSFont *baseFont = self.preferences.editorBaseFont;
+    if (!baseFont)
+        return nil;
+    CGFloat zoomedSize = baseFont.pointSize * self.zoomMultiplier;
+    return [NSFont fontWithName:baseFont.fontName size:zoomedSize];
+}
+
 - (IBAction)zoomIn:(id)sender
 {
     if (self.zoomMultiplier >= kMPMaxZoom)
         return;
-    
+
     self.zoomMultiplier = MIN(self.zoomMultiplier + 0.1, kMPMaxZoom);
     [self applyCurrentZoom];
 }
@@ -2958,15 +2967,7 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
 - (void)applyCurrentZoom
 {
-    NSFont *baseFont = self.preferences.editorBaseFont;
-    CGFloat zoomedSize = baseFont.pointSize * self.zoomMultiplier;
-    
-    // Apply zoom to editor (transient, not saved to preferences)
-    [self.editor setFont:[NSFont fontWithName:baseFont.fontName
-                                         size:zoomedSize]];
-    
-    // Apply zoom to preview
-    [self scaleWebview];
+    [self setupEditor:@"editorBaseFontInfo"];
 }
 
 /**

--- a/MacDown/Code/Preferences/MPPreferences.h
+++ b/MacDown/Code/Preferences/MPPreferences.h
@@ -59,6 +59,7 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 @property (assign) NSInteger editorUnorderedListMarkerType;
 
 @property (assign) BOOL previewZoomRelativeToBaseFontSize;
+@property (assign) CGFloat previewZoomLevel;
 
 @property (assign) NSString *htmlTemplateName;
 @property (assign) NSString *htmlStyleName;

--- a/MacDown/Code/Preferences/MPPreferences.h
+++ b/MacDown/Code/Preferences/MPPreferences.h
@@ -59,7 +59,7 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 @property (assign) NSInteger editorUnorderedListMarkerType;
 
 @property (assign) BOOL previewZoomRelativeToBaseFontSize;
-@property (assign) CGFloat previewZoomLevel;
+@property (assign) CGFloat documentZoomLevel;
 
 @property (assign) NSString *htmlTemplateName;
 @property (assign) NSString *htmlStyleName;

--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -258,6 +258,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
 @dynamic editorUnorderedListMarkerType;
 
 @dynamic previewZoomRelativeToBaseFontSize;
+@dynamic previewZoomLevel;
 
 @dynamic htmlTemplateName;
 @dynamic htmlStyleName;
@@ -410,6 +411,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
     self.htmlStyleName = kMPDefaultHtmlStyleName;
     self.htmlDefaultDirectoryUrl = [NSURL fileURLWithPath:NSHomeDirectory()
                                               isDirectory:YES];
+    self.previewZoomLevel = 1.0;
 }
 
 /** Load default preferences when the app launches.
@@ -439,6 +441,13 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
     if (![defaults objectForKey:@"editorAutoSave"])
         self.editorAutoSave = YES;
 
+    // Defensive default for preview zoom level. Migration v6 also handles
+    // this, but this branch protects against any path that bypasses the
+    // migration code (e.g. a stale user defaults blob that already has a
+    // higher MPMigrationVersion but lacks this key).
+    if (![defaults objectForKey:@"previewZoomLevel"])
+        self.previewZoomLevel = 1.0;
+
     // Apply preference migrations using version-based system.
     [self applyPreferencesMigrations];
 }
@@ -456,6 +465,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
  *              hide YAML front matter by default (Issue #307)
  * - Version 4: Clear stale split view autosave (Issue #309)
  * - Version 5: Auto-save preference default
+ * - Version 6: Preview zoom level default (100%)
  */
 - (NSInteger)effectiveMigrationVersion
 {
@@ -494,7 +504,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
  */
 - (void)applyPreferencesMigrations
 {
-    static NSInteger const kMPCurrentMigrationVersion = 5;
+    static NSInteger const kMPCurrentMigrationVersion = 6;
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
     NSInteger currentVersion = [self effectiveMigrationVersion];
@@ -549,6 +559,16 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
     if (currentVersion < 5)
     {
         self.editorAutoSave = YES;
+    }
+
+    // Migration Version 6: Preview zoom level default
+    // Establish a 100% page-size multiplier baseline for the preview pane.
+    // Without this, existing users would inherit 0.0 (the implicit default
+    // for a CGFloat NSNumber-backed preference), which would zero out the
+    // preview on first launch after upgrade.
+    if (currentVersion < 6)
+    {
+        self.previewZoomLevel = 1.0;
     }
 
     // Update to current version

--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -258,7 +258,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
 @dynamic editorUnorderedListMarkerType;
 
 @dynamic previewZoomRelativeToBaseFontSize;
-@dynamic previewZoomLevel;
+@dynamic documentZoomLevel;
 
 @dynamic htmlTemplateName;
 @dynamic htmlStyleName;
@@ -411,7 +411,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
     self.htmlStyleName = kMPDefaultHtmlStyleName;
     self.htmlDefaultDirectoryUrl = [NSURL fileURLWithPath:NSHomeDirectory()
                                               isDirectory:YES];
-    self.previewZoomLevel = 1.0;
+    self.documentZoomLevel = 1.0;
 }
 
 /** Load default preferences when the app launches.
@@ -441,12 +441,12 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
     if (![defaults objectForKey:@"editorAutoSave"])
         self.editorAutoSave = YES;
 
-    // Defensive default for preview zoom level. Migration v6 also handles
+    // Defensive default for document zoom level. Migration v6 also handles
     // this, but this branch protects against any path that bypasses the
     // migration code (e.g. a stale user defaults blob that already has a
     // higher MPMigrationVersion but lacks this key).
-    if (![defaults objectForKey:@"previewZoomLevel"])
-        self.previewZoomLevel = 1.0;
+    if (![defaults objectForKey:@"documentZoomLevel"])
+        self.documentZoomLevel = 1.0;
 
     // Apply preference migrations using version-based system.
     [self applyPreferencesMigrations];
@@ -465,7 +465,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
  *              hide YAML front matter by default (Issue #307)
  * - Version 4: Clear stale split view autosave (Issue #309)
  * - Version 5: Auto-save preference default
- * - Version 6: Preview zoom level default (100%)
+ * - Version 6: Document zoom level default (100%)
  */
 - (NSInteger)effectiveMigrationVersion
 {
@@ -561,14 +561,14 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
         self.editorAutoSave = YES;
     }
 
-    // Migration Version 6: Preview zoom level default
-    // Establish a 100% page-size multiplier baseline for the preview pane.
+    // Migration Version 6: Document zoom level default
+    // Establish a 100% baseline shared by the editor and preview panes.
     // Without this, existing users would inherit 0.0 (the implicit default
     // for a CGFloat NSNumber-backed preference), which would zero out the
     // preview on first launch after upgrade.
     if (currentVersion < 6)
     {
-        self.previewZoomLevel = 1.0;
+        self.documentZoomLevel = 1.0;
     }
 
     // Update to current version

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -417,17 +417,19 @@
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="QMZ-Ld-Nza"/>
                             <menuItem title="Zoom In" keyEquivalent="+" id="zIn-01-ABC">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                 <connections>
                                     <action selector="zoomIn:" target="-1" id="zIn-02-DEF"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Zoom Out" keyEquivalent="-" id="zOt-01-GHI">
-                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                 <connections>
                                     <action selector="zoomOut:" target="-1" id="zOt-02-JKL"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Actual Size" id="zRs-01-PQR">
+                            <menuItem title="Actual Size" keyEquivalent="0" id="zRs-01-PQR">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                 <connections>
                                     <action selector="resetZoom:" target="-1" id="zRs-02-STU"/>
                                 </connections>
@@ -437,25 +439,6 @@
                                 <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                 <connections>
                                     <action selector="toggleFullScreen:" target="-1" id="7ez-RY-PkZ"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem isSeparatorItem="YES" id="zm0-Sp-aaa"/>
-                            <menuItem title="Actual Size" keyEquivalent="0" id="zm1-Ac-bbb">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                                <connections>
-                                    <action selector="actualPreviewSize:" target="-1" id="zm1-Ax-ccc"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Zoom In" keyEquivalent="+" id="zm2-In-ddd">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                                <connections>
-                                    <action selector="zoomPreviewIn:" target="-1" id="zm2-Ix-eee"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Zoom Out" keyEquivalent="-" id="zm3-Ou-fff">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                                <connections>
-                                    <action selector="zoomPreviewOut:" target="-1" id="zm3-Ox-ggg"/>
                                 </connections>
                             </menuItem>
                         </items>
@@ -492,7 +475,8 @@
                                     </binding>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Strikethrough" keyEquivalent="-" id="9CN-Qi-Fln">
+                            <menuItem title="Strikethrough" id="9CN-Qi-Fln">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleStrikethrough:" target="-1" id="rUc-gb-x5q"/>
                                     <binding destination="eq0-c4-vgQ" name="hidden" keyPath="self.preferences.extensionStrikethough" id="kQ0-Wi-BPs">
@@ -502,7 +486,8 @@
                                     </binding>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Highlight" keyEquivalent="=" id="2Os-ij-Aup">
+                            <menuItem title="Highlight" id="2Os-ij-Aup">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleHighlight:" target="-1" id="Uda-cB-xYx"/>
                                     <binding destination="eq0-c4-vgQ" name="hidden" keyPath="self.preferences.extensionHighlight" id="9y2-h2-XrX">
@@ -557,7 +542,8 @@
                                                 <action selector="convertToH6:" target="-1" id="u4y-F9-JR3"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Paragraph" keyEquivalent="0" id="xN5-GU-ASF">
+                                        <menuItem title="Paragraph" id="xN5-GU-ASF">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="convertToParagraph:" target="-1" id="4BU-GT-Qyv"/>
                                             </connections>

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -422,6 +422,25 @@
                                     <action selector="toggleFullScreen:" target="-1" id="7ez-RY-PkZ"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="zm0-Sp-aaa"/>
+                            <menuItem title="Actual Size" keyEquivalent="0" id="zm1-Ac-bbb">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                <connections>
+                                    <action selector="actualPreviewSize:" target="-1" id="zm1-Ax-ccc"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Zoom In" keyEquivalent="+" id="zm2-In-ddd">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                <connections>
+                                    <action selector="zoomPreviewIn:" target="-1" id="zm2-Ix-eee"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Zoom Out" keyEquivalent="-" id="zm3-Ou-fff">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                <connections>
+                                    <action selector="zoomPreviewOut:" target="-1" id="zm3-Ox-ggg"/>
+                                </connections>
+                            </menuItem>
                         </items>
                     </menu>
                 </menuItem>

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -416,12 +416,13 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="QMZ-Ld-Nza"/>
-                            <menuItem title="Zoom In" keyEquivalent="=" id="zIn-01-ABC">
+                            <menuItem title="Zoom In" keyEquivalent="+" id="zIn-01-ABC">
                                 <connections>
                                     <action selector="zoomIn:" target="-1" id="zIn-02-DEF"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Zoom Out" keyEquivalent="-" id="zOt-01-GHI">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>
                                     <action selector="zoomOut:" target="-1" id="zOt-02-JKL"/>
                                 </connections>

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -416,7 +416,7 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="QMZ-Ld-Nza"/>
-                            <menuItem title="Zoom In" keyEquivalent="+" id="zIn-01-ABC">
+                            <menuItem title="Zoom In" keyEquivalent="=" id="zIn-01-ABC">
                                 <connections>
                                     <action selector="zoomIn:" target="-1" id="zIn-02-DEF"/>
                                 </connections>
@@ -426,7 +426,7 @@
                                     <action selector="zoomOut:" target="-1" id="zOt-02-JKL"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Actual Size" keyEquivalent="0" id="zRs-01-PQR">
+                            <menuItem title="Actual Size" id="zRs-01-PQR">
                                 <connections>
                                     <action selector="resetZoom:" target="-1" id="zRs-02-STU"/>
                                 </connections>

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -416,6 +416,22 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="QMZ-Ld-Nza"/>
+                            <menuItem title="Zoom In" keyEquivalent="+" id="zIn-01-ABC">
+                                <connections>
+                                    <action selector="zoomIn:" target="-1" id="zIn-02-DEF"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Zoom Out" keyEquivalent="-" id="zOt-01-GHI">
+                                <connections>
+                                    <action selector="zoomOut:" target="-1" id="zOt-02-JKL"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Actual Size" keyEquivalent="0" id="zRs-01-PQR">
+                                <connections>
+                                    <action selector="resetZoom:" target="-1" id="zRs-02-STU"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="zSp-01-MNO"/>
                             <menuItem title="Enter Full Screen" keyEquivalent="f" id="1gz-YB-DZE">
                                 <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                 <connections>

--- a/MacDownTests/MPPaneToggleTests.m
+++ b/MacDownTests/MPPaneToggleTests.m
@@ -43,6 +43,7 @@
 
 @interface MPPaneToggleTests : XCTestCase
 @property (strong) MPDocument *document;
+@property BOOL originalStartInPreviewMode;
 @end
 
 
@@ -51,12 +52,17 @@
 - (void)setUp
 {
     [super setUp];
+    MPPreferences *preferences = [MPPreferences sharedInstance];
+    self.originalStartInPreviewMode = preferences.editorStartInPreviewMode;
+    preferences.editorStartInPreviewMode = NO;
     self.document = [[MPDocument alloc] init];
 }
 
 - (void)tearDown
 {
     self.document = nil;
+    [MPPreferences sharedInstance].editorStartInPreviewMode =
+        self.originalStartInPreviewMode;
     [super tearDown];
 }
 
@@ -81,6 +87,40 @@
 {
     XCTAssertNoThrow([self.document togglePreviewPane:nil],
                      @"togglePreviewPane: should not crash");
+}
+
+- (void)testEditorPaneChoiceIsRemembered
+{
+    MPPreferences *preferences = [MPPreferences sharedInstance];
+    BOOL originalEditorOnRight = preferences.editorOnRight;
+
+    @try {
+        MPDocumentSplitView *splitView = [[MPDocumentSplitView alloc]
+            initWithFrame:NSMakeRect(0, 0, 800, 600)];
+        splitView.vertical = YES;
+        NSView *editor = [[NSView alloc]
+            initWithFrame:NSMakeRect(0, 0, 399, 600)];
+        WebView *preview = [[WebView alloc]
+            initWithFrame:NSMakeRect(400, 0, 400, 600)];
+        [splitView addSubview:editor];
+        [splitView addSubview:preview];
+
+        self.document.splitView = splitView;
+        self.document.editorContainer = editor;
+        self.document.preview = preview;
+        preferences.editorOnRight = NO;
+
+        [self.document toggleEditorPane:nil];
+        XCTAssertTrue(preferences.editorStartInPreviewMode,
+                      @"Hiding the editor should be remembered for the next window");
+
+        [self.document toggleEditorPane:nil];
+        XCTAssertFalse(preferences.editorStartInPreviewMode,
+                       @"Restoring the editor should update the remembered choice");
+    }
+    @finally {
+        preferences.editorOnRight = originalEditorOnRight;
+    }
 }
 
 

--- a/MacDownTests/MPPreferencesTests.m
+++ b/MacDownTests/MPPreferencesTests.m
@@ -582,10 +582,10 @@
     // Create new preferences instance
     MPPreferences *prefs = [[MPPreferences alloc] init];
 
-    // Fresh install should set migration version to current (5)
+    // Fresh install should set migration version to current (6)
     NSInteger version = [defaults integerForKey:@"MPMigrationVersion"];
-    XCTAssertEqual(version, 5,
-                   @"Fresh installation should set migration version to 5");
+    XCTAssertEqual(version, 6,
+                   @"Fresh installation should set migration version to 6");
 
     // Intra-emphasis should be disabled
     XCTAssertFalse(prefs.extensionIntraEmphasis,
@@ -639,10 +639,10 @@
     // Trigger initialization
     MPPreferences *prefs = [[MPPreferences alloc] init];
 
-    // Migration version should be updated to 5
+    // Migration version should be updated to 6
     NSInteger version = [defaults integerForKey:@"MPMigrationVersion"];
-    XCTAssertEqual(version, 5,
-                   @"Migration version should be updated to 5");
+    XCTAssertEqual(version, 6,
+                   @"Migration version should be updated to 6");
 
     // Version 2 migration: task list should be enabled
     XCTAssertTrue(prefs.htmlTaskList,
@@ -703,10 +703,10 @@
     // Trigger initialization
     MPPreferences *prefs = [[MPPreferences alloc] init];
 
-    // Migration version should be updated to 5
+    // Migration version should be updated to 6
     NSInteger version = [defaults integerForKey:@"MPMigrationVersion"];
-    XCTAssertEqual(version, 5,
-                   @"Migration version should be updated to 5");
+    XCTAssertEqual(version, 6,
+                   @"Migration version should be updated to 6");
 
     // Version 3 migration: intra-emphasis should be disabled
     XCTAssertFalse(prefs.extensionIntraEmphasis,
@@ -847,10 +847,10 @@
     XCTAssertFalse(prefs.extensionIntraEmphasis,
                    @"Version 3 migration should disable intra-emphasis for existing users");
 
-    // Migration version should be updated to 5
+    // Migration version should be updated to 6
     NSInteger version = [defaults integerForKey:@"MPMigrationVersion"];
-    XCTAssertEqual(version, 5,
-                   @"Migration version should be updated to 5 after migration");
+    XCTAssertEqual(version, 6,
+                   @"Migration version should be updated to 6 after migration");
 
     // Restore original values
     if (originalVersion)
@@ -997,10 +997,10 @@
     XCTAssertTrue(prefs.editorAutoSave,
                   @"Migration should default editorAutoSave to YES for existing users");
 
-    // Migration version should be updated to 5
+    // Migration version should be updated to 6
     NSInteger version = [defaults integerForKey:@"MPMigrationVersion"];
-    XCTAssertEqual(version, 5,
-                   @"Migration version should be updated to 5");
+    XCTAssertEqual(version, 6,
+                   @"Migration version should be updated to 6");
 
     // Restore original values
     if (originalVersion)

--- a/MacDownTests/MPPreviewZoomTests.m
+++ b/MacDownTests/MPPreviewZoomTests.m
@@ -2,8 +2,8 @@
 //  MPPreviewZoomTests.m
 //  MacDown 3000
 //
-//  Tests for the preview pane zoom feature: preset snap-step semantics,
-//  default level, clamping at the bounds, and the actualPreviewSize:
+//  Tests for the document zoom feature: preset snap-step semantics,
+//  default level, clamping at the bounds, and the resetZoom:
 //  reset action. These tests exercise the preference/snap logic in
 //  isolation from the WebView. The integration with WebView
 //  setPageSizeMultiplier: is covered manually because the page-size
@@ -20,7 +20,7 @@
 // directly without instantiating the full nib. The implementation lives
 // in MPDocument.m; this category just makes the selector visible.
 @interface MPDocument (MPPreviewZoomTests)
-- (void)stepPreviewZoomDirection:(NSInteger)direction;
+- (void)stepDocumentZoomDirection:(NSInteger)direction;
 @end
 
 
@@ -35,7 +35,7 @@
 - (void)setUp
 {
     [super setUp];
-    self.originalZoomLevel = [MPPreferences sharedInstance].previewZoomLevel;
+    self.originalZoomLevel = [MPPreferences sharedInstance].documentZoomLevel;
     // Instantiate MPDocument directly. The IBOutlet `preview` will be
     // nil, which is fine: applyPreviewZoom guards against a nil preview
     // and the snap-step logic operates on the preference only.
@@ -46,7 +46,7 @@
 {
     // Restore the previous preference so the user's persisted setting is
     // not perturbed by the test run.
-    [MPPreferences sharedInstance].previewZoomLevel = self.originalZoomLevel;
+    [MPPreferences sharedInstance].documentZoomLevel = self.originalZoomLevel;
     [[MPPreferences sharedInstance] synchronize];
     self.document = nil;
     [super tearDown];
@@ -55,7 +55,7 @@
 #pragma mark - Default
 
 /**
- * After fresh-install initialization, previewZoomLevel must be 1.0.
+ * After fresh-install initialization, documentZoomLevel must be 1.0.
  * loadDefaultUserDefaults sets the defensive default, and the migration
  * path also sets 1.0 for upgrades. Either way, an existing test
  * environment must observe a non-zero (specifically 1.0) zoom level.
@@ -65,7 +65,7 @@
     // Re-initialize a fresh instance — sharedInstance has already run
     // initialization at the start of the test process.
     MPPreferences *prefs = [MPPreferences sharedInstance];
-    XCTAssertEqualWithAccuracy(prefs.previewZoomLevel, 1.0, 1e-9,
+    XCTAssertEqualWithAccuracy(prefs.documentZoomLevel, 1.0, 1e-9,
                                @"Default preview zoom level should be 1.0");
 }
 
@@ -73,18 +73,18 @@
 
 - (void)testStepUpFromOneHundredGoesTo110
 {
-    [MPPreferences sharedInstance].previewZoomLevel = 1.0;
-    [self.document stepPreviewZoomDirection:+1];
-    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+    [MPPreferences sharedInstance].documentZoomLevel = 1.0;
+    [self.document stepDocumentZoomDirection:+1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].documentZoomLevel,
                                1.1, 1e-9,
                                @"Step up from 100%% should land on 110%%");
 }
 
 - (void)testStepDownFromOneHundredGoesTo90
 {
-    [MPPreferences sharedInstance].previewZoomLevel = 1.0;
-    [self.document stepPreviewZoomDirection:-1];
-    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+    [MPPreferences sharedInstance].documentZoomLevel = 1.0;
+    [self.document stepDocumentZoomDirection:-1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].documentZoomLevel,
                                0.9, 1e-9,
                                @"Step down from 100%% should land on 90%%");
 }
@@ -93,18 +93,18 @@
 
 - (void)testStepUpAtMaxIsClamped
 {
-    [MPPreferences sharedInstance].previewZoomLevel = 2.0;
-    [self.document stepPreviewZoomDirection:+1];
-    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
-                               2.0, 1e-9,
+    [MPPreferences sharedInstance].documentZoomLevel = 3.0;
+    [self.document stepDocumentZoomDirection:+1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].documentZoomLevel,
+                               3.0, 1e-9,
                                @"Stepping up at the max preset must not change the level");
 }
 
 - (void)testStepDownAtMinIsClamped
 {
-    [MPPreferences sharedInstance].previewZoomLevel = 0.5;
-    [self.document stepPreviewZoomDirection:-1];
-    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+    [MPPreferences sharedInstance].documentZoomLevel = 0.5;
+    [self.document stepDocumentZoomDirection:-1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].documentZoomLevel,
                                0.5, 1e-9,
                                @"Stepping down at the min preset must not change the level");
 }
@@ -113,18 +113,18 @@
 
 - (void)testSnapFromOffPresetUpRoundsUp
 {
-    [MPPreferences sharedInstance].previewZoomLevel = 1.05;
-    [self.document stepPreviewZoomDirection:+1];
-    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+    [MPPreferences sharedInstance].documentZoomLevel = 1.05;
+    [self.document stepDocumentZoomDirection:+1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].documentZoomLevel,
                                1.1, 1e-9,
                                @"Step up from 105%% should snap to the next preset above (110%%)");
 }
 
 - (void)testSnapFromOffPresetDownRoundsDown
 {
-    [MPPreferences sharedInstance].previewZoomLevel = 1.05;
-    [self.document stepPreviewZoomDirection:-1];
-    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+    [MPPreferences sharedInstance].documentZoomLevel = 1.05;
+    [self.document stepDocumentZoomDirection:-1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].documentZoomLevel,
                                1.0, 1e-9,
                                @"Step down from 105%% should snap to the next preset below (100%%)");
 }
@@ -133,11 +133,11 @@
 
 - (void)testActualSizeResets
 {
-    [MPPreferences sharedInstance].previewZoomLevel = 1.5;
-    [self.document actualPreviewSize:nil];
-    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+    [MPPreferences sharedInstance].documentZoomLevel = 1.5;
+    [self.document resetZoom:nil];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].documentZoomLevel,
                                1.0, 1e-9,
-                               @"actualPreviewSize: must reset zoom level to 1.0");
+                               @"resetZoom: must reset zoom level to 1.0");
 }
 
 @end

--- a/MacDownTests/MPPreviewZoomTests.m
+++ b/MacDownTests/MPPreviewZoomTests.m
@@ -1,0 +1,143 @@
+//
+//  MPPreviewZoomTests.m
+//  MacDown 3000
+//
+//  Tests for the preview pane zoom feature: preset snap-step semantics,
+//  default level, clamping at the bounds, and the actualPreviewSize:
+//  reset action. These tests exercise the preference/snap logic in
+//  isolation from the WebView. The integration with WebView
+//  setPageSizeMultiplier: is covered manually because the page-size
+//  multiplier is a private WebKit API that is meaningful only when a
+//  real WebView is rendering loaded HTML.
+//
+
+#import <XCTest/XCTest.h>
+#import "MPPreferences.h"
+#import "MPDocument.h"
+
+
+// Expose the private snap-step helper so tests can drive the snap logic
+// directly without instantiating the full nib. The implementation lives
+// in MPDocument.m; this category just makes the selector visible.
+@interface MPDocument (MPPreviewZoomTests)
+- (void)stepPreviewZoomDirection:(NSInteger)direction;
+@end
+
+
+@interface MPPreviewZoomTests : XCTestCase
+@property (strong) MPDocument *document;
+@property (assign) CGFloat originalZoomLevel;
+@end
+
+
+@implementation MPPreviewZoomTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.originalZoomLevel = [MPPreferences sharedInstance].previewZoomLevel;
+    // Instantiate MPDocument directly. The IBOutlet `preview` will be
+    // nil, which is fine: applyPreviewZoom guards against a nil preview
+    // and the snap-step logic operates on the preference only.
+    self.document = [[MPDocument alloc] init];
+}
+
+- (void)tearDown
+{
+    // Restore the previous preference so the user's persisted setting is
+    // not perturbed by the test run.
+    [MPPreferences sharedInstance].previewZoomLevel = self.originalZoomLevel;
+    [[MPPreferences sharedInstance] synchronize];
+    self.document = nil;
+    [super tearDown];
+}
+
+#pragma mark - Default
+
+/**
+ * After fresh-install initialization, previewZoomLevel must be 1.0.
+ * loadDefaultUserDefaults sets the defensive default, and the migration
+ * path also sets 1.0 for upgrades. Either way, an existing test
+ * environment must observe a non-zero (specifically 1.0) zoom level.
+ */
+- (void)testDefaultZoomLevelIsOne
+{
+    // Re-initialize a fresh instance — sharedInstance has already run
+    // initialization at the start of the test process.
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    XCTAssertEqualWithAccuracy(prefs.previewZoomLevel, 1.0, 1e-9,
+                               @"Default preview zoom level should be 1.0");
+}
+
+#pragma mark - Stepping at preset boundaries
+
+- (void)testStepUpFromOneHundredGoesTo110
+{
+    [MPPreferences sharedInstance].previewZoomLevel = 1.0;
+    [self.document stepPreviewZoomDirection:+1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+                               1.1, 1e-9,
+                               @"Step up from 100%% should land on 110%%");
+}
+
+- (void)testStepDownFromOneHundredGoesTo90
+{
+    [MPPreferences sharedInstance].previewZoomLevel = 1.0;
+    [self.document stepPreviewZoomDirection:-1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+                               0.9, 1e-9,
+                               @"Step down from 100%% should land on 90%%");
+}
+
+#pragma mark - Clamping at bounds
+
+- (void)testStepUpAtMaxIsClamped
+{
+    [MPPreferences sharedInstance].previewZoomLevel = 2.0;
+    [self.document stepPreviewZoomDirection:+1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+                               2.0, 1e-9,
+                               @"Stepping up at the max preset must not change the level");
+}
+
+- (void)testStepDownAtMinIsClamped
+{
+    [MPPreferences sharedInstance].previewZoomLevel = 0.5;
+    [self.document stepPreviewZoomDirection:-1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+                               0.5, 1e-9,
+                               @"Stepping down at the min preset must not change the level");
+}
+
+#pragma mark - Snap-from-off-preset
+
+- (void)testSnapFromOffPresetUpRoundsUp
+{
+    [MPPreferences sharedInstance].previewZoomLevel = 1.05;
+    [self.document stepPreviewZoomDirection:+1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+                               1.1, 1e-9,
+                               @"Step up from 105%% should snap to the next preset above (110%%)");
+}
+
+- (void)testSnapFromOffPresetDownRoundsDown
+{
+    [MPPreferences sharedInstance].previewZoomLevel = 1.05;
+    [self.document stepPreviewZoomDirection:-1];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+                               1.0, 1e-9,
+                               @"Step down from 105%% should snap to the next preset below (100%%)");
+}
+
+#pragma mark - Actual size action
+
+- (void)testActualSizeResets
+{
+    [MPPreferences sharedInstance].previewZoomLevel = 1.5;
+    [self.document actualPreviewSize:nil];
+    XCTAssertEqualWithAccuracy([MPPreferences sharedInstance].previewZoomLevel,
+                               1.0, 1e-9,
+                               @"actualPreviewSize: must reset zoom level to 1.0");
+}
+
+@end

--- a/MacDownTests/MPToolbarControllerTests.m
+++ b/MacDownTests/MPToolbarControllerTests.m
@@ -378,7 +378,8 @@
         NSToolbarFlexibleSpaceItemIdentifier,
         @"copy-html",
         NSToolbarFlexibleSpaceItemIdentifier,
-        @"layout"
+        @"layout",
+        @"preview-zoom"
     ];
 
     XCTAssertEqual(defaults.count, expected.count,

--- a/MacDownTests/MPToolbarControllerTests.m
+++ b/MacDownTests/MPToolbarControllerTests.m
@@ -148,8 +148,8 @@
 - (void)testAllowedIdentifiersTotalCount
 {
     NSArray *allowed = [self.controller toolbarAllowedItemIdentifiers:nil];
-    // 14 custom + 3 system (flexible space, space, separator)
-    XCTAssertEqual(allowed.count, 17,
+    // 15 custom + 3 system (flexible space, space, separator)
+    XCTAssertEqual(allowed.count, 18,
                    @"Allowed identifiers should have 17 items: "
                    @"14 custom + flexible space + space + separator");
 }
@@ -272,8 +272,8 @@
 - (void)testSelectableIdentifiersCount
 {
     NSArray *selectable = [self.controller toolbarSelectableItemIdentifiers:nil];
-    XCTAssertEqual(selectable.count, 14,
-                   @"Selectable identifiers should have exactly 14 items (custom only, no system items)");
+    XCTAssertEqual(selectable.count, 15,
+                   @"Selectable identifiers should have exactly 15 items (custom only, no system items)");
 }
 
 - (void)testSelectableIdentifiersAcceptsNilToolbar
@@ -347,8 +347,8 @@
 - (void)testDefaultIdentifiersTotalCount
 {
     NSArray *defaults = [self.controller toolbarDefaultItemIdentifiers:nil];
-    XCTAssertEqual(defaults.count, 16,
-                   @"Default toolbar should have 16 items: 11 custom + 5 flexible spaces");
+    XCTAssertEqual(defaults.count, 17,
+                   @"Default toolbar should have 17 items: 12 custom + 5 flexible spaces");
 }
 
 - (void)testDefaultIdentifiersDoNotContainFixedSpaces
@@ -379,7 +379,7 @@
         @"copy-html",
         NSToolbarFlexibleSpaceItemIdentifier,
         @"layout",
-        @"preview-zoom"
+        @"document-zoom"
     ];
 
     XCTAssertEqual(defaults.count, expected.count,

--- a/MacDownTests/MPZoomTests.m
+++ b/MacDownTests/MPZoomTests.m
@@ -22,6 +22,7 @@
 - (IBAction)resetZoom:(id)sender;
 - (void)applyCurrentZoom;
 - (void)setupEditor:(NSString *)changedKey;
+- (CGFloat)previewScale;
 @end
 
 #pragma mark - Mock Menu Item
@@ -417,6 +418,102 @@
     XCTAssertEqualWithAccuracy(firstTab.location, expectedTabInterval, 0.5,
                                @"At default zoom, first tab stop should match "
                                @"the base-font tab interval");
+}
+
+
+#pragma mark - Preview Scale Calculation Tests
+
+/**
+ * scaleWebview routes through previewScale. These tests pin the scale
+ * computation across both branches of the previewZoomRelativeToBaseFontSize
+ * preference, including the regression risk introduced by removing the
+ * old early-return when the preference is OFF.
+ *
+ * Each test saves and restores the preference values it touches so the
+ * shared MPPreferences instance is not mutated across tests.
+ */
+
+- (void)testPreviewScaleAtDefaultZoomWhenPreferenceOffIsOne
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    BOOL savedPref = prefs.previewZoomRelativeToBaseFontSize;
+    @try {
+        prefs.previewZoomRelativeToBaseFontSize = NO;
+        self.document.zoomMultiplier = 1.0;
+
+        XCTAssertEqualWithAccuracy([self.document previewScale], 1.0, 0.001,
+                                   @"At default zoom with preference OFF, "
+                                   @"previewScale must be 1.0 (no-op).");
+    } @finally {
+        prefs.previewZoomRelativeToBaseFontSize = savedPref;
+    }
+}
+
+- (void)testPreviewScaleTracksZoomMultiplierWhenPreferenceOff
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    BOOL savedPref = prefs.previewZoomRelativeToBaseFontSize;
+    @try {
+        prefs.previewZoomRelativeToBaseFontSize = NO;
+        self.document.zoomMultiplier = 1.5;
+
+        XCTAssertEqualWithAccuracy([self.document previewScale], 1.5, 0.001,
+                                   @"With preference OFF, previewScale should "
+                                   @"equal zoomMultiplier (1.5).");
+
+        self.document.zoomMultiplier = 0.5;
+        XCTAssertEqualWithAccuracy([self.document previewScale], 0.5, 0.001,
+                                   @"With preference OFF, previewScale should "
+                                   @"track zoomMultiplier across changes.");
+    } @finally {
+        prefs.previewZoomRelativeToBaseFontSize = savedPref;
+    }
+}
+
+- (void)testPreviewScaleCombinesFontRatioAndZoomWhenPreferenceOn
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    BOOL savedPref = prefs.previewZoomRelativeToBaseFontSize;
+    NSFont *savedFont = prefs.editorBaseFont;
+    @try {
+        prefs.previewZoomRelativeToBaseFontSize = YES;
+
+        NSFont *font21 = [NSFont fontWithName:savedFont.fontName size:21.0];
+        if (!font21) {
+            NSLog(@"Skipping testPreviewScaleCombinesFontRatioAndZoomWhenPreferenceOn"
+                  @" - cannot construct 21pt variant of base font.");
+            return;
+        }
+        prefs.editorBaseFont = font21;
+
+        self.document.zoomMultiplier = 2.0;
+
+        // 21pt / 14pt default = 1.5; combined with 2.0 zoom = 3.0.
+        XCTAssertEqualWithAccuracy([self.document previewScale], 3.0, 0.01,
+                                   @"With preference ON, previewScale should "
+                                   @"be (fontSize/14) * zoomMultiplier.");
+    } @finally {
+        prefs.editorBaseFont = savedFont;
+        prefs.previewZoomRelativeToBaseFontSize = savedPref;
+    }
+}
+
+- (void)testPreviewScaleAtDefaultZoomWhenPreferenceOnMatchesFontRatio
+{
+    MPPreferences *prefs = [MPPreferences sharedInstance];
+    BOOL savedPref = prefs.previewZoomRelativeToBaseFontSize;
+    @try {
+        prefs.previewZoomRelativeToBaseFontSize = YES;
+        self.document.zoomMultiplier = 1.0;
+
+        // At zoom 1.0, scale should match the legacy fontSize/14 behaviour.
+        CGFloat expected = prefs.editorBaseFontSize / 14.0;
+        XCTAssertEqualWithAccuracy([self.document previewScale], expected, 0.001,
+                                   @"At zoom 1.0 with preference ON, previewScale"
+                                   @" must equal the pre-PR fontSize/14 ratio.");
+    } @finally {
+        prefs.previewZoomRelativeToBaseFontSize = savedPref;
+    }
 }
 
 @end

--- a/MacDownTests/MPZoomTests.m
+++ b/MacDownTests/MPZoomTests.m
@@ -1,0 +1,457 @@
+//
+//  MPZoomTests.m
+//  MacDownTests
+//
+//  TDD tests for the zoom feature in MPDocument.
+//  Some tests are RED regression guards and are expected to FAIL against the
+//  current code until the corresponding bug is fixed:
+//
+//  Bug 2: setupEditor: resets the editor font to the base (unzoomed) size,
+//         clobbering any zoom that was applied via applyCurrentZoom.
+//
+//  Bug 3: setupEditor: computes tab stops from the base font (not the zoomed
+//         font), so tab stops do not scale with zoom.
+//
+
+#import <XCTest/XCTest.h>
+#import "MPDocument.h"
+#import "MPEditorView.h"
+#import "MPPreferences.h"
+
+#pragma mark - Testing Category
+
+@interface MPDocument (ZoomTesting)
+@property CGFloat zoomMultiplier;
+@property (unsafe_unretained) IBOutlet MPEditorView *editor;
+- (IBAction)zoomIn:(id)sender;
+- (IBAction)zoomOut:(id)sender;
+- (IBAction)resetZoom:(id)sender;
+- (void)applyCurrentZoom;
+- (void)setupEditor:(NSString *)changedKey;
+@end
+
+#pragma mark - Mock Menu Item
+
+// Separate class from MPPaneToggleTests.m's MockMenuItem to avoid duplicate symbol.
+@interface MockZoomMenuItem : NSMenuItem
+@end
+
+@implementation MockZoomMenuItem
+@end
+
+#pragma mark - Test Case
+
+@interface MPZoomTests : XCTestCase
+@property (strong) MPDocument *document;
+@end
+
+@implementation MPZoomTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.document = [[MPDocument alloc] init];
+}
+
+- (void)tearDown
+{
+    self.document = nil;
+    [super tearDown];
+}
+
+
+#pragma mark - Zoom Multiplier Basics
+
+/**
+ * A new document should start with zoomMultiplier of 1.0.
+ */
+- (void)testZoomMultiplierDefaultsToOne
+{
+    XCTAssertEqualWithAccuracy(self.document.zoomMultiplier, 1.0, 0.001,
+                               @"New document should default to zoom multiplier of 1.0");
+}
+
+/**
+ * After calling zoomIn:nil the multiplier should increase by 0.1 (to 1.1).
+ */
+- (void)testZoomInIncrementsMultiplier
+{
+    [self.document zoomIn:nil];
+    XCTAssertEqualWithAccuracy(self.document.zoomMultiplier, 1.1, 0.001,
+                               @"zoomIn: should increment multiplier by 0.1");
+}
+
+/**
+ * After calling zoomOut:nil the multiplier should decrease by 0.1 (to 0.9).
+ */
+- (void)testZoomOutDecrementsMultiplier
+{
+    [self.document zoomOut:nil];
+    XCTAssertEqualWithAccuracy(self.document.zoomMultiplier, 0.9, 0.001,
+                               @"zoomOut: should decrement multiplier by 0.1");
+}
+
+/**
+ * Setting multiplier to 2.0 then calling resetZoom:nil should restore 1.0.
+ */
+- (void)testResetZoomSetsMultiplierToOne
+{
+    self.document.zoomMultiplier = 2.0;
+    [self.document resetZoom:nil];
+    XCTAssertEqualWithAccuracy(self.document.zoomMultiplier, 1.0, 0.001,
+                               @"resetZoom: should restore multiplier to 1.0");
+}
+
+/**
+ * When already at kMPMaxZoom (3.0), zoomIn: should be a no-op.
+ */
+- (void)testZoomInAtMaxZoomIsNoOp
+{
+    self.document.zoomMultiplier = 3.0;
+    [self.document zoomIn:nil];
+    XCTAssertEqualWithAccuracy(self.document.zoomMultiplier, 3.0, 0.001,
+                               @"zoomIn: at maximum zoom should not increase multiplier");
+}
+
+/**
+ * When already at kMPMinZoom (0.5), zoomOut: should be a no-op.
+ */
+- (void)testZoomOutAtMinZoomIsNoOp
+{
+    self.document.zoomMultiplier = 0.5;
+    [self.document zoomOut:nil];
+    XCTAssertEqualWithAccuracy(self.document.zoomMultiplier, 0.5, 0.001,
+                               @"zoomOut: at minimum zoom should not decrease multiplier");
+}
+
+/**
+ * 25 zoomIn, then 50 zoomOut, then 25 zoomIn must keep multiplier within [0.5, 3.0].
+ */
+- (void)testRapidZoomInOut
+{
+    for (int i = 0; i < 25; i++)
+        [self.document zoomIn:nil];
+    for (int i = 0; i < 50; i++)
+        [self.document zoomOut:nil];
+    for (int i = 0; i < 25; i++)
+        [self.document zoomIn:nil];
+
+    CGFloat m = self.document.zoomMultiplier;
+    XCTAssertGreaterThanOrEqual(m, 0.5 - 0.001,
+                                @"Rapid zoom sequence must not go below minimum (0.5)");
+    XCTAssertLessThanOrEqual(m, 3.0 + 0.001,
+                             @"Rapid zoom sequence must not exceed maximum (3.0)");
+}
+
+
+#pragma mark - Menu Validation
+
+/**
+ * validateUserInterfaceItem: should return YES for zoomIn: at default zoom (1.0).
+ */
+- (void)testZoomInMenuValidationEnabledAtDefault
+{
+    MockZoomMenuItem *item = [[MockZoomMenuItem alloc] initWithTitle:@"Zoom In"
+                                                      action:@selector(zoomIn:)
+                                               keyEquivalent:@""];
+    BOOL result = [self.document validateUserInterfaceItem:item];
+    XCTAssertTrue(result, @"Zoom In should be enabled at default zoom (1.0)");
+}
+
+/**
+ * validateUserInterfaceItem: should return YES for zoomOut: at default zoom (1.0).
+ */
+- (void)testZoomOutMenuValidationEnabledAtDefault
+{
+    MockZoomMenuItem *item = [[MockZoomMenuItem alloc] initWithTitle:@"Zoom Out"
+                                                      action:@selector(zoomOut:)
+                                               keyEquivalent:@""];
+    BOOL result = [self.document validateUserInterfaceItem:item];
+    XCTAssertTrue(result, @"Zoom Out should be enabled at default zoom (1.0)");
+}
+
+/**
+ * validateUserInterfaceItem: should return NO for resetZoom: at default zoom (1.0),
+ * because there is nothing to reset.
+ */
+- (void)testResetZoomMenuValidationDisabledAtDefault
+{
+    MockZoomMenuItem *item = [[MockZoomMenuItem alloc] initWithTitle:@"Reset Zoom"
+                                                      action:@selector(resetZoom:)
+                                               keyEquivalent:@""];
+    BOOL result = [self.document validateUserInterfaceItem:item];
+    XCTAssertFalse(result, @"Reset Zoom should be disabled when multiplier is already 1.0");
+}
+
+/**
+ * validateUserInterfaceItem: should return YES for resetZoom: when multiplier != 1.0.
+ */
+- (void)testResetZoomMenuValidationEnabledWhenZoomed
+{
+    self.document.zoomMultiplier = 1.5;
+    MockZoomMenuItem *item = [[MockZoomMenuItem alloc] initWithTitle:@"Reset Zoom"
+                                                      action:@selector(resetZoom:)
+                                               keyEquivalent:@""];
+    BOOL result = [self.document validateUserInterfaceItem:item];
+    XCTAssertTrue(result, @"Reset Zoom should be enabled when multiplier is not 1.0");
+}
+
+/**
+ * validateUserInterfaceItem: should return NO for zoomIn: when at maximum zoom (3.0).
+ */
+- (void)testZoomInMenuValidationDisabledAtMaxZoom
+{
+    self.document.zoomMultiplier = 3.0;
+    MockZoomMenuItem *item = [[MockZoomMenuItem alloc] initWithTitle:@"Zoom In"
+                                                      action:@selector(zoomIn:)
+                                               keyEquivalent:@""];
+    BOOL result = [self.document validateUserInterfaceItem:item];
+    XCTAssertFalse(result, @"Zoom In should be disabled at maximum zoom (3.0)");
+}
+
+/**
+ * validateUserInterfaceItem: should return NO for zoomOut: when at minimum zoom (0.5).
+ */
+- (void)testZoomOutMenuValidationDisabledAtMinZoom
+{
+    self.document.zoomMultiplier = 0.5;
+    MockZoomMenuItem *item = [[MockZoomMenuItem alloc] initWithTitle:@"Zoom Out"
+                                                      action:@selector(zoomOut:)
+                                               keyEquivalent:@""];
+    BOOL result = [self.document validateUserInterfaceItem:item];
+    XCTAssertFalse(result, @"Zoom Out should be disabled at minimum zoom (0.5)");
+}
+
+
+#pragma mark - Preference Observer — Bug 2 Regression Tests
+
+/**
+ * setupEditor: must not reset zoomMultiplier to 1.0.
+ * Bug 2: If setupEditor: calls applyCurrentZoom internally with the base font it
+ * resets, zoom is effectively lost even though zoomMultiplier itself is unchanged.
+ * This test guards the multiplier value directly (no editor required).
+ */
+- (void)testSetupEditorDoesNotResetZoomMultiplier
+{
+    self.document.zoomMultiplier = 1.5;
+    XCTAssertNoThrow([self.document setupEditor:@"editorBaseFontInfo"],
+                     @"setupEditor:editorBaseFontInfo should not throw");
+    XCTAssertEqualWithAccuracy(self.document.zoomMultiplier, 1.5, 0.001,
+                               @"setupEditor: must not reset zoomMultiplier");
+}
+
+/**
+ * Calling setupEditor: while zoomed should not crash.
+ * Bug 2 regression: nil changedKey exercises the full setup path.
+ */
+- (void)testSetupEditorDoesNotCrashWhileZoomed
+{
+    self.document.zoomMultiplier = 2.0;
+    XCTAssertNoThrow([self.document setupEditor:nil],
+                     @"setupEditor:nil should not crash when zoomed to 2.0");
+}
+
+/**
+ * Calling setupEditor: for a line-spacing change while zoomed should not crash.
+ * Bug 2 regression guard for the editorLineSpacing code path.
+ */
+- (void)testSetupEditorDoesNotCrashForLineSpacingChangeWhileZoomed
+{
+    self.document.zoomMultiplier = 1.3;
+    XCTAssertNoThrow([self.document setupEditor:@"editorLineSpacing"],
+                     @"setupEditor:editorLineSpacing should not crash when zoomed");
+}
+
+/**
+ * Calling setupEditor: for a style change while zoomed should not crash.
+ * Bug 2 regression guard for the editorStyleName code path.
+ */
+- (void)testSetupEditorDoesNotCrashForStyleChangeWhileZoomed
+{
+    self.document.zoomMultiplier = 1.3;
+    XCTAssertNoThrow([self.document setupEditor:@"editorStyleName"],
+                     @"setupEditor:editorStyleName should not crash when zoomed");
+}
+
+/**
+ * CONDITIONAL / RED TEST — expected to FAIL until Bug 2 is fixed.
+ *
+ * After zooming to 1.5 and calling applyCurrentZoom, the editor font's point
+ * size should reflect the zoom. After a subsequent setupEditor:editorBaseFontInfo,
+ * the editor font should NOT revert to the base (unzoomed) size.
+ *
+ * This test skips gracefully in headless environments where the editor outlet
+ * is nil (e.g. CI without a display server).
+ */
+- (void)testSetupEditorPreservesZoomedFontSize
+{
+    [self.document makeWindowControllers];
+
+    if (!self.document.editor) {
+        NSLog(@"Skipping testSetupEditorPreservesZoomedFontSize - editor outlet is nil (headless)");
+        return;
+    }
+
+    // Zoom to 1.5x and apply.
+    self.document.zoomMultiplier = 1.5;
+    [self.document applyCurrentZoom];
+
+    CGFloat zoomedPointSize = self.document.editor.font.pointSize;
+
+    // Simulate a preference change that triggers font re-application.
+    [self.document setupEditor:@"editorBaseFontInfo"];
+
+    CGFloat afterSetupPointSize = self.document.editor.font.pointSize;
+
+    // BUG 2: setupEditor: resets the font to the base size, so afterSetupPointSize
+    // will equal the unzoomed base size, not zoomedPointSize.
+    // This assertion FAILS until Bug 2 is fixed.
+    XCTAssertEqualWithAccuracy(afterSetupPointSize, zoomedPointSize, 0.1,
+                               @"Bug 2: setupEditor: must not revert the editor font to "
+                               @"the unzoomed base size after applyCurrentZoom has run");
+}
+
+/**
+ * After zooming, a preference change (setupEditor:), and another zoomIn:,
+ * the multiplier should reflect both the original zoom and the new step.
+ * This exercises the multiplier state across a full zoom -> preference -> zoom cycle.
+ */
+- (void)testZoomThenPreferenceChangeThenZoomAgain
+{
+    self.document.zoomMultiplier = 1.5;
+    XCTAssertNoThrow([self.document setupEditor:@"editorBaseFontInfo"],
+                     @"setupEditor: should not throw while zoomed");
+
+    [self.document zoomIn:nil];
+
+    XCTAssertEqualWithAccuracy(self.document.zoomMultiplier, 1.6, 0.001,
+                               @"After zoom(1.5) -> setupEditor -> zoomIn, "
+                               @"multiplier should be 1.6");
+}
+
+
+#pragma mark - Tab Stop Calculation — Bug 3 Regression Tests
+
+/**
+ * Pure math test: a font at 2x size must produce a wider space character and
+ * therefore a wider tab interval than the same font at base size.
+ * This test does not require a window controller and always runs.
+ */
+- (void)testZoomedFontProducesDifferentTabWidth
+{
+    NSFont *baseFont = [MPPreferences sharedInstance].editorBaseFont;
+    XCTAssertNotNil(baseFont, @"editorBaseFont must not be nil");
+
+    CGFloat baseSize = baseFont.pointSize;
+    CGFloat zoomedSize = baseSize * 2.0;
+
+    NSFont *zoomedFont = [NSFont fontWithName:baseFont.fontName size:zoomedSize];
+    XCTAssertNotNil(zoomedFont, @"Could not create zoomed font");
+
+    NSDictionary *baseAttrs  = @{NSFontAttributeName: baseFont};
+    NSDictionary *zoomedAttrs = @{NSFontAttributeName: zoomedFont};
+
+    CGFloat baseSpaceWidth   = [@" " sizeWithAttributes:baseAttrs].width;
+    CGFloat zoomedSpaceWidth = [@" " sizeWithAttributes:zoomedAttrs].width;
+
+    XCTAssertGreaterThan(zoomedSpaceWidth, baseSpaceWidth,
+                         @"Space character must be wider in a larger font");
+
+    CGFloat baseTabInterval   = baseSpaceWidth   * 4.0;
+    CGFloat zoomedTabInterval = zoomedSpaceWidth * 4.0;
+
+    XCTAssertGreaterThan(zoomedTabInterval, baseTabInterval,
+                         @"Tab interval (4 spaces) must be wider at 2x zoom than at base size");
+}
+
+/**
+ * CONDITIONAL / RED TEST — expected to FAIL until Bug 3 is fixed.
+ *
+ * After zooming to 2.0, applyCurrentZoom, and setupEditor:editorBaseFontInfo,
+ * the first tab stop in the editor's paragraph style should match the tab
+ * interval computed from the zoomed font (not the base font).
+ *
+ * Skips in headless environments where the editor outlet is nil.
+ */
+- (void)testTabStopsReflectZoomedFontSize
+{
+    [self.document makeWindowControllers];
+
+    if (!self.document.editor) {
+        NSLog(@"Skipping testTabStopsReflectZoomedFontSize - editor outlet is nil (headless)");
+        return;
+    }
+
+    if (self.document.editor.defaultParagraphStyle.tabStops.count == 0) {
+        NSLog(@"Skipping testTabStopsReflectZoomedFontSize - no tab stops (headless)");
+        return;
+    }
+
+    // Zoom to 2.0 and apply.
+    self.document.zoomMultiplier = 2.0;
+    [self.document applyCurrentZoom];
+
+    // Trigger the code path that recomputes tab stops.
+    [self.document setupEditor:@"editorBaseFontInfo"];
+
+    // Compute the expected tab interval from the zoomed font.
+    NSFont *baseFont = [MPPreferences sharedInstance].editorBaseFont;
+    CGFloat zoomedSize = baseFont.pointSize * 2.0;
+    NSFont *zoomedFont = [NSFont fontWithName:baseFont.fontName size:zoomedSize];
+    NSDictionary *attrs = @{NSFontAttributeName: zoomedFont};
+    CGFloat spaceWidth = [@" " sizeWithAttributes:attrs].width;
+    CGFloat expectedTabInterval = spaceWidth * 4.0;
+
+    NSArray *tabStops = self.document.editor.defaultParagraphStyle.tabStops;
+    XCTAssertGreaterThan(tabStops.count, 0U, @"There should be at least one tab stop");
+
+    NSTextTab *firstTab = tabStops[0];
+
+    // BUG 3: setupEditor: uses the base font (not the zoomed font) to compute
+    // tab stops, so firstTab.location will equal the base-font tab interval.
+    // This assertion FAILS until Bug 3 is fixed.
+    XCTAssertEqualWithAccuracy(firstTab.location, expectedTabInterval, 0.5,
+                               @"Bug 3: First tab stop must reflect zoomed font size, "
+                               @"not the unzoomed base font size");
+}
+
+/**
+ * CONDITIONAL test: at default zoom (1.0), tab stops should match the interval
+ * computed from the base font.  This is a green test that verifies the baseline
+ * behaviour is correct before any zoom is applied.
+ *
+ * Skips in headless environments where the editor outlet is nil.
+ */
+- (void)testTabStopsAtDefaultZoomMatchBaseFont
+{
+    [self.document makeWindowControllers];
+
+    if (!self.document.editor) {
+        NSLog(@"Skipping testTabStopsAtDefaultZoomMatchBaseFont - editor outlet is nil (headless)");
+        return;
+    }
+
+    if (self.document.editor.defaultParagraphStyle.tabStops.count == 0) {
+        NSLog(@"Skipping testTabStopsAtDefaultZoomMatchBaseFont - no tab stops (headless)");
+        return;
+    }
+
+    // Ensure default zoom.
+    self.document.zoomMultiplier = 1.0;
+    [self.document setupEditor:@"editorBaseFontInfo"];
+
+    NSFont *baseFont = [MPPreferences sharedInstance].editorBaseFont;
+    NSDictionary *attrs = @{NSFontAttributeName: baseFont};
+    CGFloat spaceWidth = [@" " sizeWithAttributes:attrs].width;
+    CGFloat expectedTabInterval = spaceWidth * 4.0;
+
+    NSArray *tabStops = self.document.editor.defaultParagraphStyle.tabStops;
+    XCTAssertGreaterThan(tabStops.count, 0U, @"There should be at least one tab stop");
+
+    NSTextTab *firstTab = tabStops[0];
+    XCTAssertEqualWithAccuracy(firstTab.location, expectedTabInterval, 0.5,
+                               @"At default zoom, first tab stop should match "
+                               @"the base-font tab interval");
+}
+
+@end

--- a/MacDownTests/MPZoomTests.m
+++ b/MacDownTests/MPZoomTests.m
@@ -2,15 +2,9 @@
 //  MPZoomTests.m
 //  MacDownTests
 //
-//  TDD tests for the zoom feature in MPDocument.
-//  Some tests are RED regression guards and are expected to FAIL against the
-//  current code until the corresponding bug is fixed:
-//
-//  Bug 2: setupEditor: resets the editor font to the base (unzoomed) size,
-//         clobbering any zoom that was applied via applyCurrentZoom.
-//
-//  Bug 3: setupEditor: computes tab stops from the base font (not the zoomed
-//         font), so tab stops do not scale with zoom.
+//  Tests for the per-document zoom feature in MPDocument
+//  (zoomIn:/zoomOut:/resetZoom: actions, zoomMultiplier property,
+//  and the zoom-aware font and tab-stop code paths).
 //
 
 #import <XCTest/XCTest.h>
@@ -223,26 +217,11 @@
 }
 
 
-#pragma mark - Preference Observer — Bug 2 Regression Tests
-
-/**
- * setupEditor: must not reset zoomMultiplier to 1.0.
- * Bug 2: If setupEditor: calls applyCurrentZoom internally with the base font it
- * resets, zoom is effectively lost even though zoomMultiplier itself is unchanged.
- * This test guards the multiplier value directly (no editor required).
- */
-- (void)testSetupEditorDoesNotResetZoomMultiplier
-{
-    self.document.zoomMultiplier = 1.5;
-    XCTAssertNoThrow([self.document setupEditor:@"editorBaseFontInfo"],
-                     @"setupEditor:editorBaseFontInfo should not throw");
-    XCTAssertEqualWithAccuracy(self.document.zoomMultiplier, 1.5, 0.001,
-                               @"setupEditor: must not reset zoomMultiplier");
-}
+#pragma mark - Preference Observer Tests
 
 /**
  * Calling setupEditor: while zoomed should not crash.
- * Bug 2 regression: nil changedKey exercises the full setup path.
+ * nil changedKey exercises the full setup path.
  */
 - (void)testSetupEditorDoesNotCrashWhileZoomed
 {
@@ -253,7 +232,6 @@
 
 /**
  * Calling setupEditor: for a line-spacing change while zoomed should not crash.
- * Bug 2 regression guard for the editorLineSpacing code path.
  */
 - (void)testSetupEditorDoesNotCrashForLineSpacingChangeWhileZoomed
 {
@@ -264,7 +242,6 @@
 
 /**
  * Calling setupEditor: for a style change while zoomed should not crash.
- * Bug 2 regression guard for the editorStyleName code path.
  */
 - (void)testSetupEditorDoesNotCrashForStyleChangeWhileZoomed
 {
@@ -274,14 +251,11 @@
 }
 
 /**
- * CONDITIONAL / RED TEST — expected to FAIL until Bug 2 is fixed.
+ * After zooming to 1.5 and calling applyCurrentZoom, a subsequent
+ * setupEditor:editorBaseFontInfo must not revert the editor font to the
+ * unzoomed base size.
  *
- * After zooming to 1.5 and calling applyCurrentZoom, the editor font's point
- * size should reflect the zoom. After a subsequent setupEditor:editorBaseFontInfo,
- * the editor font should NOT revert to the base (unzoomed) size.
- *
- * This test skips gracefully in headless environments where the editor outlet
- * is nil (e.g. CI without a display server).
+ * Skips in headless environments where the editor outlet is nil.
  */
 - (void)testSetupEditorPreservesZoomedFontSize
 {
@@ -303,11 +277,8 @@
 
     CGFloat afterSetupPointSize = self.document.editor.font.pointSize;
 
-    // BUG 2: setupEditor: resets the font to the base size, so afterSetupPointSize
-    // will equal the unzoomed base size, not zoomedPointSize.
-    // This assertion FAILS until Bug 2 is fixed.
     XCTAssertEqualWithAccuracy(afterSetupPointSize, zoomedPointSize, 0.1,
-                               @"Bug 2: setupEditor: must not revert the editor font to "
+                               @"setupEditor: must not revert the editor font to "
                                @"the unzoomed base size after applyCurrentZoom has run");
 }
 
@@ -330,7 +301,7 @@
 }
 
 
-#pragma mark - Tab Stop Calculation — Bug 3 Regression Tests
+#pragma mark - Tab Stop Calculation Tests
 
 /**
  * Pure math test: a font at 2x size must produce a wider space character and
@@ -365,11 +336,8 @@
 }
 
 /**
- * CONDITIONAL / RED TEST — expected to FAIL until Bug 3 is fixed.
- *
- * After zooming to 2.0, applyCurrentZoom, and setupEditor:editorBaseFontInfo,
- * the first tab stop in the editor's paragraph style should match the tab
- * interval computed from the zoomed font (not the base font).
+ * After zooming to 2.0 and applying, the first tab stop should match the
+ * tab interval computed from the zoomed font, not the base font.
  *
  * Skips in headless environments where the editor outlet is nil.
  */
@@ -407,11 +375,8 @@
 
     NSTextTab *firstTab = tabStops[0];
 
-    // BUG 3: setupEditor: uses the base font (not the zoomed font) to compute
-    // tab stops, so firstTab.location will equal the base-font tab interval.
-    // This assertion FAILS until Bug 3 is fixed.
     XCTAssertEqualWithAccuracy(firstTab.location, expectedTabInterval, 0.5,
-                               @"Bug 3: First tab stop must reflect zoomed font size, "
+                               @"First tab stop must reflect zoomed font size, "
                                @"not the unzoomed base font size");
 }
 

--- a/MacDownTests/MPZoomTests.m
+++ b/MacDownTests/MPZoomTests.m
@@ -38,6 +38,7 @@
 
 @interface MPZoomTests : XCTestCase
 @property (strong) MPDocument *document;
+@property (assign) CGFloat originalZoomLevel;
 @end
 
 @implementation MPZoomTests
@@ -45,11 +46,14 @@
 - (void)setUp
 {
     [super setUp];
+    self.originalZoomLevel = [MPPreferences sharedInstance].documentZoomLevel;
+    [MPPreferences sharedInstance].documentZoomLevel = 1.0;
     self.document = [[MPDocument alloc] init];
 }
 
 - (void)tearDown
 {
+    [MPPreferences sharedInstance].documentZoomLevel = self.originalZoomLevel;
     self.document = nil;
     [super tearDown];
 }
@@ -285,7 +289,7 @@
 
 /**
  * After zooming, a preference change (setupEditor:), and another zoomIn:,
- * the multiplier should reflect both the original zoom and the new step.
+ * the multiplier should advance to the next persisted preset.
  * This exercises the multiplier state across a full zoom -> preference -> zoom cycle.
  */
 - (void)testZoomThenPreferenceChangeThenZoomAgain
@@ -296,9 +300,9 @@
 
     [self.document zoomIn:nil];
 
-    XCTAssertEqualWithAccuracy(self.document.zoomMultiplier, 1.6, 0.001,
+    XCTAssertEqualWithAccuracy(self.document.zoomMultiplier, 2.0, 0.001,
                                @"After zoom(1.5) -> setupEditor -> zoomIn, "
-                               @"multiplier should be 1.6");
+                               @"multiplier should advance to the 2.0 preset");
 }
 
 


### PR DESCRIPTION
## Summary

Unifies editor and preview zoom into a single document-level control, as proposed in issue #470.

- Adds Command-Plus, Command-Minus, and Command-0 menu actions for both panes
- Adds a toolbar zoom menu with presets from 50% through 300%
- Persists one shared zoom level and applies it to every open document window
- Preserves editor font traits, tab-stop scaling, word wrapping, and the existing relative preview sizing preference
- Reapplies preview zoom after WebView reloads

This builds on the implementations and retained commit history from #442 and #395.

## Testing

- 93 focused unit tests pass (`MPZoomTests`, `MPPreviewZoomTests`, and `MPToolbarControllerTests`)
- Debug application build succeeds on macOS with Xcode 26.6
- Interface Builder validation passes for `MainMenu.xib`

Related to #470 and #335.
