### PR TITLE
Remember editor pane visibility

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -2450,7 +2450,10 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
 - (IBAction)toggleEditorPane:(id)sender
 {
+    BOOL wasVisible = self.editorVisible;
     [self toggleSplitterCollapsingEditorPane:YES];
+    if (self.editorVisible != wasVisible)
+        self.preferences.editorStartInPreviewMode = !self.editorVisible;
 }
 
 - (IBAction)toggleAutoSave:(id)sender

--- a/MacDownTests/MPPaneToggleTests.m
+++ b/MacDownTests/MPPaneToggleTests.m
@@ -43,6 +43,7 @@
 
 @interface MPPaneToggleTests : XCTestCase
 @property (strong) MPDocument *document;
+@property BOOL originalStartInPreviewMode;
 @end
 
 
@@ -51,12 +52,17 @@
 - (void)setUp
 {
     [super setUp];
+    MPPreferences *preferences = [MPPreferences sharedInstance];
+    self.originalStartInPreviewMode = preferences.editorStartInPreviewMode;
+    preferences.editorStartInPreviewMode = NO;
     self.document = [[MPDocument alloc] init];
 }
 
 - (void)tearDown
 {
     self.document = nil;
+    [MPPreferences sharedInstance].editorStartInPreviewMode =
+        self.originalStartInPreviewMode;
     [super tearDown];
 }
 
@@ -81,6 +87,40 @@
 {
     XCTAssertNoThrow([self.document togglePreviewPane:nil],
                      @"togglePreviewPane: should not crash");
+}
+
+- (void)testEditorPaneChoiceIsRemembered
+{
+    MPPreferences *preferences = [MPPreferences sharedInstance];
+    BOOL originalEditorOnRight = preferences.editorOnRight;
+
+    @try {
+        MPDocumentSplitView *splitView = [[MPDocumentSplitView alloc]
+            initWithFrame:NSMakeRect(0, 0, 800, 600)];
+        splitView.vertical = YES;
+        NSView *editor = [[NSView alloc]
+            initWithFrame:NSMakeRect(0, 0, 399, 600)];
+        WebView *preview = [[WebView alloc]
+            initWithFrame:NSMakeRect(400, 0, 400, 600)];
+        [splitView addSubview:editor];
+        [splitView addSubview:preview];
+
+        self.document.splitView = splitView;
+        self.document.editorContainer = editor;
+        self.document.preview = preview;
+        preferences.editorOnRight = NO;
+
+        [self.document toggleEditorPane:nil];
+        XCTAssertTrue(preferences.editorStartInPreviewMode,
+                      @"Hiding the editor should be remembered for the next window");
+
+        [self.document toggleEditorPane:nil];
+        XCTAssertFalse(preferences.editorStartInPreviewMode,
+                       @"Restoring the editor should update the remembered choice");
+    }
+    @finally {
+        preferences.editorOnRight = originalEditorOnRight;
+    }
 }
 
 


### PR DESCRIPTION
## Summary

Remember the user's editor pane choice when they use **View > Hide Editor Pane** or **Restore Editor Pane**.

- Hiding the editor enables the existing "start in preview mode" preference
- Restoring the editor disables that preference again
- Only updates the preference when the pane visibility actually changes
- Leaves preview-pane toggles and the existing last-visible-pane protection unchanged

This makes the next document window honor the most recent explicit editor-pane choice without adding another preference.

## Testing

- `MPPaneToggleTests`: 32 tests pass
- Adds a non-headless layout test for hide, remember, restore, and clear
