### PR TITLE
Address issue #503: deduplicate duplicate heading slugs (github-slugger semantics)

### DIFF
--- a/Dependency/cmark-gfm/src/mdmark.c
+++ b/Dependency/cmark-gfm/src/mdmark.c
@@ -41,8 +41,97 @@ static int g_checkbox_index = 0;
 void mdmark_reset_checkbox_index(void) { g_checkbox_index = 0; }
 int mdmark_current_checkbox_index(void) { return g_checkbox_index; }
 
+#pragma mark - Heading slug dedup (issue #503)
+
+// Per-render duplicate-slug dedup, matching github-slugger semantics: a
+// purpose-built linear (slug,count) list, allocated via the render's
+// cmark_mem so it plays nicely with the Linux test harness. Not a global —
+// each render (HTML pass and TOC pass alike) owns its own stack-local
+// instance, so state resets automatically per render/per pass and no
+// mdmark_reset_* export is needed (contrast with g_checkbox_index above,
+// whose value must cross the C<->ObjC boundary and therefore has none of
+// these options).
+typedef struct slug_dedup_entry {
+  struct slug_dedup_entry *next;
+  char  *slug;   // NUL-terminated copy, owned via d->mem
+  size_t len;    // byte length excl NUL
+  int    count;  // occurrences[slug]
+} slug_dedup_entry;
+
+typedef struct slug_dedup {
+  cmark_mem        *mem;
+  slug_dedup_entry *head;
+} slug_dedup;
+
+static void slug_dedup_init(slug_dedup *d, cmark_mem *mem) {
+  d->mem = mem;
+  d->head = NULL;
+}
+
+static slug_dedup_entry *slug_dedup_find(slug_dedup *d, const char *s,
+                                         size_t len) {
+  for (slug_dedup_entry *e = d->head; e; e = e->next)
+    if (e->len == len && memcmp(e->slug, s, len) == 0)
+      return e;
+  return NULL;
+}
+
+static void slug_dedup_put(slug_dedup *d, const char *s, size_t len,
+                           int count) {
+  slug_dedup_entry *e = d->mem->calloc(1, sizeof(*e));
+  e->slug = d->mem->calloc(1, len + 1);
+  memcpy(e->slug, s, len);
+  e->len = len;
+  e->count = count;
+  e->next = d->head;
+  d->head = e;
+}
+
+static void slug_dedup_free(slug_dedup *d) {
+  slug_dedup_entry *e = d->head;
+  while (e) {
+    slug_dedup_entry *n = e->next;
+    d->mem->free(e->slug);
+    d->mem->free(e);
+    e = n;
+  }
+  d->head = NULL;
+}
+
+// Append the deduped form of base[0..base_len) to out, per github-slugger:
+// result = base; while occurrences[result] exists, occurrences[base]++ and
+// result = base + "-" + occurrences[base]; then occurrences[result] = 0.
+// NULL-tolerant: without a dedup map, just pass the base slug through
+// unchanged (used as a defensive fallback; state is never actually NULL on
+// the current call paths).
+static void slug_dedup_emit(slug_dedup *d, cmark_strbuf *out,
+                            const char *base, size_t base_len) {
+  if (!d) {
+    cmark_strbuf_put(out, (const unsigned char *)base, (bufsize_t)base_len);
+    return;
+  }
+
+  cmark_strbuf result = CMARK_BUF_INIT(d->mem);
+  cmark_strbuf_put(&result, (const unsigned char *)base, (bufsize_t)base_len);
+
+  while (slug_dedup_find(d, (const char *)result.ptr, result.size)) {
+    slug_dedup_entry *b = slug_dedup_find(d, base, base_len);
+    int n = ++b->count;
+    char suffix[16];
+    int slen = snprintf(suffix, sizeof(suffix), "-%d", n);
+    cmark_strbuf_clear(&result);
+    cmark_strbuf_put(&result, (const unsigned char *)base, (bufsize_t)base_len);
+    cmark_strbuf_put(&result, (const unsigned char *)suffix, (bufsize_t)slen);
+  }
+
+  slug_dedup_put(d, (const char *)result.ptr, result.size, 0);
+  cmark_strbuf_put(out, result.ptr, result.size);
+  cmark_strbuf_free(&result);
+}
+
 typedef struct {
     const mdmark_options *opts;
+    slug_dedup           *dedup;  // per-render dedup state (issue #503)
 } mdmark_render_state;
 
 static void escape_html(cmark_strbuf *dest, const unsigned char *source,
@@ -196,14 +285,19 @@ static const char *heading_inner_html(const char *rendered, size_t *out_len) {
   return start;
 }
 
-static void put_heading_slug(cmark_strbuf *out, cmark_node *heading) {
+// Emit the deduped id/href slug for `heading` into `out`. The "section"
+// empty-heading fallback is applied to the base slug before dedup (issue
+// #503, requirements §2.3), so repeated empty headings dedup as
+// "section, section-1, section-2, ..." rather than each claiming "section".
+static void put_heading_slug(cmark_strbuf *out, cmark_node *heading,
+                             slug_dedup *dedup) {
   char *rendered = render_heading_html(heading);
   cmark_strbuf slug = CMARK_BUF_INIT(cmark_node_mem(heading));
   if (rendered)
     mdmark_slugify(&slug, (const unsigned char *)rendered, strlen(rendered));
   if (slug.size == 0)
     cmark_strbuf_puts(&slug, "section");
-  cmark_strbuf_put(out, slug.ptr, slug.size);
+  slug_dedup_emit(dedup, out, (const char *)slug.ptr, slug.size);
   cmark_strbuf_free(&slug);
   free(rendered);
 }
@@ -433,7 +527,7 @@ static int S_render_node(cmark_html_renderer *renderer, cmark_node *node,
       // navigation, TOC anchors and scroll sync work (hoedown_html_patch's
       // rndr_header contract).
       cmark_strbuf_puts(html, " id=\"");
-      put_heading_slug(html, node);
+      put_heading_slug(html, node, state->dedup);
       cmark_strbuf_puts(html, "\">");
     } else {
       end_heading[3] = (char)('0' + node->as.heading.level);
@@ -726,7 +820,9 @@ static char *mdmark_render_html_ast(cmark_node *root, int cmark_options,
   cmark_strbuf html = CMARK_BUF_INIT(mem);
   cmark_event_type ev_type;
   cmark_node *cur;
-  mdmark_render_state state = {opts};
+  slug_dedup dedup;
+  slug_dedup_init(&dedup, mem);
+  mdmark_render_state state = {opts, &dedup};
   cmark_html_renderer renderer = {&html, NULL, NULL, 0, 0, &state};
   cmark_iter *iter = cmark_iter_new(root);
 
@@ -744,6 +840,7 @@ static char *mdmark_render_html_ast(cmark_node *root, int cmark_options,
   cmark_llist_free(mem, renderer.filter_extensions);
 
   cmark_iter_free(iter);
+  slug_dedup_free(&dedup);
   return result;
 }
 
@@ -839,6 +936,9 @@ char *mdmark_render_toc(const char *markdown, size_t length,
   int current_level = 0;
   int level_offset = 0;
 
+  slug_dedup dedup;
+  slug_dedup_init(&dedup, mem);
+
   cmark_iter *iter = cmark_iter_new(doc);
   cmark_event_type ev_type;
   while ((ev_type = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
@@ -846,9 +946,21 @@ char *mdmark_render_toc(const char *markdown, size_t length,
     if (ev_type != CMARK_EVENT_ENTER || node->type != CMARK_NODE_HEADING)
       continue;
 
+    // MacDown: advance the dedup counter for EVERY heading, in document
+    // order, before the toc_level filter below -- including headings deeper
+    // than toc_level that never make it into the list. GitHub assigns an id
+    // to (and dedups across) every heading; if a skipped deep heading isn't
+    // counted here, a shallower heading sharing its base slug would get a
+    // dedup suffix that disagrees with the id the HTML pass gave it (issue
+    // #503).
+    cmark_strbuf slug = CMARK_BUF_INIT(mem);
+    put_heading_slug(&slug, node, &dedup);
+
     int level = node->as.heading.level;
-    if (level > toc_level)
+    if (level > toc_level) {
+      cmark_strbuf_free(&slug);
       continue;
+    }
 
     // Set the level offset if this is the first header of the document.
     if (current_level == 0)
@@ -875,8 +987,9 @@ char *mdmark_render_toc(const char *markdown, size_t length,
     }
 
     cmark_strbuf_puts(&ob, "<a href=\"#");
-    put_heading_slug(&ob, node);
+    cmark_strbuf_put(&ob, slug.ptr, slug.size);  // reuse the precomputed slug
     cmark_strbuf_puts(&ob, "\">");
+    cmark_strbuf_free(&slug);
 
     char *rendered = render_heading_html(node);
     if (rendered) {
@@ -889,6 +1002,7 @@ char *mdmark_render_toc(const char *markdown, size_t length,
     cmark_strbuf_puts(&ob, "</a>\n");
   }
   cmark_iter_free(iter);
+  slug_dedup_free(&dedup);
 
   while (current_level > 0) {
     cmark_strbuf_puts(&ob, "</li>\n</ul>\n");

--- a/Dependency/cmark-gfm/src/mdmark.c
+++ b/Dependency/cmark-gfm/src/mdmark.c
@@ -114,8 +114,15 @@ static void slug_dedup_emit(slug_dedup *d, cmark_strbuf *out,
   cmark_strbuf result = CMARK_BUF_INIT(d->mem);
   cmark_strbuf_put(&result, (const unsigned char *)base, (bufsize_t)base_len);
 
+  // `base`/`base_len` are invariant across iterations, so resolve the base
+  // entry once up front rather than re-searching on every pass. Entering
+  // the loop means the while-condition found `result` (== `base` on the
+  // first pass) already registered, so `base` itself is registered too —
+  // `b` is guaranteed non-NULL whenever it is dereferenced inside the loop.
+  // On a first-occurrence slug the loop never runs, so a NULL `b` (base not
+  // yet registered) is never dereferenced.
+  slug_dedup_entry *b = slug_dedup_find(d, base, base_len);
   while (slug_dedup_find(d, (const char *)result.ptr, result.size)) {
-    slug_dedup_entry *b = slug_dedup_find(d, base, base_len);
     int n = ++b->count;
     char suffix[16];
     int slen = snprintf(suffix, sizeof(suffix), "-%d", n);

--- a/MacDownTests/Fixtures/syntax-highlighting-languages.html
+++ b/MacDownTests/Fixtures/syntax-highlighting-languages.html
@@ -14,7 +14,7 @@
     if (n &lt;= 1) return n;
     return fibonacci(n - 1) + fibonacci(n - 2);
 }</code></pre></div>
-<h2 id="c">C++</h2>
+<h2 id="c-1">C++</h2>
 <div><pre><code class="language-cpp">int fibonacci(int n) {
     if (n &lt;= 1) return n;
     return fibonacci(n - 1) + fibonacci(n - 2);

--- a/MacDownTests/MPMarkdownRenderingTests.m
+++ b/MacDownTests/MPMarkdownRenderingTests.m
@@ -145,6 +145,32 @@
 #endif
 }
 
+/**
+ * Extract every match of a regular expression's first capture group from a
+ * string, in order of appearance. Used by the duplicate-heading dedup tests
+ * to compare heading ids against TOC hrefs in document order (issue #503).
+ */
+- (NSArray<NSString *> *)matchesForPattern:(NSString *)pattern inString:(NSString *)string
+{
+    NSError *error = nil;
+    NSRegularExpression *regex =
+        [NSRegularExpression regularExpressionWithPattern:pattern
+                                                    options:0
+                                                      error:&error];
+    XCTAssertNil(error, @"Invalid regex pattern: %@", pattern);
+
+    NSMutableArray<NSString *> *results = [NSMutableArray array];
+    [regex enumerateMatchesInString:string
+                             options:0
+                               range:NSMakeRange(0, string.length)
+                          usingBlock:^(NSTextCheckingResult *match, NSMatchingFlags flags, BOOL *stop) {
+        if (match.numberOfRanges > 1) {
+            [results addObject:[string substringWithRange:[match rangeAtIndex:1]]];
+        }
+    }];
+    return results;
+}
+
 #pragma mark - Basic Markdown Tests
 
 - (void)testBasicHeaders
@@ -894,22 +920,27 @@
                   @"Heading id must skip every HTML entity. Got: %@", html);
 }
 
-// Documents the current slug contract: identical headings are not uniquified,
-// so "## C" and "## C++" both collapse to id="c". This pins the behavior so a
-// future change to deduplication is a conscious decision, not a silent side
-// effect.
+// Duplicate headings now dedup with github-slugger "-N" suffixes: the first
+// occurrence keeps the base slug, and each subsequent occurrence gets the
+// next available "-N" suffix (issue #503). "## C" and "## C++" both slugify
+// to "c"; the second becomes "c-1", not a second "id=\"c\"".
 
-- (void)testDuplicateHeadingsCollapseToSameId
+- (void)testDuplicateHeadingsGetDedupedIds
 {
     NSString *html = [self renderMarkdown:@"## C\n\n## C++\n"
                            withExtensions:0
                             rendererFlags:0];
+    XCTAssertTrue([html containsString:@"id=\"c\""],
+                  @"First heading should have id=\"c\". Got: %@", html);
+    XCTAssertTrue([html containsString:@"id=\"c-1\""],
+                  @"Second heading (also slugifying to \"c\") should dedup to id=\"c-1\". Got: %@", html);
+
     NSUInteger firstC = [html rangeOfString:@"id=\"c\""].location;
-    NSUInteger secondC = [html rangeOfString:@"id=\"c\""
-                                  options:0
-                                    range:NSMakeRange(firstC + 1, html.length - firstC - 1)].location;
-    XCTAssertNotEqual(firstC, NSNotFound, @"First heading should have id=\"c\". Got: %@", html);
-    XCTAssertNotEqual(secondC, NSNotFound, @"Second heading should also have id=\"c\". Got: %@", html);
+    NSUInteger secondC = [html rangeOfString:@"id=\"c-1\""].location;
+    XCTAssertNotEqual(firstC, NSNotFound);
+    XCTAssertNotEqual(secondC, NSNotFound);
+    XCTAssertLessThan(firstC, secondC,
+                      @"id=\"c\" must appear before id=\"c-1\" in document order. Got: %@", html);
 }
 
 // Because this PR changes both the heading id and the TOC href, lock in the
@@ -926,6 +957,187 @@
                   @"TOC entry must link to the heading slug. Got: %@", html);
     XCTAssertTrue([html containsString:@"id=\"foo-bar\""],
                   @"Heading must carry the matching id. Got: %@", html);
+}
+
+// Extends testTOCHrefMatchesHeadingId to duplicated headings (issue #503,
+// requirements §2.5 / §4.2a): every TOC href must exactly equal the
+// corresponding heading's id, in document order, including dedup suffixes.
+// All headings are levels <=6 (the real-app case; kMPRendererTOCLevel is
+// hardcoded to 6 in MPRenderer.m so every heading here is TOC-eligible).
+
+- (void)testTOCHrefMatchesHeadingIdForDuplicateHeadings
+{
+    self.delegate.renderTOC = YES;
+    NSString *markdown = @"[TOC]\n\n"
+                          @"## Overview\n\n"
+                          @"## Overview\n\n"
+                          @"### Details\n\n"
+                          @"## Overview\n\n"
+                          @"### Details\n";
+    NSString *html = [self renderMarkdown:markdown
+                           withExtensions:0
+                            rendererFlags:0];
+
+    NSArray<NSString *> *headingIds =
+        [self matchesForPattern:@"<h[1-6][^>]*\\bid=\"([^\"]+)\"" inString:html];
+    NSArray<NSString *> *tocHrefs =
+        [self matchesForPattern:@"href=\"#([^\"]+)\"" inString:html];
+
+    NSArray<NSString *> *expectedIds = @[@"overview", @"overview-1", @"details",
+                                          @"overview-2", @"details-1"];
+    XCTAssertEqualObjects(headingIds, expectedIds,
+                          @"Heading ids should dedup in document order. Got: %@", html);
+    XCTAssertEqualObjects(tocHrefs, expectedIds,
+                          @"TOC hrefs must exactly match heading ids, including dedup "
+                          @"suffixes, in document order. Got: %@", html);
+}
+
+// Canonical github-slugger dedup sequence (issue #503, requirements §2.1):
+// occurrences map keyed by generated slug; "Hello, Hello, Hello, World,
+// Hello" must yield "hello, hello-1, hello-2, world, hello-3".
+
+- (void)testDuplicateHeadingsDedupIdSequence
+{
+    NSString *markdown = @"## Hello\n\n## Hello\n\n## Hello\n\n## World\n\n## Hello\n";
+    NSString *html = [self renderMarkdown:markdown
+                           withExtensions:0
+                            rendererFlags:0];
+
+    NSArray<NSString *> *expectedIds = @[@"hello", @"hello-1", @"hello-2", @"world", @"hello-3"];
+    NSUInteger searchLocation = 0;
+    for (NSString *expectedId in expectedIds) {
+        NSString *needle = [NSString stringWithFormat:@"id=\"%@\"", expectedId];
+        NSRange range = [html rangeOfString:needle
+                                     options:0
+                                       range:NSMakeRange(searchLocation, html.length - searchLocation)];
+        XCTAssertNotEqual(range.location, NSNotFound,
+                          @"Expected to find %@ starting at or after location %lu. Got: %@",
+                          needle, (unsigned long)searchLocation, html);
+        if (range.location == NSNotFound) {
+            break;
+        }
+        searchLocation = range.location + range.length;
+    }
+}
+
+// While-loop edge case (requirements §3.2): a literal heading text that
+// collides with an already-generated suffixed slug must still get its own
+// unique suffix, not reuse "-1". "Hello, Hello 1, Hello" -> the third
+// heading's base slug "hello" is taken, so it tries "hello-1" -- but that
+// literal slug was already produced by the second heading's own text
+// ("Hello 1" -> "hello-1") -- so it must advance to "hello-2".
+
+- (void)testDuplicateHeadingsDedupWhileLoopHandlesSlugCollision
+{
+    NSString *markdown = @"## Hello\n\n## Hello 1\n\n## Hello\n";
+    NSString *html = [self renderMarkdown:markdown
+                           withExtensions:0
+                            rendererFlags:0];
+
+    NSArray<NSString *> *expectedIds = @[@"hello", @"hello-1", @"hello-2"];
+    NSUInteger searchLocation = 0;
+    for (NSString *expectedId in expectedIds) {
+        NSString *needle = [NSString stringWithFormat:@"id=\"%@\"", expectedId];
+        NSRange range = [html rangeOfString:needle
+                                     options:0
+                                       range:NSMakeRange(searchLocation, html.length - searchLocation)];
+        XCTAssertNotEqual(range.location, NSNotFound,
+                          @"Expected to find %@ starting at or after location %lu (the third "
+                          @"heading must NOT collapse back to \"hello-1\"). Got: %@",
+                          needle, (unsigned long)searchLocation, html);
+        if (range.location == NSNotFound) {
+            break;
+        }
+        searchLocation = range.location + range.length;
+    }
+}
+
+// Empty/"section" fallback dedup (requirements §2.3): the fallback
+// substitution to "section" must happen BEFORE dedup, so repeated
+// punctuation-only headings dedup as "section, section-1, section-2, ...".
+
+- (void)testEmptyHeadingsDedupWithSectionFallback
+{
+    NSString *markdown = @"## ¡¿?!\n\n## ¡¿?!\n\n## ¡¿?!\n";
+    NSString *html = [self renderMarkdown:markdown
+                           withExtensions:0
+                            rendererFlags:0];
+
+    NSArray<NSString *> *expectedIds = @[@"section", @"section-1", @"section-2"];
+    NSUInteger searchLocation = 0;
+    for (NSString *expectedId in expectedIds) {
+        NSString *needle = [NSString stringWithFormat:@"id=\"%@\"", expectedId];
+        NSRange range = [html rangeOfString:needle
+                                     options:0
+                                       range:NSMakeRange(searchLocation, html.length - searchLocation)];
+        XCTAssertNotEqual(range.location, NSNotFound,
+                          @"Expected %@ in document order. Got: %@", needle, html);
+        if (range.location == NSNotFound) {
+            break;
+        }
+        searchLocation = range.location + range.length;
+    }
+}
+
+// Per-render stability (requirements §2.4): dedup state must reset at the
+// start of each render, so repeated renders of the same duplicated-heading
+// document are byte-stable (guards against a global/static counter that
+// keeps accumulating across renders).
+
+- (void)testDuplicateHeadingDedupIsStableAcrossRenders
+{
+    NSString *markdown = @"## Hello\n\n## Hello\n\n## Hello\n";
+    NSString *first = [self renderMarkdown:markdown withExtensions:0 rendererFlags:0];
+    NSString *second = [self renderMarkdown:markdown withExtensions:0 rendererFlags:0];
+    XCTAssertEqualObjects(first, second,
+                          @"Repeated renders of the same duplicated-heading document must "
+                          @"produce identical output (dedup state must reset per render).");
+}
+
+// Deep-heading desync guard (requirements §2.2 / §4.2b), exercised directly
+// via the C API. In the shipped app kMPRendererTOCLevel is hardcoded to 6
+// and Markdown headings never exceed level 6, so the TOC pass's
+// "level > toc_level" skip branch is unreachable through the normal
+// MPRenderer path (see testTOCHrefMatchesHeadingIdForDuplicateHeadings for
+// that primary, reachable guarantee). This test exercises the branch
+// directly: a level-3 duplicate is skipped from the TOC list (toc_level=2)
+// but must still consume a dedup suffix, so the second level-2 "Foo"
+// heading must get id="foo-2" in the HTML pass, and the TOC pass's href for
+// that same heading must also be "#foo-2" (not "#foo-1", which is what you
+// get if the skipped deep heading isn't counted).
+
+- (void)testTOCHrefMatchesIdWhenDeeperDuplicateConsumesSuffix
+{
+    NSString *markdown = @"## Foo\n\n### Foo\n\n## Foo\n";
+    NSData *markdownData = [markdown dataUsingEncoding:NSUTF8StringEncoding];
+    const char *bytes = (const char *)markdownData.bytes;
+    size_t length = markdownData.length;
+
+    mdmark_options options = {0};
+
+    char *renderedHtml = mdmark_render_html(bytes, length, &options);
+    XCTAssertTrue(renderedHtml != NULL, @"mdmark_render_html returned NULL");
+    NSString *html = [NSString stringWithUTF8String:renderedHtml];
+    free(renderedHtml);
+
+    char *renderedToc = mdmark_render_toc(bytes, length, &options, /*toc_level=*/2);
+    XCTAssertTrue(renderedToc != NULL, @"mdmark_render_toc returned NULL");
+    NSString *toc = [NSString stringWithUTF8String:renderedToc];
+    free(renderedToc);
+
+    NSArray<NSString *> *headingIds =
+        [self matchesForPattern:@"<h[1-6][^>]*\\bid=\"([^\"]+)\"" inString:html];
+    NSArray<NSString *> *tocHrefs =
+        [self matchesForPattern:@"href=\"#([^\"]+)\"" inString:toc];
+
+    XCTAssertEqualObjects(headingIds, (@[@"foo", @"foo-1", @"foo-2"]),
+                          @"HTML pass must dedup every heading in document order "
+                          @"regardless of level. Got: %@", html);
+    XCTAssertEqualObjects(tocHrefs, (@[@"foo", @"foo-2"]),
+                          @"TOC pass (toc_level=2) must skip the level-3 duplicate from "
+                          @"the list but still advance the dedup counter for it, so the "
+                          @"second level-2 heading's href must be \"foo-2\" (matching its "
+                          @"actual HTML id), not \"foo-1\". Got TOC: %@ / HTML: %@", toc, html);
 }
 
 // GitHub-slugger parity (github-slugger semantics). Unicode punctuation and

--- a/MacDownTests/MPMarkdownRenderingTests.m
+++ b/MacDownTests/MPMarkdownRenderingTests.m
@@ -1079,6 +1079,34 @@
     }
 }
 
+// The literal-slug path (a heading whose text already slugifies to
+// "section") and the empty/punctuation-only fallback path (which also
+// produces the base slug "section") must share the same dedup namespace
+// (requirements §2.3): the fallback occurrence has to be treated as a
+// duplicate of the literal one, not slugified independently.
+- (void)testSectionFallbackSharesDedupNamespaceWithLiteralHeading
+{
+    NSString *markdown = @"## Section\n\n## ¡¿?!\n";
+    NSString *html = [self renderMarkdown:markdown
+                           withExtensions:0
+                            rendererFlags:0];
+
+    NSArray<NSString *> *expectedIds = @[@"section", @"section-1"];
+    NSUInteger searchLocation = 0;
+    for (NSString *expectedId in expectedIds) {
+        NSString *needle = [NSString stringWithFormat:@"id=\"%@\"", expectedId];
+        NSRange range = [html rangeOfString:needle
+                                     options:0
+                                       range:NSMakeRange(searchLocation, html.length - searchLocation)];
+        XCTAssertNotEqual(range.location, NSNotFound,
+                          @"Expected %@ in document order. Got: %@", needle, html);
+        if (range.location == NSNotFound) {
+            break;
+        }
+        searchLocation = range.location + range.length;
+    }
+}
+
 // Per-render stability (requirements §2.4): dedup state must reset at the
 // start of each render, so repeated renders of the same duplicated-heading
 // document are byte-stable (guards against a global/static counter that

--- a/MacDownTests/MPQuickLookRendererTests.m
+++ b/MacDownTests/MPQuickLookRendererTests.m
@@ -755,6 +755,35 @@
                   @"Quick Look punctuation-only heading must fall back to the 'section' id. Got: %@", html);
 }
 
+// Duplicate-slug dedup mirror (issue #503). Quick Look calls
+// mdmark_render_html directly and shares put_heading_slug with the preview
+// path, so the same github-slugger dedup sequence must hold. This is
+// id-dedup ONLY -- Quick Look has no TOC path (no renderTOC, no [TOC]
+// splice, no href concept), so there is nothing to assert parity against;
+// see MPMarkdownRenderingTests for the full id/TOC parity coverage.
+
+- (void)testQuickLookDuplicateHeadingsDedupIdSequence
+{
+    NSString *markdown = @"## Hello\n\n## Hello\n\n## Hello\n\n## World\n\n## Hello\n";
+    NSString *html = [self.renderer renderMarkdown:markdown];
+
+    NSArray<NSString *> *expectedIds = @[@"hello", @"hello-1", @"hello-2", @"world", @"hello-3"];
+    NSUInteger searchLocation = 0;
+    for (NSString *expectedId in expectedIds) {
+        NSString *needle = [NSString stringWithFormat:@"id=\"%@\"", expectedId];
+        NSRange range = [html rangeOfString:needle
+                                     options:0
+                                       range:NSMakeRange(searchLocation, html.length - searchLocation)];
+        XCTAssertNotEqual(range.location, NSNotFound,
+                          @"Expected to find %@ starting at or after location %lu. Got: %@",
+                          needle, (unsigned long)searchLocation, html);
+        if (range.location == NSNotFound) {
+            break;
+        }
+        searchLocation = range.location + range.length;
+    }
+}
+
 // Hoedown treated a bare setext underline ('-') as a heading with empty
 // content, which crashed its slug buffer (#479). cmark-gfm parses a lone
 // '-' as an empty bullet list item instead, so no empty heading exists;


### PR DESCRIPTION
## Summary

Implements Decision 1 from the issue: duplicate heading slugs are now deduplicated with github-slugger semantics (`-1`, `-2`, … suffixes), so repeated heading text no longer produces colliding anchor `id`s and `[TOC]` `href`s that silently resolve to the wrong heading.

- The dedup is added to the single shared slug emitter `put_heading_slug` in `Dependency/cmark-gfm/src/mdmark.c`, so it applies identically to the HTML heading-`id` pass and the `[TOC]` `href` pass.
- Each pass carries its own per-render occurrences map — a small `cmark_mem`-allocated linear `(slug, count)` list — threaded as a stack-local. This gives per-render reset for free and adds no new exported symbols (`mdmark.h` is unchanged).
- The registration follows github-slugger's `while`-loop exactly (keyed on slug existence, base counter increments, generated slug seeded with count 0), so it also handles the case where a heading's literal text equals an already-generated suffixed slug (`Hello` / `Hello 1` / `Hello` → `hello`, `hello-1`, `hello-2`).
- The base slug algorithm `mdmark_slugify` is untouched — Unicode lowercasing stays Latin-1-scoped per Decision 2 (#471).
- The `[TOC]` pass now advances the dedup counter for **every** heading in document order **before** the `level > toc_level` filter (which still gates only list-item emission), so a heading deeper than the TOC level that shares a base slug cannot desync TOC `href`s from the `id`s the HTML pass emits.

## Related Issue

Related to #503. Interpretation posted before implementation: https://github.com/schuyler/macdown3000/issues/503#issuecomment-5009707740

## Judgment Calls

1. **PR base is `dev/3000.1`, not `main`.** `mdmark.c` exists only on `dev/3000.1` (where the cmark-gfm migration, PR #515, landed at `29b67b0`); `main` is still hoedown-based. This change is branched off and targets `dev/3000.1` accordingly. This is the single place the described code exists, matching the issue's "this lands in `mdmark.c`".
2. **Full github-slugger `while`-loop, not a naive per-base `count++`.** Alignment with github-slugger is the stated goal, and the `while`-loop is the only variant that stays correct when a literal heading collides with a previously-generated suffixed slug.
3. **Dedup state is a stack-local struct threaded through `put_heading_slug`, rather than the file-static `g_checkbox_index` + reset pattern.** The checkbox counter is global only because its value is read across the C↔Objective-C boundary; the dedup map has no external reader, so a stack-local gives per-render reset intrinsically and keeps `mdmark.h` untouched. (This was flagged as an open question in the interpretation; happy to switch to the checkbox pattern if you prefer consistency.)
4. **Quick Look mirror covers id-dedup only, not TOC parity.** `MPQuickLookRenderer` calls only `mdmark_render_html` and has no `[TOC]`/`href` concept, so there is nothing to assert TOC parity against there.
5. **The deep-heading desync guard is currently future-proofing.** In the shipped app `kMPRendererTOCLevel` is hardcoded to 6 and headings never exceed level 6, so the `level > toc_level` branch is unreachable through `MPRenderer`; the counter-before-filter structure is nonetheless the naturally-correct one, and it is exercised by a test that calls `mdmark_render_toc` directly with a smaller `toc_level`.

## Testing

All headless XCTest, run locally (full suite: 1072 executed; the only failures are 2 pre-existing `HGMarkdownHighlighterTests` theme-color assertions unrelated to this change — a local-environment artifact that passes in CI on the same base commit).

New / updated tests:
- `testDuplicateHeadingsDedupIdSequence` — `Hello`/`Hello`/`Hello`/`World`/`Hello` → `hello, hello-1, hello-2, world, hello-3`.
- `testDuplicateHeadingsDedupWhileLoopHandlesSlugCollision` — the literal-vs-suffix collision edge case.
- `testTOCHrefMatchesHeadingIdForDuplicateHeadings` — id/TOC `href` parity across a document with duplicated headings (the fixture requested in the issue).
- `testTOCHrefMatchesIdWhenDeeperDuplicateConsumesSuffix` — direct-C-API guard for the deep-heading case.
- `testEmptyHeadingsDedupWithSectionFallback` — `section`, `section-1`, … for headings that slugify to empty.
- `testDuplicateHeadingDedupIsStableAcrossRenders` — per-render reset / byte-stability.
- `testQuickLookDuplicateHeadingsDedupIdSequence` — Quick Look id-dedup mirror.
- Renamed `testDuplicateHeadingsCollapseToSameId` → `testDuplicateHeadingsGetDedupedIds` (it previously pinned the pre-dedup collision; now asserts `c` / `c-1`).
- Regenerated the `syntax-highlighting-languages` golden fixture, whose `C`/`C++` headings now correctly render `id="c"` / `id="c-1"`.

Note: `Podfile.lock` is intentionally not included — the only local diff there is a `cmark-gfm` SPEC CHECKSUM drift from re-running `pod install` with a different local CocoaPods version. For a `:path` dev pod that checksum hashes the podspec (unchanged here), not the edited source, so CI reproduces the committed value from the unmodified podspec.
