### PR TITLE
Render Mermaid/Graphviz when syntax highlighting is off

### DIFF
--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -688,16 +688,18 @@ NS_INLINE NSString *MPPreviewHeadTags(NSString *checkboxBridgeToken)
     if ([d rendererHasSyntaxHighlighting:self])
     {
         [scripts addObjectsFromArray:self.prismScripts];
-        // mermaid
-        if ([d rendererHasMermaid:self])
-        {
-            [scripts addObjectsFromArray:self.mermaidScripts];
-        }
-        // graphviz
-        if ([d rendererHasGraphviz:self])
-        {
-            [scripts addObjectsFromArray:self.graphvizScripts];
-        }
+    }
+    // Mermaid and Graphviz render from the language-* class (always
+    // emitted) via their own init scripts; they do not depend on Prism.
+    // Keep them out of the syntax-highlighting gate so diagrams render
+    // even when syntax highlighting is off (GitHub issue #533).
+    if ([d rendererHasMermaid:self])
+    {
+        [scripts addObjectsFromArray:self.mermaidScripts];
+    }
+    if ([d rendererHasGraphviz:self])
+    {
+        [scripts addObjectsFromArray:self.graphvizScripts];
     }
     if ([d rendererHasMathJax:self])
         [scripts addObjectsFromArray:self.mathjaxScripts];


### PR DESCRIPTION
## What

Renders Mermaid and Graphviz diagrams in the live preview even when **Syntax Highlighting is turned off**.

Fixes #533.

## Why

In `-[MPRenderer scripts]`, the Mermaid and Graphviz script inclusion was nested inside the `rendererHasSyntaxHighlighting` check:

```objc
if ([d rendererHasSyntaxHighlighting:self])
{
    [scripts addObjectsFromArray:self.prismScripts];
    if ([d rendererHasMermaid:self]) { ...mermaidScripts... }
    if ([d rendererHasGraphviz:self]) { ...graphvizScripts... }
}
```

So with syntax highlighting off, `mermaid.min.js` / `mermaid.init.js` (and the Graphviz equivalents) were never added to the page, the `mermaid` library never loaded, and the fence was left as a plain code block — no SVG, no error message.

This coupling is incorrect. Neither diagram renderer depends on Prism:

- The `class="language-mermaid"` / `class="language-<engine>"` attribute is emitted by the hoedown `language_addition` hook, which is installed unconditionally in `MPCreateHTMLRenderer`, independent of the syntax-highlighting setting.
- `mermaid.init.js` and `viz.init.js` locate their targets by that `language-*` class and re-render via their own `MutationObserver`; neither references Prism.

The fix hoists both blocks out of the syntax-highlighting gate. Prism is still gated on `rendererHasSyntaxHighlighting`, as before.

## Testing

- Verified in a browser using the exact bundled `mermaid.min.js` (v11.12) + `mermaid.init.js`: a valid fence renders to SVG on both the initial `window.load` path and the `body.innerHTML` DOM-replacement path (via the MutationObserver), with Prism absent.
- Manually: Preferences → Rendering, enable **Mermaid**, disable **Syntax Highlighting** — before this change the diagram shows as raw text; after, it renders.

## Scope note

`-[MPRenderer HTMLForExportWithStyles:highlighting:]` has the same shape (Mermaid/Graphviz added only inside `if (withHighlighting)`, which also drives `scriptsOption = MPAssetEmbedded`). That path has different semantics — an explicit per-export "include highlighting" choice plus asset-embedding logic — so it is intentionally left out of this focused change and flagged in #533 for a follow-up.

## Guidelines

Branch is rebased on `main` (single commit at current `main` HEAD). Change follows CONTRIBUTING.md: Allman braces, 80-column, 4-space indent, trimmed trailing whitespace, trailing newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5dC6Kpmup5VEzggbxMUx3
