### PR TITLE
Fix unbuildable fresh clones and two silent toolbar bugs

### DIFF
--- a/MacDown 3000.xcodeproj/project.pbxproj
+++ b/MacDown 3000.xcodeproj/project.pbxproj
@@ -1287,7 +1287,6 @@
 				1FF16580199A6C950080D9A5 /* Fetch Prism Resources */,
 				E7FD807B2106CA8F0087F0A8 /* Transpile Styles */,
 				1FA6DE1F1941CC9E000409FB /* Resources */,
-				1F8A82A81952F19B00B6BF69 /* Update Build Number */,
 				905EF1B6196164E300FC3CE9 /* Copy Command Line Utility */,
 				1E02F0A95AAEBCEF65493F5F /* [CP] Copy Pods Resources */,
 				8DD02CA85834426992769538 /* Embed App Extensions */,
@@ -1565,22 +1564,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MacDown/Pods-MacDown-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		1F8A82A81952F19B00B6BF69 /* Update Build Number */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Update Build Number";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/bash;
-			shellScript = "bash Tools/update_build_number.sh\n";
 			showEnvVarsInLog = 0;
 		};
 		1FF16580199A6C950080D9A5 /* Fetch Prism Resources */ = {

--- a/MacDown 3000.xcodeproj/xcshareddata/xcschemes/MacDown.xcscheme
+++ b/MacDown 3000.xcodeproj/xcshareddata/xcschemes/MacDown.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update Build Number"
+               scriptText = "cd &quot;$SRCROOT&quot; &amp;&amp; bash Tools/update_build_number.sh">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "1FA6DE201941CC9E000409FB"
+                     BuildableName = "MacDown 3000.app"
+                     BlueprintName = "MacDown"
+                     ReferencedContainer = "container:MacDown 3000.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -7,6 +7,7 @@
 //
 
 #import "MPToolbarController.h"
+#import "MPPreferences.h"
 
 // Because we're creating selectors for methods which aren't in this class
 #pragma GCC diagnostic ignored "-Wundeclared-selector"
@@ -35,6 +36,12 @@ static CGFloat itemWidth = 37;
      * created, so we can't set target = self.document at construction time.
      */
     NSMutableDictionary<NSString *, NSString *> *standaloneItemActions;
+
+    /**
+     * Observer token for NSUserDefaultsDidChangeNotification, used to keep
+     * extension-dependent buttons in sync when preferences change.
+     */
+    id userDefaultsObserverToken;
 }
 
 - (id)init
@@ -49,8 +56,26 @@ static CGFloat itemWidth = 37;
     self->toolbarItemIdentifierObjectDictionary = [NSMutableDictionary new];
     self->standaloneItemActions = [NSMutableDictionary new];
     [self setupToolbarItems];
-    
+
+    // Issue #320: use a block-based observer on the main queue, since
+    // NSUserDefaultsDidChangeNotification is not guaranteed to be delivered on
+    // the main thread and this updates toolbar UI.
+    __weak typeof(self) weakSelf = self;
+    self->userDefaultsObserverToken = [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSUserDefaultsDidChangeNotification
+                    object:nil
+                     queue:[NSOperationQueue mainQueue]
+                usingBlock:^(NSNotification *notification) {
+        [weakSelf updateExtensionDependentItemStates];
+    }];
+
     return self;
+}
+
+- (void)dealloc
+{
+    if (self->userDefaultsObserverToken)
+        [[NSNotificationCenter defaultCenter] removeObserver:self->userDefaultsObserverToken];
 }
 
 
@@ -103,6 +128,50 @@ static CGFloat itemWidth = 37;
     ];
     
     self->toolbarItemIdentifiers = [self toolbarItemIdentifiersFromItemsArray:self->toolbarItems];
+
+    [self updateExtensionDependentItemStates];
+}
+
+/**
+ * Enable or disable a single segment of a grouped toolbar item, located by the
+ * subitem's identifier rather than a hard-coded index so the groups can be
+ * reordered without silently disabling the wrong button.
+ */
+- (void)setGroupSubitemEnabled:(BOOL)enabled
+                 forIdentifier:(NSString *)subitemIdentifier
+         inGroupWithIdentifier:(NSString *)groupIdentifier
+{
+    NSToolbarItemGroup *group = self->toolbarItemIdentifierObjectDictionary[groupIdentifier];
+    if (![group isKindOfClass:[NSToolbarItemGroup class]])
+        return;
+
+    NSSegmentedControl *segmentedControl = (NSSegmentedControl *)group.view;
+    if (![segmentedControl isKindOfClass:[NSSegmentedControl class]])
+        return;
+
+    NSUInteger index = [group.subitems indexOfObjectPassingTest:
+        ^BOOL(NSToolbarItem *item, NSUInteger idx, BOOL *stop) {
+            return [item.itemIdentifier isEqualToString:subitemIdentifier];
+        }];
+    if (index == NSNotFound || index >= (NSUInteger)segmentedControl.segmentCount)
+        return;
+
+    [segmentedControl setEnabled:enabled forSegment:(NSInteger)index];
+}
+
+/**
+ * Sync toolbar buttons whose markup only renders when a Markdown extension is
+ * enabled. Underline inserts _text_, which hoedown renders as <u> only with
+ * HOEDOWN_EXT_UNDERLINE; without it the same markup is ordinary emphasis and
+ * the button appears to produce italics. The Format menu already hides the
+ * matching command (MainMenu.xib binds its `hidden` to extensionUnderline),
+ * so the toolbar follows suit rather than offering a misleading control.
+ */
+- (void)updateExtensionDependentItemStates
+{
+    [self setGroupSubitemEnabled:[MPPreferences sharedInstance].extensionUnderline
+                   forIdentifier:@"underline"
+           inGroupWithIdentifier:@"text-formatting-group"];
 }
 
 /**

--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -28,7 +28,9 @@ static CGFloat itemWidth = 37;
 
     /**
      * Map toolbar item identifier to the selector name (NSString) that should
-     * be dispatched to self.document when a standalone button is clicked.
+     * be dispatched to self.document when the item is clicked. Covers both
+     * standalone buttons and the subitems of grouped items, since every item
+     * is built by toolbarItemWithIdentifier:.
      * Needed because self.document is nil during init when toolbar items are
      * created, so we can't set target = self.document at construction time.
      */
@@ -136,15 +138,23 @@ static CGFloat itemWidth = 37;
 
     NSToolbarItem *selectedItem = selectedGroup.subitems[selectedIndex];
 
-    // Invoke the toolbar item's action on the document. Use performSelector:
-    // (rather than a raw IMP cast) so the ObjC ABI correctly sets up self,
-    // _cmd, and the sender argument. The previous IMP cast to `void (*)(id)`
-    // left _cmd and sender as uninitialized register values, which produced
-    // garbage senders like 0x400000000000bad0 and random EXC_BAD_ACCESS
-    // crashes when the invoked action (or its responder-chain validation)
-    // touched sender.
+    // Resolve the action from standaloneItemActions rather than from
+    // selectedItem.action. NSToolbarItem forwards -action to its custom view,
+    // and every item built by toolbarItemWithIdentifier: has an NSButton view
+    // whose action is standaloneToolbarItemClicked:. Reading selectedItem.action
+    // therefore yields that dispatch helper instead of the real selector, so
+    // -respondsToSelector: fails on the document and the click silently does
+    // nothing. The identifier map is the authoritative source in both paths.
+    //
+    // Invoke the action on the document with performSelector: (rather than a
+    // raw IMP cast) so the ObjC ABI correctly sets up self, _cmd, and the
+    // sender argument. The previous IMP cast to `void (*)(id)` left _cmd and
+    // sender as uninitialized register values, which produced garbage senders
+    // like 0x400000000000bad0 and random EXC_BAD_ACCESS crashes when the
+    // invoked action (or its responder-chain validation) touched sender.
     MPDocument *document = self.document;
-    SEL action = selectedItem.action;
+    NSString *actionName = self->standaloneItemActions[selectedItem.itemIdentifier];
+    SEL action = actionName ? NSSelectorFromString(actionName) : NULL;
     if (document && action && [document respondsToSelector:action])
     {
         #pragma clang diagnostic push

--- a/MacDownTests/MPToolbarControllerTests.m
+++ b/MacDownTests/MPToolbarControllerTests.m
@@ -17,6 +17,9 @@
 - (void)selectedToolbarItemGroupItem:(NSSegmentedControl *)sender;
 - (void)standaloneToolbarItemClicked:(NSButton *)sender;
 - (void)dropdownMenuItemClicked:(NSMenuItem *)sender;
+- (void)setGroupSubitemEnabled:(BOOL)enabled
+                 forIdentifier:(NSString *)subitemIdentifier
+         inGroupWithIdentifier:(NSString *)groupIdentifier;
 @end
 
 
@@ -809,6 +812,73 @@
                           recorder.invokedSelectors);
         }
     }
+}
+
+
+#pragma mark - Extension-Dependent Item State Tests
+
+// Underline inserts _text_, which only renders as <u> when the Markdown
+// underline extension is on; otherwise it is plain emphasis and the button
+// silently produces italics. The toolbar must reflect that, as the Format
+// menu already does.
+
+- (NSSegmentedControl *)segmentedControlForGroupWithIdentifier:(NSString *)identifier
+{
+    NSToolbarItem *item = [self.controller toolbar:nil
+                             itemForItemIdentifier:identifier
+                         willBeInsertedIntoToolbar:YES];
+    return (NSSegmentedControl *)item.view;
+}
+
+- (void)testSetGroupSubitemEnabledDisablesOnlyTheNamedSegment
+{
+    NSSegmentedControl *control =
+        [self segmentedControlForGroupWithIdentifier:@"text-formatting-group"];
+
+    // bold(0), italic(1), underline(2)
+    [self.controller setGroupSubitemEnabled:NO
+                              forIdentifier:@"underline"
+                      inGroupWithIdentifier:@"text-formatting-group"];
+
+    XCTAssertFalse([control isEnabledForSegment:2],
+                   @"Underline segment should be disabled");
+    XCTAssertTrue([control isEnabledForSegment:0],
+                  @"Bold segment must be unaffected");
+    XCTAssertTrue([control isEnabledForSegment:1],
+                  @"Italic segment must be unaffected");
+}
+
+- (void)testSetGroupSubitemEnabledIsReversible
+{
+    NSSegmentedControl *control =
+        [self segmentedControlForGroupWithIdentifier:@"text-formatting-group"];
+
+    [self.controller setGroupSubitemEnabled:NO
+                              forIdentifier:@"underline"
+                      inGroupWithIdentifier:@"text-formatting-group"];
+    XCTAssertFalse([control isEnabledForSegment:2]);
+
+    [self.controller setGroupSubitemEnabled:YES
+                              forIdentifier:@"underline"
+                      inGroupWithIdentifier:@"text-formatting-group"];
+    XCTAssertTrue([control isEnabledForSegment:2],
+                  @"Re-enabling the extension must restore the segment");
+}
+
+- (void)testSetGroupSubitemEnabledWithUnknownIdentifiersDoesNothing
+{
+    XCTAssertNoThrow([self.controller setGroupSubitemEnabled:NO
+                                               forIdentifier:@"nonexistent-subitem"
+                                       inGroupWithIdentifier:@"text-formatting-group"],
+                     @"Unknown subitem identifier must be ignored, not crash");
+    XCTAssertNoThrow([self.controller setGroupSubitemEnabled:NO
+                                               forIdentifier:@"underline"
+                                       inGroupWithIdentifier:@"nonexistent-group"],
+                     @"Unknown group identifier must be ignored, not crash");
+    XCTAssertNoThrow([self.controller setGroupSubitemEnabled:NO
+                                               forIdentifier:@"underline"
+                                       inGroupWithIdentifier:@"blockquote"],
+                     @"A standalone (non-group) identifier must be ignored, not crash");
 }
 
 

--- a/MacDownTests/MPToolbarControllerTests.m
+++ b/MacDownTests/MPToolbarControllerTests.m
@@ -773,6 +773,44 @@
                      @"group identifier and in-bounds selected segment");
 }
 
+- (void)testGroupedItemDispatchSendsSubitemActionToDocument
+{
+    // Clicking a segment in a grouped toolbar item must dispatch that
+    // subitem's own action (e.g. toggleStrong:) to the document. Previous
+    // group tests only covered crash-freedom and bounds, never which selector
+    // actually arrived, so a regression here could land unnoticed.
+    NSDictionary<NSString *, NSArray<NSString *> *> *expectedMappings = @{
+        @"indent-group":          @[@"unindent:", @"indent:"],
+        @"text-formatting-group": @[@"toggleStrong:", @"toggleEmphasis:", @"toggleUnderline:"],
+        @"heading-group":         @[@"convertToH1:", @"convertToH2:", @"convertToH3:"],
+        @"list-group":            @[@"toggleUnorderedList:", @"toggleOrderedList:"],
+    };
+
+    for (NSString *groupIdentifier in expectedMappings) {
+        NSArray<NSString *> *expectedActions = expectedMappings[groupIdentifier];
+
+        for (NSUInteger segment = 0; segment < expectedActions.count; segment++) {
+            NSString *expectedAction = expectedActions[segment];
+
+            MPToolbarDispatchRecorder *recorder = [[MPToolbarDispatchRecorder alloc] init];
+            self.controller.document = (MPDocument *)recorder;
+
+            NSSegmentedControl *sender = [[NSSegmentedControl alloc] init];
+            sender.identifier = groupIdentifier;
+            sender.segmentCount = (NSInteger)expectedActions.count;
+            sender.selectedSegment = (NSInteger)segment;
+
+            [self.controller selectedToolbarItemGroupItem:sender];
+
+            XCTAssertTrue([recorder.invokedSelectors containsObject:expectedAction],
+                          @"Clicking segment %lu of '%@' should dispatch %@ to the "
+                          @"document. Got: %@",
+                          (unsigned long)segment, groupIdentifier, expectedAction,
+                          recorder.invokedSelectors);
+        }
+    }
+}
+
 
 #pragma mark - Standalone Toolbar Item Dispatch Tests (Issue #278)
 


### PR DESCRIPTION
Three independent fixes found while setting up a fresh clone. Happy to split these into separate PRs if you'd prefer — they touch unrelated areas.

All 1106 tests pass. Each fix was verified by hand in the running app.

---

## 1. A fresh clone cannot be built at all

The `Update Build Number` script phase writes git-derived versions into `${TARGET_BUILD_DIR}/${INFOPLIST_PATH}` with PlistBuddy, but Xcode runs `ProcessInfoPlistFile` during product packaging — **after every build phase**. Task ordering for the MacDown target:

```
PhaseScriptExecution Update Build Number      <- phase 6
Copy .../SharedSupport/bin/macdown            <- phase 7
PhaseScriptExecution [CP] Copy Pods Resources <- phase 8
Copy .../PlugIns/MacDownQuickLook.appex       <- phase 9 (last phase)
ProcessInfoPlistFile .../Contents/Info.plist  <- product packaging
Touch .../MacDown 3000.app
```

So the phase runs before the bundle `Info.plist` exists, `PlistBuddy -c "Set :CFBundleShortVersionString"` fails, and the build aborts. Only DerivedData left over from an earlier build lets it through — and in that case `ProcessInfoPlistFile` then overwrites every value the script wrote, so the app ships with the `0.0.0-dev` placeholder. The version stamping has effectively never worked.

No build-phase reordering can fix this, since packaging is downstream of all phases by construction. Declaring the plist in `inputPaths` produces a dependency cycle, because later phases are gated behind the script phase.

The script now runs as a scheme `BuildAction` post-action, which executes after packaging. It must `cd "$SRCROOT"` first: post-actions run with the working directory set to a temp folder, so the git calls in `Tools/utils.sh` would otherwise fail.

Verified from a wiped DerivedData: the build succeeds and the bundle carries real values (`3000.0.7-rc.1.post37` / `1448` / `v3000.0.7-rc.1-37-gec7f285`) instead of `0.0.0-dev`. CI is unaffected — post-actions still inherit `CI=true`, so the script exits early exactly as before, and releases continue taking versions from the `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` arguments passed by `.github/actions/build-macdown`.

## 2. Every grouped toolbar button silently does nothing

Shift Left/Right, Bold/Italic/Underline, H1/H2/H3 and the list group are all dead — clicking them produces no action, no error and no crash.

`selectedToolbarItemGroupItem:` resolved which action to dispatch by reading `selectedItem.action`. `NSToolbarItem` forwards `-action` to its custom view, and every item built by `toolbarItemWithIdentifier:` has an `NSButton` view. Since dd8fb71 that button's action is `standaloneToolbarItemClicked:`, so `selectedItem.action` returns the controller's own dispatch helper rather than the real selector. `MPDocument` does not respond to it, the `respondsToSelector:` guard fails, and the click is dropped.

Before dd8fb71 the button's action was still the real selector, so the forwarding happened to yield the right answer and grouped items worked. That PR fixed standalone buttons and regressed grouped ones.

The selector is now resolved from `standaloneItemActions`, keyed by the subitem's identifier — the same authoritative mapping the standalone path already uses — so neither path depends on `-action` forwarding through a view.

The existing group tests only covered crash-freedom and index bounds, never which selector arrived at the document, which is how this regressed unnoticed. Adds a test asserting the correct action for all ten subitems across the four groups; it fails before the change with the recorder capturing `standaloneToolbarItemClicked:`.

Related to #496

## 3. The Underline toolbar button applies italics

Underline inserts `_text_`, which hoedown renders as `<u>` only when `HOEDOWN_EXT_UNDERLINE` is set. That flag comes from the `extensionUnderline` preference, which is off by default, so hoedown parses `_text_` as ordinary emphasis and the button appears to apply italics.

The app already treats this command as conditional: `MainMenu.xib` binds the Format > Underline item's `hidden` to `extensionUnderline` through `NSNegateBoolean`, exactly as it does for Strikethrough, so the menu command disappears when the extension is off. The toolbar had no equivalent gating and kept offering a control that could not do what its label promised.

The underline segment of `text-formatting-group` is now disabled when the extension is off, kept in sync by an `NSUserDefaultsDidChangeNotification` observer. The observer is block-based on the main queue, following the #320 precedent, since that notification is not guaranteed to arrive on the main thread and this touches UI. The segment is located by subitem identifier rather than a hard-coded index, so reordering the group cannot disable the wrong button.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)