### PR TITLE
Render Mermaid/Graphviz when syntax highlighting is off (with test updates)

### DIFF
--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -688,16 +688,18 @@ NS_INLINE NSString *MPPreviewHeadTags(NSString *checkboxBridgeToken)
     if ([d rendererHasSyntaxHighlighting:self])
     {
         [scripts addObjectsFromArray:self.prismScripts];
-        // mermaid
-        if ([d rendererHasMermaid:self])
-        {
-            [scripts addObjectsFromArray:self.mermaidScripts];
-        }
-        // graphviz
-        if ([d rendererHasGraphviz:self])
-        {
-            [scripts addObjectsFromArray:self.graphvizScripts];
-        }
+    }
+    // Mermaid and Graphviz render from the language-* class (always
+    // emitted) via their own init scripts; they do not depend on Prism.
+    // Keep them out of the syntax-highlighting gate so diagrams render
+    // even when syntax highlighting is off (GitHub issue #533).
+    if ([d rendererHasMermaid:self])
+    {
+        [scripts addObjectsFromArray:self.mermaidScripts];
+    }
+    if ([d rendererHasGraphviz:self])
+    {
+        [scripts addObjectsFromArray:self.graphvizScripts];
     }
     if ([d rendererHasMathJax:self])
         [scripts addObjectsFromArray:self.mathjaxScripts];

--- a/MacDownTests/MPGraphvizRenderingTests.m
+++ b/MacDownTests/MPGraphvizRenderingTests.m
@@ -129,7 +129,7 @@
                    @"Should NOT include Graphviz init script when disabled");
 }
 
-- (void)testGraphvizScriptsExcludedWhenSyntaxHighlightingDisabled
+- (void)testGraphvizScriptsIncludedWhenSyntaxHighlightingDisabled
 {
     self.delegate.graphviz = YES;
     self.delegate.syntaxHighlighting = NO;
@@ -140,8 +140,10 @@
     [self.renderer parseMarkdown:self.dataSource.markdown];
     [self.renderer render];
 
-    XCTAssertFalse([self.delegate.lastHTML containsString:@"viz.init.js"],
-                   @"Graphviz requires syntax highlighting to be enabled");
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"viz.js"],
+                  @"Should include Graphviz library");
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"viz.init.js"],
+                  @"Should include Graphviz init script");
 }
 
 
@@ -337,6 +339,34 @@
                   @"Should include graphviz init script");
     XCTAssertTrue([self.delegate.lastHTML containsString:@"mermaid.init.js"],
                   @"Should include mermaid init script alongside graphviz");
+}
+
+- (void)testGraphvizAndMermaidScriptsIncludedWhenSyntaxHighlightingDisabled
+{
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.delegate.syntaxHighlighting = NO;
+    self.delegate.graphviz = YES;
+    self.delegate.mermaid = YES;
+    self.dataSource.markdown =
+        @"```dot\ndigraph G { A -> B }\n```\n\n"
+        @"```mermaid\ngraph TD;\n    A-->B;\n```";
+
+    // Use render (MPAssetFullLink) for filename checks
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"viz.js"],
+                  @"Should include Graphviz library even without syntax "
+                  @"highlighting");
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"viz.init.js"],
+                  @"Should include Graphviz init script even without "
+                  @"syntax highlighting");
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"mermaid.min.js"],
+                  @"Should include Mermaid library even without syntax "
+                  @"highlighting");
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"mermaid.init.js"],
+                  @"Should include Mermaid init script even without "
+                  @"syntax highlighting");
 }
 
 @end

--- a/MacDownTests/MPMermaidRenderingTests.m
+++ b/MacDownTests/MPMermaidRenderingTests.m
@@ -133,7 +133,7 @@
                    @"Should NOT include Mermaid init script when disabled");
 }
 
-- (void)testMermaidScriptsExcludedWhenSyntaxHighlightingDisabled
+- (void)testMermaidScriptsIncludedWhenSyntaxHighlightingDisabled
 {
     self.delegate.mermaid = YES;
     self.delegate.syntaxHighlighting = NO;
@@ -144,8 +144,30 @@
     [self.renderer parseMarkdown:self.dataSource.markdown];
     [self.renderer render];
 
-    XCTAssertFalse([self.delegate.lastHTML containsString:@"mermaid.min.js"],
-                   @"Mermaid requires syntax highlighting to be enabled");
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"mermaid.min.js"],
+                  @"Should include Mermaid library");
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"mermaid.init.js"],
+                  @"Should include Mermaid init script");
+}
+
+- (void)testPrismScriptsExcludedWhenSyntaxHighlightingDisabledWithMermaidEnabled
+{
+    self.delegate.mermaid = YES;
+    self.delegate.syntaxHighlighting = NO;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```mermaid\ngraph TD;\n    A-->B;\n```";
+
+    // Use render (MPAssetFullLink) so script URLs contain filenames
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    [self.renderer render];
+
+    XCTAssertFalse([self.delegate.lastHTML containsString:@"prism-core.min.js"],
+                   @"Should NOT include Prism when syntax highlighting is "
+                   @"disabled, even though Mermaid is enabled");
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"mermaid.min.js"],
+                  @"Should still include Mermaid library");
+    XCTAssertTrue([self.delegate.lastHTML containsString:@"mermaid.init.js"],
+                  @"Should still include Mermaid init script");
 }
 
 


### PR DESCRIPTION
## Summary

Renders Mermaid and Graphviz diagrams in the live preview even when **Syntax Highlighting is turned off**.

This carries @AgardnerAU's fix from #534 (cherry-picked, authorship preserved) and adds the test updates that the change requires, so the branch lands green on `main`.

## Changes

- **Fix (@AgardnerAU, from #534):** In `-[MPRenderer scripts]`, the Mermaid and Graphviz `<script>` inclusion was nested inside the `rendererHasSyntaxHighlighting` gate, so with syntax highlighting off the diagram libraries never loaded and the fence rendered as a plain code block. Both blocks are hoisted out of that gate; Prism remains gated on syntax highlighting. Neither diagram renderer depends on Prism — the `language-*` class is emitted unconditionally by the hoedown `language_addition` hook, and the init scripts locate their targets by that class via their own `MutationObserver`.
- **Tests:** Two existing tests asserted the old coupling (`testMermaidScriptsExcludedWhenSyntaxHighlightingDisabled` and its Graphviz twin) and would fail against the fix. They are renamed to `...Included...` and now assert the diagram scripts are present with highlighting off. Added regression coverage: Prism stays absent (highlighting off) while Mermaid loads, and a combined Mermaid + Graphviz case.

## Testing

CI (macOS `Tests` workflow) is green on the branch head. Coverage is headless (no window/WebView): the tests assert on the emitted `<script>` URLs in the rendered HTML.

## Follow-up (not in this change)

`-[MPRenderer HTMLForExportWithStyles:highlighting:]` has the identical shape — Mermaid/Graphviz scripts are added only inside `if (withHighlighting)`, which also drives asset embedding. That path has different semantics (an explicit per-export "include highlighting" toggle), so it is intentionally left out of this focused change and remains tracked for a separate follow-up.

Related to #533
Related to #534

---
_Generated by [Claude Code](https://claude.ai/code/session_014HPFyo6fqNTZd8YppidhP7)_