### PR TITLE
Address issue #541: render Mermaid/Graphviz in HTML export when highlighting is off

### DIFF
--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -890,15 +890,20 @@ NS_INLINE NSString *MPPreviewHeadTags(NSString *checkboxBridgeToken)
         scriptsOption = MPAssetEmbedded;
         [styles addObjectsFromArray:self.prismStylesheets];
         [scripts addObjectsFromArray:self.prismScripts];
-        if ([self.delegate rendererHasMermaid:self])
-        {
-            [scripts addObjectsFromArray:self.mermaidScripts];
-        }
-        if ([self.delegate rendererHasGraphviz:self])
-        {
-            [scripts addObjectsFromArray:self.graphvizScripts];
-        }
-
+    }
+    // Mermaid and Graphviz render from the language-* class (always
+    // emitted) via their own init scripts; they do not depend on Prism.
+    // Keep them out of the highlighting gate so diagrams export even
+    // when syntax highlighting is off (GitHub issue #541).
+    if ([self.delegate rendererHasMermaid:self])
+    {
+        scriptsOption = MPAssetEmbedded;
+        [scripts addObjectsFromArray:self.mermaidScripts];
+    }
+    if ([self.delegate rendererHasGraphviz:self])
+    {
+        scriptsOption = MPAssetEmbedded;
+        [scripts addObjectsFromArray:self.graphvizScripts];
     }
     if ([self.delegate rendererHasMathJax:self])
     {

--- a/MacDownTests/MPRendererEdgeCaseTests.m
+++ b/MacDownTests/MPRendererEdgeCaseTests.m
@@ -610,6 +610,9 @@ static NSString * const kMPTestPrismAbsenceMarker = @"Prism.highlightAll";
                   @"when highlighting is off (issue #541)");
     XCTAssertFalse([html containsString:kMPTestPrismAbsenceMarker],
                    @"Prism should not be embedded when highlighting is off");
+    XCTAssertFalse([html containsString:@"function doGraphviz(engine) {"],
+                   @"Graphviz script should not be embedded when only "
+                   @"Mermaid is enabled");
 }
 
 - (void)testRendererWithGraphvizEnabled
@@ -628,6 +631,9 @@ static NSString * const kMPTestPrismAbsenceMarker = @"Prism.highlightAll";
                   @"when highlighting is off (issue #541)");
     XCTAssertFalse([html containsString:kMPTestPrismAbsenceMarker],
                    @"Prism should not be embedded when highlighting is off");
+    XCTAssertFalse([html containsString:@"mermaid.initialize("],
+                   @"Mermaid script should not be embedded when only "
+                   @"Graphviz is enabled");
 }
 
 - (void)testRendererExportDiagramsWithHighlightingOffBothPresent
@@ -723,6 +729,20 @@ static NSString * const kMPTestPrismAbsenceMarker = @"Prism.highlightAll";
 
     XCTAssertTrue([html containsString:@"mermaid.initialize("],
                   @"Mermaid init script should be embedded independent of "
+                  @"the withStyles option");
+}
+
+- (void)testRendererExportGraphvizPresentWithoutStylesAndHighlightingOff
+{
+    self.delegate.graphviz = YES;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
+
+    XCTAssertTrue([html containsString:@"function doGraphviz(engine) {"],
+                  @"Graphviz init script should be embedded independent of "
                   @"the withStyles option");
 }
 

--- a/MacDownTests/MPRendererEdgeCaseTests.m
+++ b/MacDownTests/MPRendererEdgeCaseTests.m
@@ -16,6 +16,15 @@
 #import "hoedown_html_patch.h"
 
 
+// Substring proving Prism was NOT embedded. Confirmed absent from the
+// bundled diagram assets (mermaid.min.js, mermaid.init.js, viz.js,
+// viz.init.js), so a false absence-check pass can't come from a diagram
+// script instead of real Prism content. Only ever asserted as ABSENT: the
+// Prism submodule may not be checked out in this environment, so its real
+// content cannot be reliably asserted present here (GitHub issue #541).
+static NSString * const kMPTestPrismAbsenceMarker = @"Prism.highlightAll";
+
+
 #pragma mark - Test Class
 
 @interface MPRendererEdgeCaseTests : XCTestCase
@@ -45,6 +54,20 @@
     self.dataSource = nil;
     self.delegate = nil;
     [super tearDown];
+}
+
+
+#pragma mark - Helpers
+
+// Counts non-overlapping occurrences of `substring` within `string`. Used
+// to guard against double-inclusion regressions (e.g. a diagram init
+// script being embedded twice).
+- (NSUInteger)mp_occurrencesOfSubstring:(NSString *)substring
+                               inString:(NSString *)string
+{
+    if (string.length == 0 || substring.length == 0)
+        return 0;
+    return [string componentsSeparatedByString:substring].count - 1;
 }
 
 
@@ -565,7 +588,8 @@
     self.dataSource.markdown = @"Inline $x^2$ and display:\n\n$$\\sum_{i=1}^n x_i$$";
 
     [self.renderer parseMarkdown:self.dataSource.markdown];
-    NSString *html = [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
+    NSString *html =
+        [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
 
     XCTAssertNotNil(html, @"Should handle MathJax content");
 }
@@ -577,9 +601,15 @@
     self.dataSource.markdown = @"```mermaid\ngraph TD;\n    A-->B;\n```";
 
     [self.renderer parseMarkdown:self.dataSource.markdown];
-    NSString *html = [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
+    NSString *html =
+        [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
 
     XCTAssertNotNil(html, @"Should handle Mermaid diagrams");
+    XCTAssertTrue([html containsString:@"mermaid.initialize("],
+                  @"Mermaid init script should be embedded in exports even "
+                  @"when highlighting is off (issue #541)");
+    XCTAssertFalse([html containsString:kMPTestPrismAbsenceMarker],
+                   @"Prism should not be embedded when highlighting is off");
 }
 
 - (void)testRendererWithGraphvizEnabled
@@ -589,9 +619,131 @@
     self.dataSource.markdown = @"```dot\ndigraph G { A -> B }\n```";
 
     [self.renderer parseMarkdown:self.dataSource.markdown];
-    NSString *html = [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
+    NSString *html =
+        [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
 
     XCTAssertNotNil(html, @"Should handle Graphviz diagrams");
+    XCTAssertTrue([html containsString:@"function doGraphviz(engine) {"],
+                  @"Graphviz init script should be embedded in exports even "
+                  @"when highlighting is off (issue #541)");
+    XCTAssertFalse([html containsString:kMPTestPrismAbsenceMarker],
+                   @"Prism should not be embedded when highlighting is off");
+}
+
+- (void)testRendererExportDiagramsWithHighlightingOffBothPresent
+{
+    self.delegate.mermaid = YES;
+    self.delegate.graphviz = YES;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```mermaid\ngraph TD;\n    A-->B;\n```\n\n"
+                               @"```dot\ndigraph G { A -> B }\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html =
+        [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
+
+    XCTAssertTrue([html containsString:@"mermaid.initialize("],
+                  @"Mermaid init script should be embedded when both "
+                  @"diagram types are enabled and highlighting is off");
+    XCTAssertTrue([html containsString:@"function doGraphviz(engine) {"],
+                  @"Graphviz init script should be embedded when both "
+                  @"diagram types are enabled and highlighting is off");
+}
+
+- (void)testRendererExportMermaidWithHighlightingOnIncludedOnce
+{
+    self.delegate.mermaid = YES;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```mermaid\ngraph TD;\n    A-->B;\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html =
+        [self.renderer HTMLForExportWithStyles:YES highlighting:YES];
+
+    XCTAssertEqual(
+        [self mp_occurrencesOfSubstring:@"mermaid.initialize("
+                               inString:html],
+        (NSUInteger)1,
+        @"Mermaid init script should be embedded exactly once when "
+        @"highlighting is also on, guarding against double inclusion");
+}
+
+- (void)testRendererExportMermaidAndGraphvizWithHighlightingOnIncludedOnce
+{
+    self.delegate.mermaid = YES;
+    self.delegate.graphviz = YES;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```mermaid\ngraph TD;\n    A-->B;\n```\n\n"
+                               @"```dot\ndigraph G { A -> B }\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html =
+        [self.renderer HTMLForExportWithStyles:YES highlighting:YES];
+
+    XCTAssertEqual(
+        [self mp_occurrencesOfSubstring:@"mermaid.initialize("
+                               inString:html],
+        (NSUInteger)1,
+        @"Mermaid init script should appear exactly once");
+    XCTAssertEqual(
+        [self mp_occurrencesOfSubstring:@"function doGraphviz(engine) {"
+                               inString:html],
+        (NSUInteger)1,
+        @"Graphviz init script should appear exactly once");
+}
+
+- (void)testRendererExportWithDiagramsDisabledOmitsBothScripts
+{
+    self.delegate.mermaid = NO;
+    self.delegate.graphviz = NO;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```mermaid\ngraph TD;\n    A-->B;\n```\n\n"
+                               @"```dot\ndigraph G { A -> B }\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html =
+        [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
+
+    XCTAssertFalse([html containsString:@"mermaid.initialize("],
+                   @"Mermaid script should not be embedded when Mermaid is "
+                   @"disabled");
+    XCTAssertFalse([html containsString:@"function doGraphviz(engine) {"],
+                   @"Graphviz script should not be embedded when Graphviz "
+                   @"is disabled");
+}
+
+- (void)testRendererExportMermaidPresentWithoutStylesAndHighlightingOff
+{
+    self.delegate.mermaid = YES;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"```mermaid\ngraph TD;\n    A-->B;\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
+
+    XCTAssertTrue([html containsString:@"mermaid.initialize("],
+                  @"Mermaid init script should be embedded independent of "
+                  @"the withStyles option");
+}
+
+- (void)testRendererExportMermaidWithMathJaxAndHighlightingOff
+{
+    self.delegate.mermaid = YES;
+    self.delegate.mathJax = YES;
+    self.delegate.extensions = HOEDOWN_EXT_FENCED_CODE;
+    self.dataSource.markdown = @"Inline $x^2$\n\n"
+                               @"```mermaid\ngraph TD;\n    A-->B;\n```";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html =
+        [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
+
+    XCTAssertTrue([html containsString:@"mermaid.initialize("],
+                  @"Mermaid init script should be embedded even when "
+                  @"MathJax is also enabled and highlighting is off");
+    XCTAssertTrue([html containsString:@"MathJax.Hub.Config("],
+                  @"MathJax init script should still be embedded alongside "
+                  @"Mermaid");
 }
 
 
@@ -603,7 +755,8 @@
     self.dataSource.markdown = @"# First\n\n## Second\n\n### Third\n\nContent here.";
 
     [self.renderer parseMarkdown:self.dataSource.markdown];
-    NSString *html = [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
+    NSString *html =
+        [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
 
     XCTAssertNotNil(html, @"Should render with TOC");
 }
@@ -614,7 +767,8 @@
     self.dataSource.markdown = @"Just a paragraph with no headings.";
 
     [self.renderer parseMarkdown:self.dataSource.markdown];
-    NSString *html = [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
+    NSString *html =
+        [self.renderer HTMLForExportWithStyles:YES highlighting:NO];
 
     XCTAssertNotNil(html, @"Should handle TOC with no headings");
 }


### PR DESCRIPTION
## Summary

Fixes the export-path counterpart of #533/#540: Mermaid and Graphviz diagrams now render in exported HTML regardless of the export panel's "include highlighting" option.

In `-[MPRenderer HTMLForExportWithStyles:highlighting:]`, diagram script inclusion was nested inside the `if (withHighlighting)` gate — which also drives `scriptsOption`. With highlighting off, the diagram scripts were never added **and** `scriptsOption` stayed `MPAssetNone` (so `MPGetHTML` would drop them anyway), leaving exported diagram fences as plain code blocks.

The fix:
- Hoists the Mermaid and Graphviz blocks out of the `withHighlighting` gate into their own top-level `if` blocks.
- Sets `scriptsOption = MPAssetEmbedded` when either diagram type is enabled, mirroring the existing MathJax branch (both parts are required — hoisting alone would leave the scripts silently dropped).
- Leaves Prism gated on `withHighlighting`, and leaves `stylesOption`, the MathJax branch, and the live-preview `-scripts` path untouched.

## Related Issue

Related to #541 (interpretation posted here: https://github.com/schuyler/macdown3000/issues/541#issuecomment-5086226789)

## Judgment Calls

- **Two-part fix, not a pure hoist.** The `scriptsOption` promotion is load-bearing: without it, hoisted scripts render to nothing (`MPAssetNone` → nil → skipped). Mirroring the MathJax branch keeps the idiom consistent.
- **Embedded, not linked.** Export continues to embed diagram JS (`MPAssetEmbedded`), keeping exported files self-contained — consistent with existing export behavior and MathJax.
- **Test assertions use inlined content, never filenames.** Because export embeds (inlines) JS, tests assert on `mermaid.initialize(` and `function doGraphviz(engine) {` (each verified to occur exactly once in the init scripts, absent from the bundled libraries). Filename substrings only work on the linked preview path.
- **Prism asserted absent only.** The Prism submodule/embedded-content substring is version-fragile, so highlighting-off tests assert Prism *absence* (always safe); the highlighting-on regression is guarded by diagram-script no-duplication (occurrence count == 1) rather than a Prism-presence check.
- **Strengthened the two weak tests in place.** `testRendererWithMermaidEnabled`/`testRendererWithGraphvizEnabled` previously asserted only `XCTAssertNotNil` — which is why the bug shipped undetected — so they were upgraded rather than left alongside new tests.

No open questions block this change.

## Testing

Automated (headless, via the mock renderer delegate; the final test gate is the macOS CI run on this branch):
- Strengthened `testRendererWithMermaidEnabled` / `testRendererWithGraphvizEnabled`: diagram scripts embedded and Prism absent with highlighting off.
- New: both diagrams together (highlighting off); each diagram embedded exactly once when highlighting is on (double-inclusion guard); diagrams disabled → no scripts; `withStyles:NO` independence; MathJax coexistence.

---
_Generated by [Claude Code](https://claude.ai/code/session_014HPFyo6fqNTZd8YppidhP7)_