### PR TITLE
Add `img` max-width to the four themes that lack it

### DIFF
--- a/MacDown/Resources/Styles/Clearness Dark.css
+++ b/MacDown/Resources/Styles/Clearness Dark.css
@@ -38,6 +38,10 @@ a:hover {
 a img {
     border: none;
 }
+img {
+    max-width: 100%;
+    height: auto;
+}
 p {
     margin-bottom: 9px;
 }

--- a/MacDown/Resources/Styles/Clearness.css
+++ b/MacDown/Resources/Styles/Clearness.css
@@ -39,6 +39,10 @@ a:hover {
 a img {
     border: none;
 }
+img {
+    max-width: 100%;
+    height: auto;
+}
 p {
     margin-bottom: 9px;
 }

--- a/MacDown/Resources/Styles/Solarized (Dark).css
+++ b/MacDown/Resources/Styles/Solarized (Dark).css
@@ -85,6 +85,8 @@ h6 {
 }
 img {
   margin-bottom: 20px;
+  max-width: 100%;
+  height: auto;
 }
 h1 img,
 h2 img,

--- a/MacDown/Resources/Styles/Solarized (Light).css
+++ b/MacDown/Resources/Styles/Solarized (Light).css
@@ -85,6 +85,8 @@ h6 {
 }
 img {
   margin-bottom: 20px;
+  max-width: 100%;
+  height: auto;
 }
 h1 img,
 h2 img,


### PR DESCRIPTION
Fixes #546.

Four of the eleven bundled themes — Clearness, Clearness Dark, Solarized (Dark) and Solarized (Light) — had no width constraint on `img`, so images wider than the preview pane rendered at natural size and overflowed horizontally. The other seven already set `max-width` on `img`.

This adds the same constraint to the four:

```css
max-width: 100%;
height: auto;
```

`height: auto` keeps the aspect ratio once the width is clamped.

Placement follows each file's existing structure and indentation rather than appending at the end:

- **Solarized (Dark) / (Light)** — extends the existing `img { margin-bottom: 20px; }` rule (2-space indent).
- **Clearness / Clearness Dark** — a new `img` rule directly after `a img { border: none; }` (4-space indent).

12 added lines, no deletions, no other rules touched.

### Verifying

Before and after, each stylesheet was parsed for a rule whose selector list includes `img` and whose body sets `max-width` (comments stripped). Before: 7 of 11 pass. After: 11 of 11.

To see it by hand: set the style to Solarized (Dark), open a document embedding an image wider than the pane (a 1920x1080 screenshot will do), and compare against a GitHub theme.