### PR TITLE
Address issue #548: refresh bundled styles and themes without destroying user edits

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -32,6 +32,7 @@ Use TodoWrite to create a todo list for tracking progress:
 - Validate version and run pre-flight checks
 - Build and commit changelog
 - Create and push git tag
+- Regenerate and commit the bundled resource history
 - Monitor build and notarization
 - Complete release workflow
 ```
@@ -368,6 +369,19 @@ git push origin "v{VERSION}"
 
 If successful, the tag is now on GitHub and the release workflow will start within 1-2 minutes.
 
+#### 3d. Regenerate the Bundled Resource History
+
+The generator enumerates release tags, so this must run *after* the tag is pushed — files shipped in an untagged release can never be classified, which silently removes the recovery path for any user who later loses their provenance manifest.
+
+```bash
+Tools/generate-bundled-resource-history.sh
+git add MacDown/Resources/BundledResourceHistory.json
+git commit -m "Record bundled resource digests for v{VERSION}"
+git push origin main
+```
+
+If the script reports no changes, there is nothing to commit — continue.
+
 
 ### Step 4: Monitor Build Workflow
 
@@ -419,6 +433,7 @@ The website will update automatically after the workflow completes.
 Summary:
 - ✅ CHANGELOG.md and README.md updated and committed
 - ✅ Tag v{VERSION} created and pushed
+- ✅ Bundled resource history regenerated and committed
 - ✅ Build workflow triggered
 
 **What happens next:**

--- a/MacDown 3000.xcodeproj/project.pbxproj
+++ b/MacDown 3000.xcodeproj/project.pbxproj
@@ -160,6 +160,10 @@
 		504AC0000000000000000005 /* MPPDFAnchorInjectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 504AC0000000000000000004 /* MPPDFAnchorInjectorTests.m */; };
 		504AC0000000000000000007 /* PDFKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 504AC0000000000000000006 /* PDFKit.framework */; };
 		504AC0000000000000000008 /* PDFKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 504AC0000000000000000006 /* PDFKit.framework */; };
+		6DF7634F7CFB0E718623C743 /* MPBundledResourceSync.m in Sources */ = {isa = PBXBuildFile; fileRef = BFB785FC2553E0F066BF4314 /* MPBundledResourceSync.m */; };
+		0EF7F855A6D63BC60A67CCE7 /* BundledResourceHistory.json in Resources */ = {isa = PBXBuildFile; fileRef = BFF7FCCC3D2D303F270D4F89 /* BundledResourceHistory.json */; };
+		7F018F1F3C7619EA26F737AC /* MPBundledResourceSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93338DE9459DD0BBABF0172B /* MPBundledResourceSyncTests.m */; };
+		276BBE5A1237B16170426444 /* MPBundledResourceDigestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F20FA45DCC9EBE32F401EC /* MPBundledResourceDigestTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -722,6 +726,11 @@
 		504AC0000000000000000002 /* MPPDFAnchorInjector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPPDFAnchorInjector.m; sourceTree = "<group>"; };
 		504AC0000000000000000004 /* MPPDFAnchorInjectorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPPDFAnchorInjectorTests.m; sourceTree = "<group>"; };
 		504AC0000000000000000006 /* PDFKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PDFKit.framework; path = System/Library/Frameworks/PDFKit.framework; sourceTree = SDKROOT; };
+		BBC74269D0EC21874A73003D /* MPBundledResourceSync.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPBundledResourceSync.h; sourceTree = "<group>"; };
+		BFB785FC2553E0F066BF4314 /* MPBundledResourceSync.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPBundledResourceSync.m; sourceTree = "<group>"; };
+		BFF7FCCC3D2D303F270D4F89 /* BundledResourceHistory.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = BundledResourceHistory.json; path = Resources/BundledResourceHistory.json; sourceTree = "<group>"; };
+		93338DE9459DD0BBABF0172B /* MPBundledResourceSyncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPBundledResourceSyncTests.m; sourceTree = "<group>"; };
+		90F20FA45DCC9EBE32F401EC /* MPBundledResourceDigestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPBundledResourceDigestTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -840,6 +849,8 @@
 				7EDA4DCB8E20B177D4704F77 /* MPHTMLResourceURLs.m */,
 				URLSECPOLHDRFILEREFID /* MPURLSecurityPolicy.h */,
 				URLSECPOLIMPFILEREFID /* MPURLSecurityPolicy.m */,
+				BBC74269D0EC21874A73003D /* MPBundledResourceSync.h */,
+				BFB785FC2553E0F066BF4314 /* MPBundledResourceSync.m */,
 			);
 			name = Utility;
 			path = Code/Utility;
@@ -920,6 +931,7 @@
 				1F3A47521953E84700293260 /* updateHeaderLocations.js */,
 				1F59491A1AB57C78007394CB /* syntax_highlighting.json */,
 				1F3FC8A91C85AE9F000965E1 /* MacDown.sdef */,
+				BFF7FCCC3D2D303F270D4F89 /* BundledResourceHistory.json */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -1141,6 +1153,8 @@
 				QLTST00003PVCT00000M /* MPPreviewViewControllerTests.m */,
 				5E44CF1BD72E49A99DA6A4C1 /* MPPaneToggleTests.m */,
 				504AC0000000000000000004 /* MPPDFAnchorInjectorTests.m */,
+				93338DE9459DD0BBABF0172B /* MPBundledResourceSyncTests.m */,
+				90F20FA45DCC9EBE32F401EC /* MPBundledResourceDigestTests.m */,
 			);
 			path = MacDownTests;
 			sourceTree = "<group>";
@@ -1510,6 +1524,7 @@
 				1FB3C0241E5061A2002AEB6A /* MPExportPanelAccessoryViewController.xib in Resources */,
 				3028039E1FD84EAC0055B0DA /* contribute.md in Resources */,
 				A2310231000000000001IMAG /* Images in Resources */,
+				0EF7F855A6D63BC60A67CCE7 /* BundledResourceHistory.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1791,6 +1806,7 @@
 				BA2B9EC2E95175092A97B41E /* MPResourceWatcherSet.m in Sources */,
 				1F13B5E1110695033F2B57AE /* MPHTMLResourceURLs.m in Sources */,
 				504AC0000000000000000003 /* MPPDFAnchorInjector.m in Sources */,
+				6DF7634F7CFB0E718623C743 /* MPBundledResourceSync.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1846,6 +1862,8 @@
 				QLBLD00006PVCTESTSRC0 /* MPPreviewViewControllerTests.m in Sources */,
 				1457815B1A710E4C40F07FCA /* MPPaneToggleTests.m in Sources */,
 				504AC0000000000000000005 /* MPPDFAnchorInjectorTests.m in Sources */,
+				7F018F1F3C7619EA26F737AC /* MPBundledResourceSyncTests.m in Sources */,
+				276BBE5A1237B16170426444 /* MPBundledResourceDigestTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacDown/Code/Application/MPMainController.m
+++ b/MacDown/Code/Application/MPMainController.m
@@ -12,6 +12,7 @@
 // #import <Sparkle/SUUpdater.h>
 #import "MPGlobals.h"
 #import "MPUtilities.h"
+#import "MPBundledResourceSync.h"
 #import "NSDocumentController+Document.h"
 #import "NSUserDefaults+Suite.h"
 #import "MPPreferences.h"
@@ -272,39 +273,8 @@ NS_INLINE void treat()
 
 - (void)copyFiles
 {
-    NSFileManager *manager = [NSFileManager defaultManager];
-    NSString *root = MPDataDirectory(nil);
-    if (![manager fileExistsAtPath:root])
-    {
-        [manager createDirectoryAtPath:root
-           withIntermediateDirectories:YES attributes:nil error:NULL];
-    }
-
-    NSBundle *bundle = [NSBundle mainBundle];
-    for (NSString *key in @[kMPStylesDirectoryName, kMPThemesDirectoryName])
-    {
-        NSURL *dirSource = [bundle URLForResource:key withExtension:@""];
-        NSURL *dirTarget = [NSURL fileURLWithPath:MPDataDirectory(key)];
-
-        // If the directory doesn't exist, just copy the whole thing.
-        if (![manager fileExistsAtPath:dirTarget.path])
-        {
-            [manager copyItemAtURL:dirSource toURL:dirTarget error:NULL];
-            continue;
-        }
-
-        // Check for existence of each file and copy if it's not there.
-        NSArray *contents = [manager contentsOfDirectoryAtURL:dirSource
-                                   includingPropertiesForKeys:nil options:0
-                                                        error:NULL];
-        for (NSURL *fileSource in contents)
-        {
-            NSString *name = fileSource.lastPathComponent;
-            NSURL *fileTarget = [dirTarget URLByAppendingPathComponent:name];
-            if (![manager fileExistsAtPath:fileTarget.path])
-                [manager copyItemAtURL:fileSource toURL:fileTarget error:NULL];
-        }
-    }
+    MPSyncBundledResourcesInPaths(MPDataDirectory(nil),
+                                  [NSBundle mainBundle].resourcePath);
 }
 
 - (void)openPendingFiles

--- a/MacDown/Code/Utility/MPBundledResourceSync.h
+++ b/MacDown/Code/Utility/MPBundledResourceSync.h
@@ -1,0 +1,139 @@
+//
+//  MPBundledResourceSync.h
+//  MacDown 3000
+//
+//  Keeps the bundled Styles and Themes in the user's Application Support
+//  directory up to date with the installed app, without ever overwriting a
+//  file the user has edited.
+//  Related to GitHub issue #548.
+//
+
+#import <Foundation/Foundation.h>
+
+/// File name of the per-user provenance manifest, at the data-directory root.
+extern NSString * const kMPBundledResourceManifestFileName;   // BundledResourceManifest.json
+/// File name of the read-only shipped-history manifest, in the app bundle.
+extern NSString * const kMPBundledResourceHistoryFileName;    // BundledResourceHistory.json
+
+
+#pragma mark - Digests
+
+/// Lowercase 64-character hex SHA-256 of the bytes of the file at `path`.
+/// Reads in fixed-size chunks; never maps or loads the whole file.
+/// Returns nil and sets `error` if `path` is nil, is not a regular file, or
+/// cannot be read. Never raises.
+NSString *MPSHA256HexOfFileAtPath(NSString *path,
+                                  NSError *__autoreleasing *error);
+
+/// Lowercase 64-character hex SHA-256 of `data`. Returns nil for nil data;
+/// returns the well-known empty digest for zero-length data.
+NSString *MPSHA256HexOfData(NSData *data);
+
+
+#pragma mark - Manifests
+
+/// Read the provenance manifest at `path`.
+/// Returns an empty (non-nil) dictionary when the file is missing, unreadable,
+/// not JSON, of an unexpected shape, or of an unrecognised schema version —
+/// decision-table rows 8 and 9 are the same code path. Non-string values are
+/// dropped individually. Never raises, never returns nil.
+NSDictionary<NSString *, NSString *> *
+MPReadProvenanceManifestAtPath(NSString *path);
+
+/// Serialize and atomically write `manifest` to `path`
+/// (NSDataWritingAtomic; §7.3 — no locking).
+/// Returns NO and sets `error` on serialisation or write failure.
+/// A nil or empty manifest is still written, as an empty `files` object.
+BOOL MPWriteProvenanceManifestAtPath(
+    NSDictionary<NSString *, NSString *> *manifest,
+    NSString *path, NSError *__autoreleasing *error);
+
+/// Canonical bytes for a provenance manifest: sorted keys, two-space indent,
+/// trailing newline. Deterministic — the same dictionary always produces the
+/// same bytes. Used by the writer and by the B3 "did anything change?" check.
+/// Returns nil only if serialisation itself fails.
+NSData *MPProvenanceManifestData(NSDictionary<NSString *, NSString *> *manifest);
+
+/// Read the shipped-history manifest at `path`.
+/// Returns an empty (non-nil) dictionary on any failure, exactly as above.
+/// Digest arrays become NSSets; non-string and malformed members are dropped.
+NSDictionary<NSString *, NSSet<NSString *> *> *
+MPReadHistoryManifestAtPath(NSString *path);
+
+/// Canonical manifest locations, so callers and tests never hardcode literals.
+NSString *MPProvenanceManifestPathInRoot(NSString *userDataRoot);
+NSString *MPHistoryManifestPathInRoot(NSString *bundleResourceRoot);
+
+
+#pragma mark - Classification
+
+/// State of the entry at the target path, from
+/// -[NSFileManager attributesOfItemAtPath:error:], which does not follow
+/// symlinks (§7.4). Never from -fileExistsAtPath:isDirectory:, which does.
+typedef NS_ENUM(NSInteger, MPBundledResourceTargetState) {
+    MPBundledResourceTargetAbsent = 0,
+    MPBundledResourceTargetRegular,      // NSFileType == NSFileTypeRegular
+    MPBundledResourceTargetNonRegular,   // symlink, directory, FIFO, socket, …
+};
+
+typedef NS_ENUM(NSInteger, MPBundledResourceAction) {
+    MPBundledResourceActionSkip = 0,   // rows 5, 10 — leave alone, no entry
+    MPBundledResourceActionCopy,       // rows 1, 2, 6 — copy, record digest
+    MPBundledResourceActionRefresh,    // rows 3, 12 — atomic replace, record
+    MPBundledResourceActionRecordOnly, // row 4 — no file write, backfill entry
+    MPBundledResourceActionForget,     // row 7 — never delete, drop entry
+};
+
+/// The whole decision table, as one pure function. No I/O, no globals.
+/// `targetDigest`   — required iff targetState == Regular; ignored otherwise.
+///                    If targetState == Regular and targetDigest is nil,
+///                    returns Skip (unclassifiable → leave alone) before any
+///                    other check, so the function is verifiably total even
+///                    though this combination cannot occur in the current
+///                    orchestration.
+/// `bundleDigest`   — nil means the file is no longer shipped (row 7).
+/// `provenanceDigest` — nil means no entry (rows 8, 9, or a first sighting).
+/// `historyDigests` — may be nil or empty.
+/// Total: every input combination returns a defined action.
+MPBundledResourceAction MPBundledResourceActionForFile(
+    MPBundledResourceTargetState targetState,
+    NSString *targetDigest,
+    NSString *bundleDigest,
+    NSString *provenanceDigest,
+    NSSet<NSString *> *historyDigests);
+
+
+#pragma mark - Sync
+
+/// Outcome of one sync. Counts are per file.
+@interface MPBundledResourceSyncReport : NSObject
+@property (readonly) NSUInteger copiedCount;     // rows 1, 2, 6
+@property (readonly) NSUInteger refreshedCount;  // rows 3, 12
+@property (readonly) NSUInteger unchangedCount;  // row 4
+@property (readonly) NSUInteger modifiedCount;   // row 5 — left untouched
+@property (readonly) NSUInteger skippedCount;    // row 10 — non-regular
+@property (readonly) NSUInteger orphanedCount;   // row 7 — gone from bundle
+@property (readonly) NSUInteger failedCount;     // row 11 — per-file I/O error
+/// NO when the computed manifest was byte-identical to the one on disk (B3).
+@property (readonly) BOOL manifestWritten;
+/// YES when the bundle could not be enumerated at all; nothing was written.
+@property (readonly) BOOL aborted;
+/// The manifest as written (or as it would have been). Never nil.
+@property (readonly, copy) NSDictionary<NSString *, NSString *> *manifest;
+@end
+
+/// Testable variant that accepts explicit paths instead of using
+/// NSBundle mainBundle / MPDataDirectory. Both manifest paths are derived
+/// from the roots via MPProvenanceManifestPathInRoot /
+/// MPHistoryManifestPathInRoot.
+///
+/// Never raises, never returns nil, never aborts on a per-file failure.
+/// Returns an empty report with `aborted` set if either root is nil or
+/// either of the bundle's Styles and Themes directories fails to
+/// enumerate — in that case the provenance manifest on disk is left
+/// completely alone. "Fails to enumerate" means the NSError out-parameter
+/// of -contentsOfDirectoryAtURL:… is set; a directory that exists, is
+/// readable, and genuinely contains zero files is not an error and must
+/// not abort.
+MPBundledResourceSyncReport *MPSyncBundledResourcesInPaths(
+    NSString *userDataRoot, NSString *bundleResourceRoot);

--- a/MacDown/Code/Utility/MPBundledResourceSync.h
+++ b/MacDown/Code/Utility/MPBundledResourceSync.h
@@ -5,6 +5,10 @@
 //  Keeps the bundled Styles and Themes in the user's Application Support
 //  directory up to date with the installed app, without ever overwriting a
 //  file the user has edited.
+//
+//  The cited "contract §…" and "design §…" sections refer to the requirements
+//  and design documents posted on GitHub issue #548.
+//
 //  Related to GitHub issue #548.
 //
 

--- a/MacDown/Code/Utility/MPBundledResourceSync.m
+++ b/MacDown/Code/Utility/MPBundledResourceSync.m
@@ -290,8 +290,18 @@ NSData *MPProvenanceManifestData(NSDictionary<NSString *, NSString *> *manifest)
     NSError *error = nil;
     // Sorted keys make the file diffable and make the B3 byte-comparison
     // in MPSyncBundledResourcesInPaths meaningful.
-    NSJSONWritingOptions options =
-        NSJSONWritingSortedKeys | NSJSONWritingPrettyPrinted;
+    //
+    // WithoutEscapingSlashes is load-bearing, not cosmetic. With
+    // PrettyPrinted alone, NSJSONSerialization emits "Styles\/GitHub.css",
+    // and every key in this file carries a '/' separator per §7.2 — so the
+    // on-disk manifest would match neither design §3.1's rendering of it
+    // nor its sibling BundledResourceHistory.json, which the Python
+    // generator writes with unescaped slashes.
+    //
+    // Available unconditionally here: the flag is macOS 10.15+ and the
+    // deployment target is macOS 11.0.
+    NSJSONWritingOptions options = NSJSONWritingSortedKeys
+        | NSJSONWritingPrettyPrinted | NSJSONWritingWithoutEscapingSlashes;
     NSData *json = [NSJSONSerialization dataWithJSONObject:document
                                                    options:options
                                                      error:&error];

--- a/MacDown/Code/Utility/MPBundledResourceSync.m
+++ b/MacDown/Code/Utility/MPBundledResourceSync.m
@@ -659,7 +659,11 @@ MPBundledResourceSyncReport *MPSyncBundledResourcesInPaths(
     {
         // B3: the steady state is byte-identical, and a byte-identical
         // manifest is not rewritten — no write, no fsync, no log line.
-        NSData *existingData = [NSData dataWithContentsOfFile:manifestPath];
+        // A non-regular node at manifestPath (e.g. a FIFO) must not block
+        // here forever; treat it exactly like a missing manifest, as the
+        // row 8/9 readers already do.
+        NSData *existingData = MPPathIsRegularFile(manifestPath)
+            ? [NSData dataWithContentsOfFile:manifestPath] : nil;
         if (![manifestData isEqualToData:existingData])
         {
             NSError *writeError = nil;
@@ -768,6 +772,12 @@ static NSDictionary *MPManifestFilesObjectAtPath(NSString *path,
                                                  NSString *label)
 {
     if (!path)
+        return nil;
+
+    // A FIFO, socket, or other non-regular node left at this path must not
+    // block here indefinitely; treat it exactly like a missing manifest
+    // (rows 8, 9), the same guard row 10 applies to style/theme targets.
+    if (!MPPathIsRegularFile(path))
         return nil;
 
     NSData *data = [NSData dataWithContentsOfFile:path];
@@ -909,6 +919,7 @@ static BOOL MPRefreshFileAtPath(NSString *targetPath, NSString *bundlePath,
                           toURL:temporaryURL
                           error:error])
     {
+        [manager removeItemAtURL:temporaryURL error:NULL];
         return NO;
     }
 

--- a/MacDown/Code/Utility/MPBundledResourceSync.m
+++ b/MacDown/Code/Utility/MPBundledResourceSync.m
@@ -10,10 +10,44 @@
 
 #import "MPBundledResourceSync.h"
 
+#import <CommonCrypto/CommonDigest.h>
+#import <errno.h>
+#import <fcntl.h>
+#import <stdlib.h>
+#import <sys/stat.h>
+#import <unistd.h>
+
+#import "MPUtilities.h"
+
 NSString * const kMPBundledResourceManifestFileName =
     @"BundledResourceManifest.json";
 NSString * const kMPBundledResourceHistoryFileName =
     @"BundledResourceHistory.json";
+
+/// Schema version understood by both manifest readers. Anything else reads
+/// as corrupt and degrades to decision-table row 9, which is safe by design.
+static const NSInteger kMPBundledResourceManifestVersion = 1;
+
+/// Bytes hashed per read(2). Fixed and bounded: a user who drops a very
+/// large file into Styles/ under a bundled name must not cost us a
+/// launch-time allocation spike (design §6 R2).
+static const size_t kMPDigestChunkSize = 64 * 1024;
+
+static NSString *MPHexStringOfDigest(const unsigned char *digest);
+static BOOL MPDigestStringIsWellFormed(id digest);
+static NSError *MPPOSIXError(int code, NSString *path);
+static NSError *MPCocoaFileError(NSInteger code, NSString *path,
+                                 NSString *description);
+static NSDictionary *MPManifestFilesObjectAtPath(NSString *path,
+                                                 NSString *label);
+static MPBundledResourceTargetState MPTargetStateOfPath(NSString *path);
+static BOOL MPPathIsRegularFile(NSString *path);
+static NSArray<NSString *> *MPDirectoryEntryNames(NSString *directoryPath,
+                                                  BOOL *failed);
+static NSSet<NSString *> *MPBundleFileNamesInDirectory(
+    NSString *directoryPath, BOOL *failed);
+static BOOL MPRefreshFileAtPath(NSString *targetPath, NSString *bundlePath,
+                                NSError *__autoreleasing *error);
 
 
 #pragma mark - MPBundledResourceSyncReport
@@ -32,22 +66,156 @@ NSString * const kMPBundledResourceHistoryFileName =
 @end
 
 @implementation MPBundledResourceSyncReport
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+        _manifest = @{};
+    return self;
+}
+
 @end
 
-
-// TODO(#548): implemented in the green phase
 
 #pragma mark - Digests
 
 NSString *MPSHA256HexOfFileAtPath(NSString *path,
                                   NSError *__autoreleasing *error)
 {
-    return nil;
+    if (error)
+        *error = nil;
+
+    if (!path)
+    {
+        if (error)
+            *error = MPCocoaFileError(NSFileNoSuchFileError, nil,
+                                      @"No file path was given.");
+        return nil;
+    }
+
+    // §7.4: attributesOfItemAtPath: does not traverse a terminal symbolic
+    // link, so this rejects a symlink, directory, FIFO, socket or device
+    // node before anything is opened.
+    NSError *attributesError = nil;
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSDictionary *attributes =
+        [manager attributesOfItemAtPath:path error:&attributesError];
+    if (!attributes)
+    {
+        if (error)
+            *error = attributesError;
+        return nil;
+    }
+    if (![attributes.fileType isEqualToString:NSFileTypeRegular])
+    {
+        if (error)
+            *error = MPCocoaFileError(NSFileReadUnknownError, path,
+                                      @"Not a regular file.");
+        return nil;
+    }
+
+    // O_NONBLOCK closes the window in which the entry could have become a
+    // FIFO between the check above and this open(2): opening a FIFO with no
+    // writer would otherwise block the launch (design §6 R2, row 10).
+    int descriptor = open(path.fileSystemRepresentation,
+                          O_RDONLY | O_NONBLOCK);
+    if (descriptor < 0)
+    {
+        if (error)
+            *error = MPPOSIXError(errno, path);
+        return nil;
+    }
+
+    struct stat status;
+    if (fstat(descriptor, &status) != 0)
+    {
+        int failure = errno;
+        close(descriptor);
+        if (error)
+            *error = MPPOSIXError(failure, path);
+        return nil;
+    }
+    if (!S_ISREG(status.st_mode))
+    {
+        close(descriptor);
+        if (error)
+            *error = MPCocoaFileError(NSFileReadUnknownError, path,
+                                      @"Not a regular file.");
+        return nil;
+    }
+
+    void *buffer = malloc(kMPDigestChunkSize);
+    if (!buffer)
+    {
+        close(descriptor);
+        if (error)
+            *error = MPPOSIXError(ENOMEM, path);
+        return nil;
+    }
+
+    CC_SHA256_CTX context;
+    CC_SHA256_Init(&context);
+
+    int readFailure = 0;
+    while (YES)
+    {
+        ssize_t bytesRead = read(descriptor, buffer, kMPDigestChunkSize);
+        if (bytesRead > 0)
+        {
+            CC_SHA256_Update(&context, buffer, (CC_LONG)bytesRead);
+            continue;
+        }
+        if (bytesRead == 0)
+            break;
+        if (errno == EINTR)
+            continue;
+        readFailure = errno;
+        break;
+    }
+
+    free(buffer);
+    close(descriptor);
+
+    if (readFailure != 0)
+    {
+        if (error)
+            *error = MPPOSIXError(readFailure, path);
+        return nil;
+    }
+
+    unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256_Final(digest, &context);
+    return MPHexStringOfDigest(digest);
 }
 
 NSString *MPSHA256HexOfData(NSData *data)
 {
-    return nil;
+    if (!data)
+        return nil;
+
+    CC_SHA256_CTX context;
+    CC_SHA256_Init(&context);
+
+    // The block captures a pointer to the stack context, not a copy of it.
+    CC_SHA256_CTX *contextRef = &context;
+    [data enumerateByteRangesUsingBlock:
+        ^(const void *bytes, NSRange range, BOOL *stop) {
+            NSUInteger offset = 0;
+            while (offset < range.length)
+            {
+                NSUInteger remaining = range.length - offset;
+                if (remaining > (NSUInteger)UINT32_MAX)
+                    remaining = (NSUInteger)UINT32_MAX;
+                CC_SHA256_Update(contextRef, (const uint8_t *)bytes + offset,
+                                 (CC_LONG)remaining);
+                offset += remaining;
+            }
+        }];
+
+    unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256_Final(digest, &context);
+    return MPHexStringOfDigest(digest);
 }
 
 
@@ -56,25 +224,115 @@ NSString *MPSHA256HexOfData(NSData *data)
 NSDictionary<NSString *, NSString *> *
 MPReadProvenanceManifestAtPath(NSString *path)
 {
-    return @{};
+    NSDictionary *files = MPManifestFilesObjectAtPath(path, @"provenance");
+    if (!files)
+        return @{};
+
+    NSMutableDictionary<NSString *, NSString *> *manifest =
+        [NSMutableDictionary dictionaryWithCapacity:files.count];
+    for (id key in files)
+    {
+        if (![key isKindOfClass:[NSString class]])
+            continue;
+        id digest = files[key];
+        // Non-string and malformed values are dropped individually rather
+        // than failing the whole file (§2.3).
+        if (!MPDigestStringIsWellFormed(digest))
+            continue;
+        manifest[key] = digest;
+    }
+    return [manifest copy];
 }
 
 BOOL MPWriteProvenanceManifestAtPath(
     NSDictionary<NSString *, NSString *> *manifest,
     NSString *path, NSError *__autoreleasing *error)
 {
-    return NO;
+    if (error)
+        *error = nil;
+
+    if (!path)
+    {
+        if (error)
+            *error = MPCocoaFileError(NSFileNoSuchFileError, nil,
+                                      @"No manifest path was given.");
+        return NO;
+    }
+
+    NSData *data = MPProvenanceManifestData(manifest);
+    if (!data)
+    {
+        if (error)
+            *error = MPCocoaFileError(NSFileWriteUnknownError, path,
+                                      @"Manifest could not be serialised.");
+        return NO;
+    }
+
+    // §7.3: atomic, and deliberately unlocked. NSDataWritingAtomic writes a
+    // temporary file in the same directory and renames it, so a concurrent
+    // reader never observes a partial manifest.
+    return [data writeToFile:path options:NSDataWritingAtomic error:error];
 }
 
 NSData *MPProvenanceManifestData(NSDictionary<NSString *, NSString *> *manifest)
 {
-    return nil;
+    NSDictionary *document = @{
+        @"version": @(kMPBundledResourceManifestVersion),
+        @"files": manifest ?: @{},
+    };
+    if (![NSJSONSerialization isValidJSONObject:document])
+    {
+        NSLog(@"[MPBundledResourceSync] manifest is not serialisable as "
+              @"JSON; refusing to write it");
+        return nil;
+    }
+
+    NSError *error = nil;
+    // Sorted keys make the file diffable and make the B3 byte-comparison
+    // in MPSyncBundledResourcesInPaths meaningful.
+    NSJSONWritingOptions options =
+        NSJSONWritingSortedKeys | NSJSONWritingPrettyPrinted;
+    NSData *json = [NSJSONSerialization dataWithJSONObject:document
+                                                   options:options
+                                                     error:&error];
+    if (!json)
+    {
+        NSLog(@"[MPBundledResourceSync] could not serialise manifest: %@",
+              error);
+        return nil;
+    }
+
+    NSMutableData *data = [json mutableCopy];
+    [data appendBytes:"\n" length:1];
+    return [data copy];
 }
 
 NSDictionary<NSString *, NSSet<NSString *> *> *
 MPReadHistoryManifestAtPath(NSString *path)
 {
-    return @{};
+    NSDictionary *files = MPManifestFilesObjectAtPath(path, @"history");
+    if (!files)
+        return @{};
+
+    NSMutableDictionary<NSString *, NSSet<NSString *> *> *history =
+        [NSMutableDictionary dictionaryWithCapacity:files.count];
+    for (id key in files)
+    {
+        if (![key isKindOfClass:[NSString class]])
+            continue;
+        id digests = files[key];
+        if (![digests isKindOfClass:[NSArray class]])
+            continue;
+
+        NSMutableSet<NSString *> *set = [NSMutableSet set];
+        for (id digest in (NSArray *)digests)
+        {
+            if (MPDigestStringIsWellFormed(digest))
+                [set addObject:digest];
+        }
+        history[key] = [set copy];
+    }
+    return [history copy];
 }
 
 NSString *MPProvenanceManifestPathInRoot(NSString *userDataRoot)
@@ -99,7 +357,59 @@ MPBundledResourceAction MPBundledResourceActionForFile(
     NSString *provenanceDigest,
     NSSet<NSString *> *historyDigests)
 {
-    return MPBundledResourceActionSkip;
+    // Row 10 — target exists but is not a regular file (symlink, directory,
+    // FIFO, socket, device node). Skip entirely: never open, follow, hash,
+    // replace, or record provenance. Checked first: it is the strongest
+    // prohibition and must win over every other row.
+    if (targetState == MPBundledResourceTargetNonRegular)
+        return MPBundledResourceActionSkip;
+
+    // Row 7 — present in the target directory, removed from the bundle.
+    // Never delete; the user may have it selected. Drop the entry (§7.5).
+    if (!bundleDigest)
+        return MPBundledResourceActionForget;
+
+    // Rows 2 and 6 — absent from the target directory. Row 1 reaches here
+    // too, once per file, after the directories have been created.
+    if (targetState == MPBundledResourceTargetAbsent)
+        return MPBundledResourceActionCopy;
+
+    // Defensive: targetState == Regular with targetDigest == nil is
+    // unreachable from MPSyncBundledResourcesInPaths (a failed hash is
+    // short-circuited into the row-11 path before this function is ever
+    // called), but the function is specified as total, so it must have a
+    // defined answer for this combination in isolation. Treat it as
+    // unclassifiable and leave the file alone, which is the safe direction.
+    if (!targetDigest)
+        return MPBundledResourceActionSkip;
+
+    // §4.3 classification. Rows 8 and 9 arrive here with provenanceDigest
+    // nil and are handled by exactly this expression — there is no separate
+    // "no manifest" mode, which is the point of §6.1 step 3.
+    //
+    // -isEqualToString: is case-sensitive, and deliberately so (§7.2, §7.1).
+    // Note this diverges from MPPrismThemeURLInRoot (MPUtilities.m:248),
+    // which matches file names case-insensitively; normalising case here
+    // would let two distinct entries collide on a case-insensitive volume.
+    BOOL pristine =
+        (provenanceDigest && [targetDigest isEqualToString:provenanceDigest])
+        || [targetDigest isEqualToString:bundleDigest]
+        || [historyDigests containsObject:targetDigest];
+
+    // Row 5 — modified. Leave untouched. No backup, no .orig, no warning,
+    // no prompt, and crucially no provenance entry (§6.1 step 6).
+    if (!pristine)
+        return MPBundledResourceActionSkip;
+
+    // Row 4 — pristine and byte-equal to the bundle. No write to the file;
+    // backfill the provenance entry if it was missing.
+    if ([targetDigest isEqualToString:bundleDigest])
+        return MPBundledResourceActionRecordOnly;
+
+    // Rows 3 and 12 — pristine and differing. Atomically refresh from the
+    // bundle and update provenance. Row 12 (downgrade) is deliberately the
+    // same branch: pristine files always track the installed version (§6.2).
+    return MPBundledResourceActionRefresh;
 }
 
 
@@ -108,17 +418,509 @@ MPBundledResourceAction MPBundledResourceActionForFile(
 MPBundledResourceSyncReport *MPSyncBundledResourcesInPaths(
     NSString *userDataRoot, NSString *bundleResourceRoot)
 {
-    MPBundledResourceSyncReport *report = [[MPBundledResourceSyncReport alloc]
-        init];
-    report.copiedCount = 0;
-    report.refreshedCount = 0;
-    report.unchangedCount = 0;
-    report.modifiedCount = 0;
-    report.skippedCount = 0;
-    report.orphanedCount = 0;
-    report.failedCount = 0;
-    report.manifestWritten = NO;
-    report.aborted = NO;
-    report.manifest = @{};
+    MPBundledResourceSyncReport *report =
+        [[MPBundledResourceSyncReport alloc] init];
+
+    // Step 0 — guard. Nothing is read, nothing is written.
+    if (!userDataRoot || !bundleResourceRoot)
+    {
+        report.aborted = YES;
+        return report;
+    }
+
+    NSFileManager *manager = [NSFileManager defaultManager];
+
+    // Step 1 — both manifests degrade to @{} on missing or corrupt input,
+    // which is all rows 8 and 9 need (see MPBundledResourceActionForFile).
+    NSDictionary<NSString *, NSSet<NSString *> *> *history =
+        MPReadHistoryManifestAtPath(
+            MPHistoryManifestPathInRoot(bundleResourceRoot));
+    NSString *manifestPath = MPProvenanceManifestPathInRoot(userDataRoot);
+    NSDictionary<NSString *, NSString *> *provenance =
+        MPReadProvenanceManifestAtPath(manifestPath);
+
+    // Step 2 — enumerate the bundle FIRST, before touching anything on
+    // disk. If the bundle cannot be enumerated, every target file would
+    // classify as row 7 and the resulting (empty) manifest would silently
+    // erase all provenance, so this is a hard guard, not an optimisation
+    // (design §6 R4).
+    NSArray<NSString *> *directoryNames =
+        @[kMPStylesDirectoryName, kMPThemesDirectoryName];
+
+    // -fileExistsAtPath:isDirectory: follows symbolic links, which is what
+    // we want for the resource root itself: we only ever read from it, and
+    // §7.4's prohibition is about target entries we might write over. A
+    // root that is missing (a wrong resourcePath, a stripped bundle) aborts
+    // — unlike a missing Styles/ or Themes/ inside an otherwise valid root,
+    // which is simply a bundle that ships nothing of that kind.
+    BOOL bundleRootIsDirectory = NO;
+    if (![manager fileExistsAtPath:bundleResourceRoot
+                       isDirectory:&bundleRootIsDirectory]
+        || !bundleRootIsDirectory)
+    {
+        NSLog(@"[MPBundledResourceSync] bundle resource root is missing or "
+              @"is not a directory: %@", bundleResourceRoot);
+        report.aborted = YES;
+        return report;
+    }
+
+    NSMutableDictionary<NSString *, NSSet<NSString *> *> *bundleNames =
+        [NSMutableDictionary dictionaryWithCapacity:directoryNames.count];
+    for (NSString *directoryName in directoryNames)
+    {
+        NSString *bundleDirectory =
+            [bundleResourceRoot stringByAppendingPathComponent:directoryName];
+        BOOL failed = NO;
+        NSSet<NSString *> *names =
+            MPBundleFileNamesInDirectory(bundleDirectory, &failed);
+        if (failed)
+        {
+            report.aborted = YES;
+            return report;
+        }
+        bundleNames[directoryName] = names;
+    }
+
+    // Step 3 — row 1, the data directory itself. §7.4: any entry at that
+    // path, symlink included, means the directory is PRESENT.
+    if (![manager attributesOfItemAtPath:userDataRoot error:NULL])
+    {
+        NSError *createError = nil;
+        if (![manager createDirectoryAtPath:userDataRoot
+                withIntermediateDirectories:YES
+                                 attributes:nil
+                                      error:&createError])
+        {
+            NSLog(@"[MPBundledResourceSync] %@: %@", userDataRoot,
+                  createError);
+            return report;
+        }
+    }
+
+    // Step 4 — the twelve rows, per directory and per file.
+    NSMutableDictionary<NSString *, NSString *> *newManifest =
+        [NSMutableDictionary dictionary];
+
+    for (NSString *directoryName in directoryNames)
+    {
+        NSString *bundleDirectory =
+            [bundleResourceRoot stringByAppendingPathComponent:directoryName];
+        NSString *targetDirectory =
+            [userDataRoot stringByAppendingPathComponent:directoryName];
+
+        // §7.4: a symlinked Styles/ or Themes/ is present, not absent. The
+        // per-file rules below still run inside it.
+        if (![manager attributesOfItemAtPath:targetDirectory error:NULL])
+        {
+            NSError *createError = nil;
+            if (![manager createDirectoryAtPath:targetDirectory
+                    withIntermediateDirectories:YES
+                                     attributes:nil
+                                          error:&createError])
+            {
+                // Row 11 at directory grain: a broken Styles/ must not stop
+                // Themes/.
+                NSLog(@"[MPBundledResourceSync] %@: %@", targetDirectory,
+                      createError);
+                continue;
+            }
+        }
+
+        // The UNION of bundle and target names, so row 7 is exercised for
+        // real rather than falling out silently.
+        NSSet<NSString *> *shippedNames = bundleNames[directoryName];
+        NSMutableSet<NSString *> *names =
+            [NSMutableSet setWithSet:shippedNames];
+        [names addObjectsFromArray:
+            MPDirectoryEntryNames(targetDirectory, NULL)];
+        NSArray<NSString *> *sortedNames =
+            [names.allObjects sortedArrayUsingSelector:@selector(compare:)];
+
+        for (NSString *name in sortedNames)
+        {
+            // §7.2: keys are spelled exactly as the bundle spells them, no
+            // normalisation and no escaping.
+            NSString *key =
+                [directoryName stringByAppendingPathComponent:name];
+            NSString *bundlePath =
+                [bundleDirectory stringByAppendingPathComponent:name];
+            NSString *targetPath =
+                [targetDirectory stringByAppendingPathComponent:name];
+
+            NSString *bundleDigest = nil;
+            if ([shippedNames containsObject:name])
+            {
+                NSError *digestError = nil;
+                bundleDigest = MPSHA256HexOfFileAtPath(bundlePath,
+                                                       &digestError);
+                if (!bundleDigest)
+                {
+                    // Row 11 — log and continue; one bad file must not stop
+                    // the others.
+                    NSLog(@"[MPBundledResourceSync] %@: %@", key,
+                          digestError);
+                    report.failedCount += 1;
+                    continue;
+                }
+            }
+
+            MPBundledResourceTargetState targetState =
+                MPTargetStateOfPath(targetPath);
+
+            // Only hash the target when the answer can matter: never for a
+            // non-regular entry (row 10) and never for an orphan (row 7).
+            NSString *targetDigest = nil;
+            if (targetState == MPBundledResourceTargetRegular && bundleDigest)
+            {
+                NSError *digestError = nil;
+                targetDigest = MPSHA256HexOfFileAtPath(targetPath,
+                                                       &digestError);
+                if (!targetDigest)
+                {
+                    NSLog(@"[MPBundledResourceSync] %@: %@", key,
+                          digestError);
+                    report.failedCount += 1;
+                    continue;
+                }
+            }
+
+            MPBundledResourceAction action = MPBundledResourceActionForFile(
+                targetState, targetDigest, bundleDigest, provenance[key],
+                history[key]);
+
+            switch (action)
+            {
+                case MPBundledResourceActionCopy:
+                {
+                    NSError *copyError = nil;
+                    NSURL *source = [NSURL fileURLWithPath:bundlePath];
+                    NSURL *destination = [NSURL fileURLWithPath:targetPath];
+                    if ([manager copyItemAtURL:source
+                                         toURL:destination
+                                         error:&copyError])
+                    {
+                        newManifest[key] = bundleDigest;
+                        report.copiedCount += 1;
+                    }
+                    else
+                    {
+                        NSLog(@"[MPBundledResourceSync] %@: %@", key,
+                              copyError);
+                        report.failedCount += 1;
+                    }
+                    break;
+                }
+                case MPBundledResourceActionRefresh:
+                {
+                    NSError *refreshError = nil;
+                    if (MPRefreshFileAtPath(targetPath, bundlePath,
+                                            &refreshError))
+                    {
+                        newManifest[key] = bundleDigest;
+                        report.refreshedCount += 1;
+                    }
+                    else
+                    {
+                        NSLog(@"[MPBundledResourceSync] %@: %@", key,
+                              refreshError);
+                        report.failedCount += 1;
+                    }
+                    break;
+                }
+                case MPBundledResourceActionRecordOnly:
+                    // Row 4 — no write to the file, just backfill the entry.
+                    newManifest[key] = bundleDigest;
+                    report.unchangedCount += 1;
+                    break;
+                case MPBundledResourceActionSkip:
+                    // Row 10 when the entry is not a regular file, row 5
+                    // when it is one we cannot prove we placed. Neither
+                    // performs I/O and neither records provenance — the
+                    // missing entry is what keeps a modified file protected
+                    // on subsequent launches (§6.1 step 6).
+                    if (targetState == MPBundledResourceTargetNonRegular)
+                        report.skippedCount += 1;
+                    else
+                        report.modifiedCount += 1;
+                    break;
+                case MPBundledResourceActionForget:
+                    // Row 7 — the file stays on disk, the entry does not.
+                    report.orphanedCount += 1;
+                    break;
+            }
+        }
+    }
+
+    // Step 5 — one manifest write, after the loop (§10 partial-copy), and
+    // only when the bytes would actually change (B3).
+    report.manifest = newManifest;
+    NSData *manifestData = MPProvenanceManifestData(newManifest);
+    if (manifestData)
+    {
+        // B3: the steady state is byte-identical, and a byte-identical
+        // manifest is not rewritten — no write, no fsync, no log line.
+        NSData *existingData = [NSData dataWithContentsOfFile:manifestPath];
+        if (![manifestData isEqualToData:existingData])
+        {
+            NSError *writeError = nil;
+            if (MPWriteProvenanceManifestAtPath(newManifest, manifestPath,
+                                                &writeError))
+            {
+                report.manifestWritten = YES;
+            }
+            else
+            {
+                NSLog(@"[MPBundledResourceSync] %@: %@", manifestPath,
+                      writeError);
+            }
+        }
+    }
+
+    // Step 6 — exactly one summary line when something changed, silent
+    // otherwise. modifiedCount is deliberately excluded: a user with one
+    // permanently-edited theme must not get a log line on every launch.
+    // orphanedCount is deliberately included: a mass-orphan event is
+    // notable, not a steady state.
+    BOOL changed = (report.copiedCount + report.refreshedCount) > 0
+        || report.orphanedCount > 0
+        || report.manifestWritten;
+    if (changed)
+    {
+        NSLog(@"[MPBundledResourceSync] copied %lu, refreshed %lu, left %lu "
+              @"user-modified file(s) untouched, skipped %lu, orphaned %lu, "
+              @"failed %lu",
+              (unsigned long)report.copiedCount,
+              (unsigned long)report.refreshedCount,
+              (unsigned long)report.modifiedCount,
+              (unsigned long)report.skippedCount,
+              (unsigned long)report.orphanedCount,
+              (unsigned long)report.failedCount);
+    }
+
     return report;
+}
+
+
+#pragma mark - Private helpers
+
+static NSString *MPHexStringOfDigest(const unsigned char *digest)
+{
+    static const char *hexDigits = "0123456789abcdef";
+    char buffer[CC_SHA256_DIGEST_LENGTH * 2];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++)
+    {
+        buffer[i * 2] = hexDigits[(digest[i] >> 4) & 0x0F];
+        buffer[i * 2 + 1] = hexDigits[digest[i] & 0x0F];
+    }
+    // §7.1: lowercase hexadecimal, 64 characters, no prefix, no separators.
+    return [[NSString alloc] initWithBytes:buffer
+                                    length:sizeof(buffer)
+                                  encoding:NSASCIIStringEncoding];
+}
+
+static BOOL MPDigestStringIsWellFormed(id digest)
+{
+    if (![digest isKindOfClass:[NSString class]])
+        return NO;
+    NSString *string = digest;
+    if (string.length != (NSUInteger)(CC_SHA256_DIGEST_LENGTH * 2))
+        return NO;
+    for (NSUInteger i = 0; i < string.length; i++)
+    {
+        unichar character = [string characterAtIndex:i];
+        BOOL isHex = (character >= '0' && character <= '9')
+            || (character >= 'a' && character <= 'f');
+        if (!isHex)
+            return NO;
+    }
+    return YES;
+}
+
+static NSError *MPPOSIXError(int code, NSString *path)
+{
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+    if (path)
+        userInfo[NSFilePathErrorKey] = path;
+    return [NSError errorWithDomain:NSPOSIXErrorDomain
+                               code:code
+                           userInfo:userInfo];
+}
+
+static NSError *MPCocoaFileError(NSInteger code, NSString *path,
+                                 NSString *description)
+{
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+    if (path)
+        userInfo[NSFilePathErrorKey] = path;
+    if (description)
+        userInfo[NSLocalizedDescriptionKey] = description;
+    return [NSError errorWithDomain:NSCocoaErrorDomain
+                               code:code
+                           userInfo:userInfo];
+}
+
+/// The shared body of both manifest readers: read, parse, version-check and
+/// unwrap the `files` object. Returns nil — never raises — when the file is
+/// missing, unreadable, not JSON, of an unexpected shape, or of an
+/// unrecognised schema version. A missing file is the ordinary first-run
+/// case and is not logged; anything else is logged once.
+static NSDictionary *MPManifestFilesObjectAtPath(NSString *path,
+                                                 NSString *label)
+{
+    if (!path)
+        return nil;
+
+    NSData *data = [NSData dataWithContentsOfFile:path];
+    if (!data)
+        return nil;
+
+    NSError *error = nil;
+    id root = [NSJSONSerialization JSONObjectWithData:data
+                                              options:0
+                                                error:&error];
+    if (![root isKindOfClass:[NSDictionary class]])
+    {
+        NSLog(@"[MPBundledResourceSync] ignoring unreadable %@ manifest at "
+              @"%@: %@", label, path, error);
+        return nil;
+    }
+
+    id version = ((NSDictionary *)root)[@"version"];
+    if (![version isKindOfClass:[NSNumber class]]
+        || [version integerValue] != kMPBundledResourceManifestVersion)
+    {
+        NSLog(@"[MPBundledResourceSync] ignoring %@ manifest at %@ with "
+              @"unrecognised schema version %@", label, path, version);
+        return nil;
+    }
+
+    id files = ((NSDictionary *)root)[@"files"];
+    if (![files isKindOfClass:[NSDictionary class]])
+    {
+        NSLog(@"[MPBundledResourceSync] ignoring %@ manifest at %@ with no "
+              @"usable file map", label, path);
+        return nil;
+    }
+    return files;
+}
+
+/// §7.4: from -attributesOfItemAtPath:error:, which does not traverse a
+/// terminal symbolic link. Never from -fileExistsAtPath:isDirectory:, which
+/// does.
+static MPBundledResourceTargetState MPTargetStateOfPath(NSString *path)
+{
+    NSDictionary *attributes = [[NSFileManager defaultManager]
+        attributesOfItemAtPath:path error:NULL];
+    if (!attributes)
+        return MPBundledResourceTargetAbsent;
+    if ([attributes.fileType isEqualToString:NSFileTypeRegular])
+        return MPBundledResourceTargetRegular;
+    return MPBundledResourceTargetNonRegular;
+}
+
+static BOOL MPPathIsRegularFile(NSString *path)
+{
+    return MPTargetStateOfPath(path) == MPBundledResourceTargetRegular;
+}
+
+/// Shallow listing of `directoryPath`, names only. Sets `*failed` when the
+/// directory exists but could not be enumerated; a directory that is simply
+/// absent, and one that enumerates successfully to zero entries, are both
+/// reported as an empty listing with `*failed` NO.
+static NSArray<NSString *> *MPDirectoryEntryNames(NSString *directoryPath,
+                                                  BOOL *failed)
+{
+    if (failed)
+        *failed = NO;
+
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSError *error = nil;
+    NSArray<NSURL *> *urls = [manager
+              contentsOfDirectoryAtURL:[NSURL fileURLWithPath:directoryPath]
+            includingPropertiesForKeys:@[]
+                               options:NSDirectoryEnumerationSkipsHiddenFiles
+                                 error:&error];
+    if (!urls)
+    {
+        // Distinguish a genuine enumeration failure from a directory that
+        // is not there at all. -attributesOfItemAtPath: does not traverse a
+        // terminal symlink, so a dangling link counts as present — and so
+        // as a failure — rather than being quietly ignored.
+        if (![manager attributesOfItemAtPath:directoryPath error:NULL])
+            return @[];
+
+        NSLog(@"[MPBundledResourceSync] cannot enumerate %@: %@",
+              directoryPath, error);
+        if (failed)
+            *failed = YES;
+        return @[];
+    }
+
+    NSMutableArray<NSString *> *names =
+        [NSMutableArray arrayWithCapacity:urls.count];
+    for (NSURL *url in urls)
+        [names addObject:url.lastPathComponent];
+    return [names copy];
+}
+
+/// The regular files a bundle directory ships. Anything else in there — a
+/// symlink, a nested directory — is ignored rather than counted as a
+/// failure, and so is never copied.
+static NSSet<NSString *> *MPBundleFileNamesInDirectory(
+    NSString *directoryPath, BOOL *failed)
+{
+    NSArray<NSString *> *entries = MPDirectoryEntryNames(directoryPath,
+                                                         failed);
+    NSMutableSet<NSString *> *names =
+        [NSMutableSet setWithCapacity:entries.count];
+    for (NSString *name in entries)
+    {
+        NSString *path = [directoryPath stringByAppendingPathComponent:name];
+        if (MPPathIsRegularFile(path))
+            [names addObject:name];
+    }
+    return [names copy];
+}
+
+/// B2 — the only code path in this file that touches an existing target
+/// file, and it never removes one. The bundle copy lands on a temporary in
+/// the SAME directory and is then swapped in with
+/// -replaceItemAtURL:withItemAtURL:…, so there is no window in which the
+/// file does not exist. Delete-then-copy is forbidden (design §6 R1: the
+/// app-hosted HGMarkdownHighlighterTests read the live Themes directory
+/// during the test run and would fail intermittently).
+///
+/// The temporary name starts with "." and does not end in ".css" or
+/// ".style", so that even if a failure leaves residue behind,
+/// MPFileNameHasExtensionProcessor (MPUtilities.m:73-84) filters it out of
+/// every style and theme listing.
+static BOOL MPRefreshFileAtPath(NSString *targetPath, NSString *bundlePath,
+                                NSError *__autoreleasing *error)
+{
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSString *directory = targetPath.stringByDeletingLastPathComponent;
+    NSString *temporaryName =
+        [NSString stringWithFormat:@".%@.%@.tmp", targetPath.lastPathComponent,
+                                   [[NSUUID UUID] UUIDString]];
+    NSURL *temporaryURL = [NSURL fileURLWithPath:
+        [directory stringByAppendingPathComponent:temporaryName]];
+
+    if (![manager copyItemAtURL:[NSURL fileURLWithPath:bundlePath]
+                          toURL:temporaryURL
+                          error:error])
+    {
+        return NO;
+    }
+
+    if (![manager replaceItemAtURL:[NSURL fileURLWithPath:targetPath]
+                     withItemAtURL:temporaryURL
+                    backupItemName:nil
+                           options:0
+                  resultingItemURL:NULL
+                             error:error])
+    {
+        [manager removeItemAtURL:temporaryURL error:NULL];
+        return NO;
+    }
+    return YES;
 }

--- a/MacDown/Code/Utility/MPBundledResourceSync.m
+++ b/MacDown/Code/Utility/MPBundledResourceSync.m
@@ -5,6 +5,10 @@
 //  Keeps the bundled Styles and Themes in the user's Application Support
 //  directory up to date with the installed app, without ever overwriting a
 //  file the user has edited.
+//
+//  The cited "contract §…" and "design §…" sections refer to the requirements
+//  and design documents posted on GitHub issue #548.
+//
 //  Related to GitHub issue #548.
 //
 
@@ -660,8 +664,9 @@ MPBundledResourceSyncReport *MPSyncBundledResourcesInPaths(
                     // genuine orphan, and a provenance entry is that proof:
                     // it means we shipped this path once and no longer do.
                     // A target file with no entry is simply the user's own
-                    // — help.md:293 invites users to add custom CSS — so it
-                    // is not counted, and therefore never reaches the
+                    // — the "CSS" section of help.md, under "The Rendering
+                    // Preference Pane", invites users to add custom CSS — so
+                    // it is not counted, and therefore never reaches the
                     // summary log below. (It is not touched or recorded
                     // either way; that part is row 7 regardless.)
                     //

--- a/MacDown/Code/Utility/MPBundledResourceSync.m
+++ b/MacDown/Code/Utility/MPBundledResourceSync.m
@@ -655,7 +655,22 @@ MPBundledResourceSyncReport *MPSyncBundledResourcesInPaths(
                     break;
                 case MPBundledResourceActionForget:
                     // Row 7 — the file stays on disk, the entry does not.
-                    report.orphanedCount += 1;
+                    //
+                    // Only a file we can prove the app itself placed is a
+                    // genuine orphan, and a provenance entry is that proof:
+                    // it means we shipped this path once and no longer do.
+                    // A target file with no entry is simply the user's own
+                    // — help.md:293 invites users to add custom CSS — so it
+                    // is not counted, and therefore never reaches the
+                    // summary log below. (It is not touched or recorded
+                    // either way; that part is row 7 regardless.)
+                    //
+                    // This also makes the count transient rather than
+                    // permanent: the first sync after we stop shipping a
+                    // file counts it once and drops its entry (§7.5), so
+                    // every later sync sees no entry and stays silent.
+                    if (provenance[key])
+                        report.orphanedCount += 1;
                     break;
             }
         }
@@ -693,8 +708,9 @@ MPBundledResourceSyncReport *MPSyncBundledResourcesInPaths(
     // Step 6 — exactly one summary line when something changed, silent
     // otherwise. modifiedCount is deliberately excluded: a user with one
     // permanently-edited theme must not get a log line on every launch.
-    // orphanedCount is deliberately included: a mass-orphan event is
-    // notable, not a steady state.
+    // orphanedCount is deliberately included: it counts only files that
+    // carried a provenance entry (see MPBundledResourceActionForget above),
+    // so a mass-orphan event is notable and it is never a steady state.
     BOOL changed = (report.copiedCount + report.refreshedCount) > 0
         || report.orphanedCount > 0
         || report.manifestWritten;

--- a/MacDown/Code/Utility/MPBundledResourceSync.m
+++ b/MacDown/Code/Utility/MPBundledResourceSync.m
@@ -1,0 +1,124 @@
+//
+//  MPBundledResourceSync.m
+//  MacDown 3000
+//
+//  Keeps the bundled Styles and Themes in the user's Application Support
+//  directory up to date with the installed app, without ever overwriting a
+//  file the user has edited.
+//  Related to GitHub issue #548.
+//
+
+#import "MPBundledResourceSync.h"
+
+NSString * const kMPBundledResourceManifestFileName =
+    @"BundledResourceManifest.json";
+NSString * const kMPBundledResourceHistoryFileName =
+    @"BundledResourceHistory.json";
+
+
+#pragma mark - MPBundledResourceSyncReport
+
+@interface MPBundledResourceSyncReport ()
+@property (readwrite) NSUInteger copiedCount;
+@property (readwrite) NSUInteger refreshedCount;
+@property (readwrite) NSUInteger unchangedCount;
+@property (readwrite) NSUInteger modifiedCount;
+@property (readwrite) NSUInteger skippedCount;
+@property (readwrite) NSUInteger orphanedCount;
+@property (readwrite) NSUInteger failedCount;
+@property (readwrite) BOOL manifestWritten;
+@property (readwrite) BOOL aborted;
+@property (readwrite, copy) NSDictionary<NSString *, NSString *> *manifest;
+@end
+
+@implementation MPBundledResourceSyncReport
+@end
+
+
+// TODO(#548): implemented in the green phase
+
+#pragma mark - Digests
+
+NSString *MPSHA256HexOfFileAtPath(NSString *path,
+                                  NSError *__autoreleasing *error)
+{
+    return nil;
+}
+
+NSString *MPSHA256HexOfData(NSData *data)
+{
+    return nil;
+}
+
+
+#pragma mark - Manifests
+
+NSDictionary<NSString *, NSString *> *
+MPReadProvenanceManifestAtPath(NSString *path)
+{
+    return @{};
+}
+
+BOOL MPWriteProvenanceManifestAtPath(
+    NSDictionary<NSString *, NSString *> *manifest,
+    NSString *path, NSError *__autoreleasing *error)
+{
+    return NO;
+}
+
+NSData *MPProvenanceManifestData(NSDictionary<NSString *, NSString *> *manifest)
+{
+    return nil;
+}
+
+NSDictionary<NSString *, NSSet<NSString *> *> *
+MPReadHistoryManifestAtPath(NSString *path)
+{
+    return @{};
+}
+
+NSString *MPProvenanceManifestPathInRoot(NSString *userDataRoot)
+{
+    return [userDataRoot
+        stringByAppendingPathComponent:kMPBundledResourceManifestFileName];
+}
+
+NSString *MPHistoryManifestPathInRoot(NSString *bundleResourceRoot)
+{
+    return [bundleResourceRoot
+        stringByAppendingPathComponent:kMPBundledResourceHistoryFileName];
+}
+
+
+#pragma mark - Classification
+
+MPBundledResourceAction MPBundledResourceActionForFile(
+    MPBundledResourceTargetState targetState,
+    NSString *targetDigest,
+    NSString *bundleDigest,
+    NSString *provenanceDigest,
+    NSSet<NSString *> *historyDigests)
+{
+    return MPBundledResourceActionSkip;
+}
+
+
+#pragma mark - Sync
+
+MPBundledResourceSyncReport *MPSyncBundledResourcesInPaths(
+    NSString *userDataRoot, NSString *bundleResourceRoot)
+{
+    MPBundledResourceSyncReport *report = [[MPBundledResourceSyncReport alloc]
+        init];
+    report.copiedCount = 0;
+    report.refreshedCount = 0;
+    report.unchangedCount = 0;
+    report.modifiedCount = 0;
+    report.skippedCount = 0;
+    report.orphanedCount = 0;
+    report.failedCount = 0;
+    report.manifestWritten = NO;
+    report.aborted = NO;
+    report.manifest = @{};
+    return report;
+}

--- a/MacDown/Resources/BundledResourceHistory.json
+++ b/MacDown/Resources/BundledResourceHistory.json
@@ -1,0 +1,130 @@
+{
+  "files": {
+    "Styles/Clearness Dark.css": [
+      "2a85f66c4ada7ac072f6dd8dea6c0475fe43486ffe0ee02d1b4aea2cbf1dbf4b",
+      "bfd53b6ac76c5dc36ae906c23f12fe84f7b1b400dae0221ddcd81201317fdd56"
+    ],
+    "Styles/Clearness.css": [
+      "88fe43c01e68cd61d1c5cec30deefbd062ba03d118bc54af0f783bfdc7786220",
+      "9592b8a209974c614bef8085700788df0e97fc57480c7bfd17840d9b436a02a3"
+    ],
+    "Styles/GitHub Tomorrow.css": [
+      "d274836c48020747374111fec9b3428670fb75d0eaaf298523221ff74b86f5d8",
+      "da9493cf8eb7e215d603c2eb1d9b290a489901b39a7860dfe5c36add8f58b013"
+    ],
+    "Styles/GitHub-2020.css": [
+      "00dbded9d7173d8b9978cb8a53719c1e754c4c9f97521a1bbb994711f0be89a0",
+      "02a6f516007712296361b92b9f6dd97a15ac05d3ae2e32cbb98cb95d419ed277"
+    ],
+    "Styles/GitHub.css": [
+      "50b145c3b6ae27c8c1f0d2907f83eeade0feabbf082ed9827fd423fa02086328",
+      "673ad0add6f2ad0283f152bd0c4806fce92ac095a8c69331d71a6fb4835140a1"
+    ],
+    "Styles/GitHub2.css": [
+      "62ed816fefa18599c6b8dd0b3d81143459e799e335f77b81ddc1650178ddcefd",
+      "d526e3d22730267ba919c1af92c9ed826ccd8b681f516add89de9ce912a79938"
+    ],
+    "Styles/Github2 (dark).css": [
+      "d437fa41d15204f524a180dd75c0fbf03ca84df442e64154f97f6f73980af3e5"
+    ],
+    "Styles/Gmail.css": [
+      "cf2f35839c870f75716ea92a40cb27a1431049983b7095a983689fc188fa5e35"
+    ],
+    "Styles/Google Docs.css": [
+      "7305f1bbf7680a5dfa6f3db8d3fdb6f98377d9a2b0c31cc4939f40dde28ea819"
+    ],
+    "Styles/Solarized (Dark).css": [
+      "7ffd144dc8257bd98723a1d119cca2168ac7c6c92bf75aa25d72b92d2014590e",
+      "bf4621dfa934e085ebf96d083d72dd026a77999a4a94306f8e55e9fa81ef8003"
+    ],
+    "Styles/Solarized (Light).css": [
+      "525852c300063e5d27c02fac5e09ce5e9278979e7a9788e0bcccca7c214f5bcc",
+      "59b7f94e154dcd17905b4916ebddb1497d5531ac203ca68fee4f003f0f7438c8"
+    ],
+    "Themes/GitHub Dark Default+.style": [
+      "1c871c959cdd2b32178de980ad180cd0f5cd1f629f11075449be10289f07d6ab"
+    ],
+    "Themes/GitHub Dark Default.style": [
+      "7ddc20007c5b98703cc031461f7d68080d46a1c51c1f63596681f17ce84d381a"
+    ],
+    "Themes/Mou Fresh Air+.style": [
+      "3e07b681f9e56bec4d1036b015877eec5fbd160049049895703bef292ceefa38",
+      "9c7b5281bc5736ef43daa6a415dc9d875f72eb4d386f2631294372a138d7d21c"
+    ],
+    "Themes/Mou Fresh Air.style": [
+      "769cc6393d4b8465314b833e1bfdd420ebc88850e1f648ffea11767b4780378f",
+      "7cf14e22925608ef66e58f8e48bf1cc3640f3b1890631e4cc4ebeadd6dafed9e"
+    ],
+    "Themes/Mou Night+.style": [
+      "29ac097ec816c3f6c315ede0b0aba97ee0175ff9f83d65e18bb05a2906b5650e",
+      "39872c51d2972803efe27d7ea3114ce91c8718a07a3662c95b6a0ba65bed3f95"
+    ],
+    "Themes/Mou Night.style": [
+      "3a7141f6ce52ba617d2da554efa0a77d02587789e80fb93bfa8642219f4171df",
+      "5f07cfb769df3846bfe0aca3ab4305291580d0bdbb84e67574e3063587861017"
+    ],
+    "Themes/Mou Paper+.style": [
+      "8d2350b0042a4fa4ebe889296db1c5f0b471b3115911f98ef34dfef4efa4dd7d",
+      "df27e819d93eef4f42f116d04778ee72cbaefcf1c60401c42c29d568372608cc"
+    ],
+    "Themes/Mou Paper.style": [
+      "28227900a310617c62593ae65581082dce83905ae366fc0f49ed0ec79cec5fd4",
+      "f91490c350a951a55c5bc0530544f8de80309adab93fdadd8735cbee0ebc7c5b"
+    ],
+    "Themes/Solarized (Dark)+.style": [
+      "2fc489c15373f77d12ae28eb42b75bf4fa80ae0295d1957cee17f37d96cf432d",
+      "be586af79701e88d4cb96be7998a872ea0de112aae855a96e35765e3d7fc3196"
+    ],
+    "Themes/Solarized (Dark).style": [
+      "b087429dda9c25540a339485bde5632d5f1c5e8cacc438c3b256d69b36b67fae",
+      "d69113f482bdbfa6b1d575a5d1e7ca3628a930c443aa9a856559bd9fb35e7248"
+    ],
+    "Themes/Solarized (Light)+.style": [
+      "30751252517c8d159fbc8c30af5387199c96bdb5b86a817f0f9bfc07d52212a4",
+      "807de1062aad78f56eb4c1a9155aa0c1387732ae1b1881853a70a3e3c8ab0964"
+    ],
+    "Themes/Solarized (Light).style": [
+      "1e62c3734ef412f23a8ae4ccf8c509c55d069c644c0af94f849dd20bdcf42b50",
+      "5d5ed023976fd319ae10532fe40c9d22d6faad6b3826dfe372846781d8f57d1c"
+    ],
+    "Themes/Tomorrow Blue.style": [
+      "090ad9ac160ce57ab4133050be04050d36be35596f53a726b6b21aa346abd354",
+      "c6c1143811f2f0ef438998e2595a4dcb6b1cec4c79c84c5d8bcd32b632ba1e66"
+    ],
+    "Themes/Tomorrow+.style": [
+      "08cde05e7ed3255be21881924ddc8ccb66554e76e4e29e5eed2d5e17e079707b",
+      "ed759e275d7a46f370fc00f315a49db90b5fb27ffe8f007560dbc6709e1c15c2"
+    ],
+    "Themes/Tomorrow.style": [
+      "484219dc9b45ad3215bf3dfe1caeb29dc15948f9aae0663ef37b2292e4db4995",
+      "75c8dc06b2f41fa2838478b8e4a8459668067e2a554937881ec6cbb9a90a33fe"
+    ],
+    "Themes/Writer+.style": [
+      "732b282bb9928f5ab0f9c4fb62ec70d9b1a4a87780be06d45d3addab68790012",
+      "f23b609218f4e0b0491cec38e48293af0325b9e6aec79da60ee6a9cd277c3945"
+    ],
+    "Themes/Writer.style": [
+      "1f9c437258f2716b2ff2d1385be05629a20b8b11056f1cd55395e411b96fa3ab",
+      "4deb71d57e1bc79ae53132156946f891f02951a320a5205552966e4fcc458c10"
+    ]
+  },
+  "tags": [
+    "v3000.0.0-beta.0",
+    "v3000.0.0-beta.1",
+    "v3000.0.0-beta.2",
+    "v3000.0.0-beta.3",
+    "v3000.0.0",
+    "v3000.0.1",
+    "v3000.0.2",
+    "v3000.0.3-beta.1",
+    "v3000.0.3",
+    "v3000.0.4",
+    "v3000.0.5",
+    "v3000.0.6",
+    "v3000.0.7-rc.1",
+    "v3000.0.7-rc.2",
+    "v3000.0.7-rc.3",
+    "v3000.0.7"
+  ],
+  "version": 1
+}

--- a/MacDown/Resources/help.md
+++ b/MacDown/Resources/help.md
@@ -292,6 +292,8 @@ This is where I keep preferences relating to how I render and style the parsed m
 
 You can choose different css files for me to use to render your html. You can even customize or add your own custom css files.
 
+I also keep the built-in css files up to date on my own, so you always have the latest fixes without doing anything. If you've customized one, though, I'll never overwrite it. Want the newest bundled version instead? Delete your copy and relaunch me, and I'll put a fresh one back in its place.
+
 ### Syntax Highlighting
 
 You have already seen how I can syntax highlight your fenced code blocks. See the [Fenced Code Block](#fenced-code-block) section if you haven’t! You can also choose different themes for syntax highlighting.
@@ -355,6 +357,8 @@ This is where I keep preferences related to the behavior and styling of the edit
 My editor provides syntax highlighting. You can edit the base font and the coloring/sizing theme. I provided some default themes (courtesy of [Mou](http://mouapp.com)’s creator, Chen Luo) if you don’t know where to start.
 
 You can also edit, or even add new themes if you want to! Just click the ***Reveal*** button, and start moving things around. Remember to use the correct file extension (`.styles`), though. I’m picky about that.
+
+I keep the built-in themes up to date the same way — automatically, and without ever touching one you've edited yourself. If you want the latest version of a theme you changed, just delete it and relaunch me, and I'll restore the bundled copy.
 
 I offer auto-completion and other functions to ease your editing experience. If you don't like it, however, you can turn them off.
 

--- a/MacDownTests/MPBundledResourceDigestTests.m
+++ b/MacDownTests/MPBundledResourceDigestTests.m
@@ -6,8 +6,13 @@
 //  MPBundledResourceSync: SHA-256 digesting, provenance/history manifest
 //  I/O, and the MPBundledResourceActionForFile decision table.
 //
-//  Written against the design and contract for GitHub issue #548, not
-//  against MPBundledResourceSync.m's current (deliberately stubbed) bodies.
+//  These tests were written against the design and contract before the
+//  implementation existed, so they follow the specification rather than
+//  mirroring the structure of MPBundledResourceSync.m.
+//
+//  The cited "contract §…" and "design §…" sections refer to the requirements
+//  and design documents posted on GitHub issue #548.
+//
 //  Related to GitHub issue #548.
 //
 

--- a/MacDownTests/MPBundledResourceDigestTests.m
+++ b/MacDownTests/MPBundledResourceDigestTests.m
@@ -1,0 +1,744 @@
+//
+//  MPBundledResourceDigestTests.m
+//  MacDown 3000
+//
+//  Tests for the pure, non-filesystem-orchestrating half of
+//  MPBundledResourceSync: SHA-256 digesting, provenance/history manifest
+//  I/O, and the MPBundledResourceActionForFile decision table.
+//
+//  Written against the design and contract for GitHub issue #548, not
+//  against MPBundledResourceSync.m's current (deliberately stubbed) bodies.
+//  Related to GitHub issue #548.
+//
+
+#import <XCTest/XCTest.h>
+#import "MPBundledResourceSync.h"
+
+// Real SHA-256 vectors, computed with `shasum -a 256` / Python's hashlib so
+// they are independently verifiable and do not depend on this codebase.
+static NSString * const kSHA256EmptyDigest =
+    @"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+static NSString * const kSHA256AbcDigest =
+    @"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+// SHA-256 of 65553 bytes (64 KiB + 17) where byte[i] == i % 251, computed
+// independently with Python's hashlib. Pins chunk-boundary correctness to a
+// known value rather than only cross-checking the file and data code paths
+// against each other.
+static NSString * const kSHA256ChunkBoundaryDigest =
+    @"db321256cd80da245f26f881e6b51650d0c95881f47d47e0e8c51a455b66af34";
+
+// Arbitrary, well-formed (64 lowercase hex char) digests used as opaque
+// stand-ins in manifest and truth-table tests, where only equality/
+// inequality among them matters, not what they are digests of. Each is a
+// real `shasum -a 256` output so nothing here is a "looks like hex" fake.
+static NSString * const kHexV1 =
+    @"3bfc269594ef649228e9a74bab00f042efc91d5acc6fbee31a382e80d42388fe";
+static NSString * const kHexV2 =
+    @"fb04dcb6970e4c3d1873de51fd5a50d7bb46b3383113602665c350ec40b5f990";
+static NSString * const kHexV3 =
+    @"e0d2747b9ab7abb6eb65e0373fa1b428a28bd6d8a2380106dcc080f58005ee14";
+static NSString * const kHexBundle =
+    @"1e6ed65d77d6364eeaed5a745ba5c4985ae2b700dd85d7cf7f027bdf294a33fc";
+static NSString * const kHexProvenance =
+    @"96d815328a42cb4ef89d5e0b7a1df6be43b484832c83a7b4596d8402c7c0b12b";
+static NSString * const kHexTarget =
+    @"34a04005bcaf206eec990bd9637d9fdb6725e0a0c0d4aebf003f17f4c956eb5c";
+static NSString * const kHexModified =
+    @"b80012851cf027c6d8adda328907d400c95773958fb4fec3e544a02cd5eeab0e";
+
+
+@interface MPBundledResourceDigestTests : XCTestCase
+@property (strong) NSString *tempDir;
+@end
+
+
+@implementation MPBundledResourceDigestTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.tempDir = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+    [[NSFileManager defaultManager] createDirectoryAtPath:self.tempDir
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+}
+
+- (void)tearDown
+{
+    [[NSFileManager defaultManager] removeItemAtPath:self.tempDir error:nil];
+    [super tearDown];
+}
+
+#pragma mark - Helpers
+
+- (NSString *)pathForName:(NSString *)name
+{
+    return [self.tempDir stringByAppendingPathComponent:name];
+}
+
+#pragma mark - MPSHA256HexOfFileAtPath / MPSHA256HexOfData
+
+- (void)testSHA256HexOfEmptyFileMatchesKnownVector
+{
+    NSString *name = @"empty.bin";
+    NSError *writeError = nil;
+    BOOL wrote = [[NSData data] writeToFile:[self pathForName:name]
+                                     options:0
+                                       error:&writeError];
+    XCTAssertTrue(wrote, @"fixture write failed: %@", writeError);
+
+    NSError *error = nil;
+    NSString *digest = MPSHA256HexOfFileAtPath([self pathForName:name],
+                                                &error);
+    XCTAssertNotNil(digest,
+                    @"empty file must hash successfully, error: %@", error);
+    XCTAssertNil(error, @"no error expected for a readable empty file");
+    XCTAssertEqualObjects(digest, kSHA256EmptyDigest,
+                          @"empty-file digest must match the well-known "
+                          @"SHA-256(\"\") vector");
+}
+
+- (void)testSHA256HexOfKnownStringMatchesKnownVector
+{
+    NSData *abc = [@"abc" dataUsingEncoding:NSUTF8StringEncoding];
+
+    NSString *dataDigest = MPSHA256HexOfData(abc);
+    XCTAssertEqualObjects(dataDigest, kSHA256AbcDigest,
+                          @"MPSHA256HexOfData(\"abc\") must match the "
+                          @"well-known SHA-256(\"abc\") vector");
+
+    // Cross-check the file path against the same known vector, not just
+    // against the data path, so this test cannot pass merely because both
+    // functions independently return the same (possibly wrong) stub value.
+    NSString *name = @"abc.bin";
+    NSError *writeError = nil;
+    BOOL wrote = [abc writeToFile:[self pathForName:name]
+                           options:0
+                             error:&writeError];
+    XCTAssertTrue(wrote, @"fixture write failed: %@", writeError);
+
+    NSError *error = nil;
+    NSString *fileDigest = MPSHA256HexOfFileAtPath([self pathForName:name],
+                                                    &error);
+    XCTAssertEqualObjects(fileDigest, kSHA256AbcDigest,
+                          @"MPSHA256HexOfFileAtPath must also match the "
+                          @"well-known SHA-256(\"abc\") vector");
+    XCTAssertNil(error, @"no error expected for a readable file");
+}
+
+- (void)testSHA256HexIsLowercaseAnd64Characters
+{
+    NSData *data = [@"regex pin" dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *digest = MPSHA256HexOfData(data);
+    XCTAssertNotNil(digest, @"a digest is required before regex-checking it");
+    XCTAssertEqual(digest.length, (NSUInteger)64,
+                   @"digest must be exactly 64 characters, got %lu",
+                   (unsigned long)digest.length);
+
+    NSError *regexError = nil;
+    NSRegularExpression *re =
+        [NSRegularExpression regularExpressionWithPattern:@"^[0-9a-f]{64}$"
+                                                    options:0
+                                                      error:&regexError];
+    XCTAssertNil(regexError, @"regex itself must compile: %@", regexError);
+
+    NSUInteger matchCount =
+        [re numberOfMatchesInString:digest
+                             options:0
+                               range:NSMakeRange(0, digest.length)];
+    XCTAssertEqual(matchCount, (NSUInteger)1,
+                   @"digest %@ must be lowercase 64-char hex per §7.1",
+                   digest);
+}
+
+- (void)testSHA256HexCrossesChunkBoundaryCorrectly
+{
+    // 64 KiB + 17 bytes: one byte past a plausible internal chunk size, so a
+    // correct implementation must handle a final, non-full chunk.
+    const NSUInteger length = 64 * 1024 + 17;
+    NSMutableData *data = [NSMutableData dataWithCapacity:length];
+    for (NSUInteger i = 0; i < length; i++)
+    {
+        uint8_t byte = (uint8_t)(i % 251);
+        [data appendBytes:&byte length:1];
+    }
+    XCTAssertEqual(data.length, length, @"fixture must be exactly 64 KiB+17");
+
+    NSString *name = @"chunk-boundary.bin";
+    NSError *writeError = nil;
+    BOOL wrote = [data writeToFile:[self pathForName:name]
+                            options:0
+                              error:&writeError];
+    XCTAssertTrue(wrote, @"fixture write failed: %@", writeError);
+
+    NSError *fileError = nil;
+    NSString *fileDigest = MPSHA256HexOfFileAtPath([self pathForName:name],
+                                                    &fileError);
+    NSString *dataDigest = MPSHA256HexOfData(data);
+
+    XCTAssertNotNil(fileDigest,
+                    @"file-path digest must not be nil, error: %@",
+                    fileError);
+    XCTAssertNotNil(dataDigest, @"data-path digest must not be nil");
+    XCTAssertEqualObjects(fileDigest, dataDigest,
+                          @"chunked file reading must agree with the "
+                          @"whole-buffer data path at a chunk boundary");
+    XCTAssertEqualObjects(fileDigest, kSHA256ChunkBoundaryDigest,
+                          @"digest must match the independently-computed "
+                          @"pinned value for this exact 65553-byte fixture");
+}
+
+- (void)testSHA256HexReturnsNilAndSetsErrorForMissingFile
+{
+    NSString *missing = [self pathForName:@"does-not-exist.bin"];
+    NSError *error = nil;
+    NSString *digest = MPSHA256HexOfFileAtPath(missing, &error);
+    XCTAssertNil(digest, @"missing file must not produce a digest");
+    XCTAssertNotNil(error,
+                    @"missing file must set an error describing the "
+                    @"underlying failure, not just return nil silently");
+}
+
+- (void)testSHA256HexReturnsNilAndSetsErrorForDirectory
+{
+    NSString *dirPath = [self pathForName:@"a-directory"];
+    [[NSFileManager defaultManager] createDirectoryAtPath:dirPath
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+    NSError *error = nil;
+    NSString *digest = MPSHA256HexOfFileAtPath(dirPath, &error);
+    XCTAssertNil(digest, @"a directory is not a regular file and must not "
+                         @"produce a digest");
+    XCTAssertNotNil(error,
+                    @"attempting to hash a directory must set an error");
+}
+
+- (void)testSHA256HexReturnsNilAndSetsErrorForNilPath
+{
+    NSError *error = nil;
+    NSString *digest = MPSHA256HexOfFileAtPath(nil, &error);
+    XCTAssertNil(digest, @"nil path must not produce a digest");
+    XCTAssertNotNil(error, @"nil path must set an error");
+    XCTAssertEqual(error.code, NSFileNoSuchFileError,
+                   @"§2.3's error table pins a nil path specifically to "
+                   @"NSFileNoSuchFileError, got %ld", (long)error.code);
+}
+
+#pragma mark - Provenance manifest
+
+- (void)testProvenanceManifestRoundTrip
+{
+    NSDictionary<NSString *, NSString *> *manifest = @{
+        @"Styles/A.css": kHexV1,
+        @"Themes/B.style": kHexV2,
+    };
+    NSString *path = [self pathForName:@"roundtrip.json"];
+
+    NSError *writeError = nil;
+    BOOL ok = MPWriteProvenanceManifestAtPath(manifest, path, &writeError);
+    XCTAssertTrue(ok, @"write must succeed: %@", writeError);
+    XCTAssertNil(writeError, @"no error expected on a successful write");
+
+    NSDictionary<NSString *, NSString *> *readBack =
+        MPReadProvenanceManifestAtPath(path);
+    XCTAssertEqualObjects(readBack, manifest,
+                          @"round-tripped manifest must equal the original");
+}
+
+- (void)testProvenanceManifestDataIsDeterministicSortedAndNewlineTerminated
+{
+    NSDictionary<NSString *, NSString *> *manifest = @{
+        @"Styles/Zebra.css": kHexV1,
+        @"Styles/Alpha.css": kHexV2,
+        @"Themes/Middle.style": kHexV3,
+    };
+
+    NSData *first = MPProvenanceManifestData(manifest);
+    NSData *second = MPProvenanceManifestData(manifest);
+    XCTAssertNotNil(first, @"serialisation must succeed for a valid dict");
+    XCTAssertEqualObjects(first, second,
+                          @"the same dictionary must always serialise to "
+                          @"byte-identical data (B3 depends on this)");
+
+    NSString *text = [[NSString alloc] initWithData:first
+                                            encoding:NSUTF8StringEncoding];
+    XCTAssertNotNil(text, @"serialised bytes must be valid UTF-8");
+    XCTAssertTrue([text hasSuffix:@"\n"],
+                  @"canonical bytes must end with a trailing newline");
+
+    NSRange alphaRange = [text rangeOfString:@"Styles/Alpha.css"];
+    NSRange zebraRange = [text rangeOfString:@"Styles/Zebra.css"];
+    NSRange themesRange = [text rangeOfString:@"Themes/Middle.style"];
+    XCTAssertNotEqual(alphaRange.location, (NSUInteger)NSNotFound);
+    XCTAssertNotEqual(zebraRange.location, (NSUInteger)NSNotFound);
+    XCTAssertNotEqual(themesRange.location, (NSUInteger)NSNotFound);
+    XCTAssertLessThan(alphaRange.location, zebraRange.location,
+                      @"keys must appear in sorted order: Alpha before "
+                      @"Zebra");
+    XCTAssertLessThan(zebraRange.location, themesRange.location,
+                      @"keys must appear in sorted order: Styles/* before "
+                      @"Themes/*");
+}
+
+- (void)testProvenanceManifestReadReturnsEmptyForMissingFile
+{
+    // Positive control in the same test: prove the reader can return a
+    // populated dictionary at all, so the empty result below cannot be
+    // explained by a stub that always returns @{} regardless of input.
+    NSString *validPath = [self pathForName:@"valid-control.json"];
+    NSString *validJSON =
+        [NSString stringWithFormat:@"{\"version\":1,\"files\":"
+                                    @"{\"Styles/A.css\":\"%@\"}}", kHexV1];
+    NSError *writeError = nil;
+    [validJSON writeToFile:validPath
+                 atomically:YES
+                   encoding:NSUTF8StringEncoding
+                      error:&writeError];
+    XCTAssertNil(writeError, @"control fixture write failed: %@",
+                writeError);
+    NSDictionary *control = MPReadProvenanceManifestAtPath(validPath);
+    XCTAssertEqual(control.count, (NSUInteger)1,
+                   @"positive control: a well-formed manifest must read "
+                   @"back non-empty, proving the reader is not hardcoded "
+                   @"to always return @{}");
+
+    NSString *missingPath = [self pathForName:@"does-not-exist.json"];
+    NSDictionary *result = MPReadProvenanceManifestAtPath(missingPath);
+    XCTAssertNotNil(result, @"must never return nil");
+    XCTAssertEqual(result.count, (NSUInteger)0,
+                   @"a missing manifest file must degrade to an empty "
+                   @"dictionary");
+}
+
+- (void)testProvenanceManifestReadReturnsEmptyForCorruptJSON
+{
+    NSString *validPath = [self pathForName:@"valid-control.json"];
+    NSString *validJSON =
+        [NSString stringWithFormat:@"{\"version\":1,\"files\":"
+                                    @"{\"Styles/A.css\":\"%@\"}}", kHexV1];
+    [validJSON writeToFile:validPath
+                 atomically:YES
+                   encoding:NSUTF8StringEncoding
+                      error:nil];
+    NSDictionary *control = MPReadProvenanceManifestAtPath(validPath);
+    XCTAssertEqual(control.count, (NSUInteger)1,
+                   @"positive control must read back non-empty");
+
+    NSString *corruptPath = [self pathForName:@"corrupt.json"];
+    // Deliberately truncated JSON.
+    [@"{\"version\":1,\"files\":" writeToFile:corruptPath
+                                    atomically:YES
+                                      encoding:NSUTF8StringEncoding
+                                         error:nil];
+    NSDictionary *result = MPReadProvenanceManifestAtPath(corruptPath);
+    XCTAssertNotNil(result, @"must never return nil");
+    XCTAssertEqual(result.count, (NSUInteger)0,
+                   @"invalid/truncated JSON must degrade to an empty "
+                   @"dictionary, not raise or return nil");
+}
+
+- (void)testProvenanceManifestReadReturnsEmptyForWrongShape
+{
+    NSString *validPath = [self pathForName:@"valid-control.json"];
+    NSString *validJSON =
+        [NSString stringWithFormat:@"{\"version\":1,\"files\":"
+                                    @"{\"Styles/A.css\":\"%@\"}}", kHexV1];
+    [validJSON writeToFile:validPath
+                 atomically:YES
+                   encoding:NSUTF8StringEncoding
+                      error:nil];
+    NSDictionary *control = MPReadProvenanceManifestAtPath(validPath);
+    XCTAssertEqual(control.count, (NSUInteger)1,
+                   @"positive control must read back non-empty");
+
+    NSString *wrongShapePath = [self pathForName:@"wrong-shape.json"];
+    // Valid JSON, but the top level is an array, not the expected object.
+    [@"[1,2,3]" writeToFile:wrongShapePath
+                  atomically:YES
+                    encoding:NSUTF8StringEncoding
+                       error:nil];
+    NSDictionary *result = MPReadProvenanceManifestAtPath(wrongShapePath);
+    XCTAssertNotNil(result, @"must never return nil");
+    XCTAssertEqual(result.count, (NSUInteger)0,
+                   @"a JSON value of the wrong shape must degrade to an "
+                   @"empty dictionary");
+}
+
+- (void)testProvenanceManifestReadReturnsEmptyForUnknownVersion
+{
+    NSString *validPath = [self pathForName:@"valid-control.json"];
+    NSString *validJSON =
+        [NSString stringWithFormat:@"{\"version\":1,\"files\":"
+                                    @"{\"Styles/A.css\":\"%@\"}}", kHexV1];
+    [validJSON writeToFile:validPath
+                 atomically:YES
+                   encoding:NSUTF8StringEncoding
+                      error:nil];
+    NSDictionary *control = MPReadProvenanceManifestAtPath(validPath);
+    XCTAssertEqual(control.count, (NSUInteger)1,
+                   @"positive control must read back non-empty");
+
+    NSString *unknownVersionPath =
+        [self pathForName:@"unknown-version.json"];
+    NSString *unknownVersionJSON =
+        [NSString stringWithFormat:@"{\"version\":99,\"files\":"
+                                    @"{\"Styles/A.css\":\"%@\"}}", kHexV1];
+    [unknownVersionJSON writeToFile:unknownVersionPath
+                          atomically:YES
+                            encoding:NSUTF8StringEncoding
+                               error:nil];
+    NSDictionary *result =
+        MPReadProvenanceManifestAtPath(unknownVersionPath);
+    XCTAssertNotNil(result, @"must never return nil");
+    XCTAssertEqual(result.count, (NSUInteger)0,
+                   @"an otherwise well-formed manifest with an "
+                   @"unrecognised schema version must degrade to empty "
+                   @"(rows 8 and 9 are the same code path)");
+}
+
+- (void)testProvenanceManifestReadDropsNonStringAndMalformedDigests
+{
+    NSString *path = [self pathForName:@"mixed.json"];
+    NSString *json =
+        [NSString stringWithFormat:
+            @"{\"version\":1,\"files\":{"
+            @"\"Styles/A.css\":42,"
+            @"\"Styles/B.css\":\"NOTHEX\","
+            @"\"Styles/C.css\":\"%@\"}}", kHexV1];
+    [json writeToFile:path
+           atomically:YES
+             encoding:NSUTF8StringEncoding
+                error:nil];
+
+    NSDictionary<NSString *, NSString *> *result =
+        MPReadProvenanceManifestAtPath(path);
+    XCTAssertEqual(result.count, (NSUInteger)1,
+                   @"only the valid entry must survive, got keys: %@",
+                   result.allKeys);
+    XCTAssertNil(result[@"Styles/A.css"],
+                @"a non-string digest value must be dropped");
+    XCTAssertNil(result[@"Styles/B.css"],
+                @"a string that is not 64 lowercase hex chars must be "
+                @"dropped");
+    XCTAssertEqualObjects(result[@"Styles/C.css"], kHexV1,
+                          @"the one well-formed entry must survive intact");
+}
+
+#pragma mark - History manifest
+
+- (void)testHistoryManifestReadParsesArraysIntoSets
+{
+    NSString *path = [self pathForName:@"history.json"];
+    NSString *json =
+        [NSString stringWithFormat:
+            @"{\"version\":1,\"tags\":[\"v1\"],\"files\":{"
+            @"\"Styles/A.css\":[\"%@\",\"%@\"]}}", kHexV1, kHexV2];
+    [json writeToFile:path
+           atomically:YES
+             encoding:NSUTF8StringEncoding
+                error:nil];
+
+    NSDictionary<NSString *, NSSet<NSString *> *> *result =
+        MPReadHistoryManifestAtPath(path);
+    NSSet<NSString *> *entry = result[@"Styles/A.css"];
+    XCTAssertNotNil(entry, @"key must be present");
+    XCTAssertTrue([entry isKindOfClass:[NSSet class]],
+                  @"digest arrays must be converted to NSSet, got %@",
+                  NSStringFromClass([entry class]));
+    XCTAssertEqualObjects(entry, ([NSSet setWithObjects:kHexV1, kHexV2, nil]),
+                          @"set must contain exactly the array's digests");
+}
+
+- (void)testHistoryManifestReadReturnsEmptyForMissingFile
+{
+    // Positive control, for the same reason as the provenance-manifest
+    // equivalent: an always-@{} reader must not be indistinguishable from
+    // a correct one here.
+    NSString *validPath = [self pathForName:@"history-control.json"];
+    NSString *validJSON =
+        [NSString stringWithFormat:
+            @"{\"version\":1,\"tags\":[],\"files\":{"
+            @"\"Styles/A.css\":[\"%@\"]}}", kHexV1];
+    [validJSON writeToFile:validPath
+                 atomically:YES
+                   encoding:NSUTF8StringEncoding
+                      error:nil];
+    NSDictionary *control = MPReadHistoryManifestAtPath(validPath);
+    XCTAssertEqual(control.count, (NSUInteger)1,
+                   @"positive control: a well-formed history manifest must "
+                   @"read back non-empty");
+
+    NSString *missingPath = [self pathForName:@"no-history.json"];
+    NSDictionary *result = MPReadHistoryManifestAtPath(missingPath);
+    XCTAssertNotNil(result, @"must never return nil");
+    XCTAssertEqual(result.count, (NSUInteger)0,
+                   @"a missing history manifest must degrade to an empty "
+                   @"dictionary");
+}
+
+- (void)testHistoryManifestReadIgnoresNonStringMembers
+{
+    NSString *path = [self pathForName:@"mixed-history.json"];
+    NSString *json =
+        [NSString stringWithFormat:
+            @"{\"version\":1,\"tags\":[],\"files\":{"
+            @"\"Styles/A.css\":[\"%@\",42,\"NOTHEX\",\"%@\"]}}",
+            kHexV1, kHexV2];
+    [json writeToFile:path
+           atomically:YES
+             encoding:NSUTF8StringEncoding
+                error:nil];
+
+    NSDictionary<NSString *, NSSet<NSString *> *> *result =
+        MPReadHistoryManifestAtPath(path);
+    NSSet<NSString *> *entry = result[@"Styles/A.css"];
+    XCTAssertEqualObjects(entry, ([NSSet setWithObjects:kHexV1, kHexV2, nil]),
+                          @"non-string (42) and malformed (\"NOTHEX\") "
+                          @"members must be dropped, valid ones kept, got "
+                          @"%@", entry);
+}
+
+- (void)testHistoryManifestReadHandlesTheShippedFileShape
+{
+    // The §3.2 example, verbatim.
+    NSString *json =
+        @"{\n"
+        @"  \"version\": 1,\n"
+        @"  \"tags\": [\n"
+        @"    \"v3000.0.0-beta.0\", \"v3000.0.0-beta.1\", "
+        @"\"v3000.0.0-beta.2\",\n"
+        @"    \"v3000.0.0-beta.3\", \"v3000.0.0\", \"v3000.0.1\", "
+        @"\"v3000.0.2\",\n"
+        @"    \"v3000.0.3-beta.1\", \"v3000.0.3\", \"v3000.0.4\", "
+        @"\"v3000.0.5\",\n"
+        @"    \"v3000.0.6\", \"v3000.0.7-rc.1\", \"v3000.0.7-rc.2\", "
+        @"\"v3000.0.7-rc.3\",\n"
+        @"    \"v3000.0.7\"\n"
+        @"  ],\n"
+        @"  \"files\": {\n"
+        @"    \"Styles/GitHub.css\": [\n"
+        @"      \"50b145c3b6ae27c8c1f0d2907f83eeade0feabbf082ed9827fd423f"
+        @"a02086328\",\n"
+        @"      \"673ad0add6f2ad0283f152bd0c4806fce92ac095a8c69331d71a6f"
+        @"b4835140a1\"\n"
+        @"    ],\n"
+        @"    \"Styles/GitHub2.css\": [\n"
+        @"      \"62ed816fefa18599c6b8dd0b3d81143459e799e335f77b81ddc165"
+        @"0178ddcefd\",\n"
+        @"      \"d526e3d22730267ba919c1af92c9ed826ccd8b681f516add89de9c"
+        @"e912a79938\"\n"
+        @"    ],\n"
+        @"    \"Themes/Mou Night+.style\": [\n"
+        @"      \"29ac097ec816c3f6c315ede0b0aba97ee0175ff9f83d65e18bb05a"
+        @"2906b5650e\",\n"
+        @"      \"39872c51d2972803efe27d7ea3114ce91c8718a07a3662c95b6a0b"
+        @"a65bed3f95\"\n"
+        @"    ]\n"
+        @"  }\n"
+        @"}\n";
+    NSString *path = [self pathForName:@"shipped-history.json"];
+    NSError *writeError = nil;
+    BOOL wrote = [json writeToFile:path
+                         atomically:YES
+                           encoding:NSUTF8StringEncoding
+                              error:&writeError];
+    XCTAssertTrue(wrote, @"fixture write failed: %@", writeError);
+
+    NSDictionary<NSString *, NSSet<NSString *> *> *result =
+        MPReadHistoryManifestAtPath(path);
+    XCTAssertEqual(result.count, (NSUInteger)3,
+                   @"exactly the three files in the §3.2 example, got "
+                   @"keys: %@", result.allKeys);
+    XCTAssertEqualObjects(result[@"Styles/GitHub.css"],
+        ([NSSet setWithObjects:
+            @"50b145c3b6ae27c8c1f0d2907f83eeade0feabbf082ed9827fd423f"
+            @"a02086328",
+            @"673ad0add6f2ad0283f152bd0c4806fce92ac095a8c69331d71a6f"
+            @"b4835140a1",
+            nil]));
+    XCTAssertEqualObjects(result[@"Styles/GitHub2.css"],
+        ([NSSet setWithObjects:
+            @"62ed816fefa18599c6b8dd0b3d81143459e799e335f77b81ddc165"
+            @"0178ddcefd",
+            @"d526e3d22730267ba919c1af92c9ed826ccd8b681f516add89de9c"
+            @"e912a79938",
+            nil]));
+    XCTAssertEqualObjects(result[@"Themes/Mou Night+.style"],
+        ([NSSet setWithObjects:
+            @"29ac097ec816c3f6c315ede0b0aba97ee0175ff9f83d65e18bb05a"
+            @"2906b5650e",
+            @"39872c51d2972803efe27d7ea3114ce91c8718a07a3662c95b6a0b"
+            @"a65bed3f95",
+            nil]));
+}
+
+#pragma mark - MPBundledResourceActionForFile truth table
+
+- (void)testActionSkipsNonRegularTargetEvenWhenBundleDigestMissing
+{
+    MPBundledResourceAction result = MPBundledResourceActionForFile(
+        MPBundledResourceTargetNonRegular, nil, nil, kHexProvenance, nil);
+    XCTAssertEqual(result, MPBundledResourceActionSkip,
+                   @"row 10 must win even when bundleDigest is nil (row 7 "
+                   @"must not fire first)");
+
+    // Discriminating pair: flip only targetState away from NonRegular,
+    // keeping bundleDigest nil. This must now Forget (row 7), proving the
+    // Skip above tracked targetState rather than being a constant answer.
+    MPBundledResourceAction result2 = MPBundledResourceActionForFile(
+        MPBundledResourceTargetAbsent, nil, nil, kHexProvenance, nil);
+    XCTAssertEqual(result2, MPBundledResourceActionForget,
+                   @"with bundleDigest nil and targetState no longer "
+                   @"NonRegular, row 7 must fire");
+}
+
+- (void)testActionForgetsWhenBundleDigestIsNil
+{
+    MPBundledResourceAction result = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexTarget, nil, kHexProvenance,
+        nil);
+    XCTAssertEqual(result, MPBundledResourceActionForget,
+                   @"row 7: no longer shipped in the bundle, must Forget "
+                   @"the entry without touching the file");
+}
+
+- (void)testActionCopiesWhenTargetAbsent
+{
+    MPBundledResourceAction result = MPBundledResourceActionForFile(
+        MPBundledResourceTargetAbsent, nil, kHexBundle, nil, nil);
+    XCTAssertEqual(result, MPBundledResourceActionCopy,
+                   @"rows 1/2/6: file shipped, absent on disk, must Copy");
+}
+
+- (void)testActionRefreshesWhenMatchesProvenanceButNotBundle
+{
+    // targetDigest matches provenance (so it's pristine) but not the
+    // current bundle contents (rows 3/12).
+    MPBundledResourceAction result = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexV1, kHexV2, kHexV1, nil);
+    XCTAssertEqual(result, MPBundledResourceActionRefresh,
+                   @"pristine (matches provenance) and differing from "
+                   @"bundle must Refresh");
+}
+
+- (void)testActionRecordsOnlyWhenEqualsBundle
+{
+    MPBundledResourceAction result = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexBundle, kHexBundle, nil, nil);
+    XCTAssertEqual(result, MPBundledResourceActionRecordOnly,
+                   @"row 4: already byte-equal to the bundle, must "
+                   @"RecordOnly (no file write, backfill provenance)");
+}
+
+- (void)testActionSkipsWhenMatchesNothing
+{
+    NSSet<NSString *> *history = [NSSet setWithObject:kHexV1];
+    MPBundledResourceAction result = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexModified, kHexV2, kHexV1,
+        history);
+    XCTAssertEqual(result, MPBundledResourceActionSkip,
+                   @"row 5: matches provenance, bundle, nor history — must "
+                   @"be left alone as modified");
+
+    // Discriminating pair: add the exact targetDigest to history so it
+    // becomes pristine. Result must change to Refresh (differs from
+    // bundle), proving the Skip above depended on the actual inputs rather
+    // than being a constant answer.
+    NSSet<NSString *> *historyWithMatch =
+        [NSSet setWithObjects:kHexV1, kHexModified, nil];
+    MPBundledResourceAction result2 = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexModified, kHexV2, kHexV1,
+        historyWithMatch);
+    XCTAssertEqual(result2, MPBundledResourceActionRefresh,
+                   @"once targetDigest is in history it becomes pristine; "
+                   @"differing from bundle must Refresh");
+}
+
+- (void)testActionTreatsHistoryMatchAsPristine
+{
+    // No provenance entry at all (rows 8/9 territory); the file's digest
+    // is found in shipped history instead, and differs from the current
+    // bundle, so it must be classified pristine-but-stale and refreshed.
+    NSSet<NSString *> *history = [NSSet setWithObject:kHexV1];
+    MPBundledResourceAction result = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexV1, kHexV2, nil, history);
+    XCTAssertEqual(result, MPBundledResourceActionRefresh,
+                   @"row 8: history match without a provenance entry must "
+                   @"still be treated as pristine and refreshed to current "
+                   @"bundle bytes");
+}
+
+- (void)testActionTreatsBundleMatchAsPristineWithoutProvenance
+{
+    // No provenance entry, but the on-disk bytes already equal the
+    // bundle's, which by itself is sufficient to classify pristine.
+    MPBundledResourceAction result = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexBundle, kHexBundle, nil,
+        [NSSet setWithObject:kHexV3]);
+    XCTAssertEqual(result, MPBundledResourceActionRecordOnly,
+                   @"row 8: no provenance entry, but target already equals "
+                   @"bundle bytes, must RecordOnly — provenance is "
+                   @"unnecessary when the bundle match alone proves "
+                   @"pristine-ness");
+}
+
+- (void)testActionTreatsNilHistoryAsEmpty
+{
+    MPBundledResourceAction withNilHistory = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexBundle, kHexBundle, nil, nil);
+    MPBundledResourceAction withEmptyHistory = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexBundle, kHexBundle, nil,
+        [NSSet set]);
+    XCTAssertEqual(withNilHistory, withEmptyHistory,
+                   @"nil historyDigests must behave identically to an "
+                   @"empty NSSet");
+    XCTAssertEqual(withNilHistory, MPBundledResourceActionRecordOnly,
+                   @"sanity check on the shared result: bundle match with "
+                   @"no history must still RecordOnly");
+}
+
+- (void)testActionRejectsUppercaseHexDigestMatch
+{
+    NSString *upperProvenance = [kHexV1 uppercaseString];
+    MPBundledResourceAction caseMismatch = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexV1, kHexV2, upperProvenance,
+        nil);
+    XCTAssertEqual(caseMismatch, MPBundledResourceActionSkip,
+                   @"§7.1: an uppercase-hex provenanceDigest must NOT "
+                   @"case-insensitively match a lowercase targetDigest — "
+                   @"comparison must be exact string equality");
+
+    // Discriminating pair: the exact same digest, same case, must match.
+    MPBundledResourceAction caseMatch = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexV1, kHexV2, kHexV1, nil);
+    XCTAssertEqual(caseMatch, MPBundledResourceActionRefresh,
+                   @"the same digest in matching (lowercase) case must be "
+                   @"treated as pristine, proving the Skip above was "
+                   @"caused specifically by the case mismatch");
+}
+
+- (void)testActionSkipsRegularTargetWithNilDigest
+{
+    // Defensive totality guard: targetState == Regular with a nil
+    // targetDigest is unreachable from the real orchestration, but the
+    // function is specified as total and must answer safely (Skip) here.
+    MPBundledResourceAction result = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, nil, kHexBundle, nil, nil);
+    XCTAssertEqual(result, MPBundledResourceActionSkip,
+                   @"an unclassifiable Regular target with a nil digest "
+                   @"must be defensively skipped before any other check");
+
+    // Discriminating pair: identical inputs except targetDigest is now
+    // supplied (and equals bundleDigest). Result must flip away from Skip,
+    // proving the guard is keyed on targetDigest == nil specifically.
+    MPBundledResourceAction withDigest = MPBundledResourceActionForFile(
+        MPBundledResourceTargetRegular, kHexBundle, kHexBundle, nil, nil);
+    XCTAssertEqual(withDigest, MPBundledResourceActionRecordOnly,
+                   @"supplying targetDigest must flip the result away from "
+                   @"Skip");
+}
+
+@end

--- a/MacDownTests/MPBundledResourceSyncTests.m
+++ b/MacDownTests/MPBundledResourceSyncTests.m
@@ -33,6 +33,7 @@
 #import <unistd.h>
 #import <CommonCrypto/CommonDigest.h>
 #import "MPBundledResourceSync.h"
+#import "MPUtilities.h"
 
 @interface MPBundledResourceSyncTests : XCTestCase
 @property (strong) NSString *tempDir;
@@ -1477,6 +1478,93 @@
                       @"Every written path must resolve under the injected "
                       @"fake user root, never a real one: %@", fullPath);
     }
+}
+
+#pragma mark - The real call site's assumption about the app bundle
+
+// Every other test in this file drives MPSyncBundledResourcesInPaths through
+// injected fake roots. The one call site that ships does not:
+//
+//     MPSyncBundledResourcesInPaths(MPDataDirectory(nil),
+//                                   [NSBundle mainBundle].resourcePath);
+//     — MPMainController.m:274-278
+//
+// and it depends on Styles/ and Themes/ being readable directories directly
+// inside that resource path. If a resource-layout change in project.pbxproj
+// ever moved, renamed or nested either of them, the sync would abort (see
+// MPBundledResourceSync.h on `aborted`: "either of the bundle's Styles and
+// Themes directories fails to enumerate"), write nothing, and never refresh
+// anybody's styles again — while every fake-root test above stayed green.
+// That is exactly the class of silent failure that
+// MacDownTests/MPTerminalPreferencesTests.m exhibits today, and this test is
+// the tripwire for it.
+//
+// WHY THIS TEST IS EXEMPT FROM makeRootsUser:bundle:. The temp-root safety
+// factory is mandatory for anything that calls the sync, because the sync
+// writes. This test never calls the sync and never writes anything: it only
+// reads the app bundle's own layout. The subject under test IS the real
+// bundle, so handing it a temp root would defeat the entire point. Calling
+// MPSyncBundledResourcesInPaths with the real roots — which would rewrite a
+// developer's actual ~/Library/Application Support themes — is precisely what
+// the factory exists to prevent, and this test deliberately does not do it.
+// The guard is not being bypassed; there is nothing here for it to guard.
+//
+// MacDownTests is app-hosted (TEST_HOST = BUNDLE_LOADER = MacDown 3000.app),
+// so [NSBundle mainBundle] here is the very bundle -[MPMainController
+// copyFiles] sees at launch.
+- (void)testAppBundleLaysOutStylesAndThemesWhereTheRealSyncCallLooks
+{
+    NSString *bundleResourceRoot = [NSBundle mainBundle].resourcePath;
+    XCTAssertNotNil(bundleResourceRoot,
+                    @"The app-hosted main bundle must have a resource path");
+
+    for (NSString *dirName in @[kMPStylesDirectoryName, kMPThemesDirectoryName])
+    {
+        NSString *dirPath =
+            [bundleResourceRoot stringByAppendingPathComponent:dirName];
+
+        NSError *attributesError = nil;
+        NSDictionary *attributes = [self.fm attributesOfItemAtPath:dirPath
+                                                             error:&attributesError];
+        XCTAssertNotNil(attributes,
+                        @"%@/ must exist as a direct child of the bundle's "
+                        @"resource path %@: %@",
+                        dirName, bundleResourceRoot, attributesError);
+        XCTAssertEqualObjects(attributes[NSFileType], NSFileTypeDirectory,
+                              @"%@/ must be a real directory, not a file or "
+                              @"a link", dirName);
+
+        NSError *enumerationError = nil;
+        NSArray<NSString *> *entries =
+            [self.fm contentsOfDirectoryAtPath:dirPath error:&enumerationError];
+        XCTAssertNotNil(entries,
+                        @"%@/ must be readable — an enumeration failure here "
+                        @"aborts the entire sync: %@",
+                        dirName, enumerationError);
+
+        NSUInteger regularFileCount = 0;
+        for (NSString *entry in entries)
+        {
+            NSString *entryPath = [dirPath stringByAppendingPathComponent:entry];
+            NSDictionary *entryAttributes =
+                [self.fm attributesOfItemAtPath:entryPath error:NULL];
+            if ([entryAttributes[NSFileType] isEqual:NSFileTypeRegular])
+                regularFileCount++;
+        }
+        XCTAssertGreaterThan(regularFileCount, 0u,
+                             @"%@/ must ship at least one regular file, or "
+                             @"the sync has nothing to copy or refresh",
+                             dirName);
+    }
+
+    // The shipped-history manifest lives at the same root and is what reaches
+    // the existing installed base (contract §5). If it ever stopped being
+    // copied into the bundle it would simply read as empty, every already
+    // installed user's files would classify as modified, and the refresh would
+    // silently never reach them — the same green-but-broken failure.
+    NSString *historyPath = MPHistoryManifestPathInRoot(bundleResourceRoot);
+    XCTAssertTrue([self.fm fileExistsAtPath:historyPath],
+                  @"%@ must ship inside the app bundle", historyPath);
 }
 
 @end

--- a/MacDownTests/MPBundledResourceSyncTests.m
+++ b/MacDownTests/MPBundledResourceSyncTests.m
@@ -486,6 +486,50 @@
                           @"pruned (§7.5), got keys: %@", report.manifest.allKeys);
 }
 
+// A provenance entry is the only thing that distinguishes "we shipped this
+// once and no longer do" (a genuine row 7 orphan) from "the user made their
+// own style" — help.md:293 explicitly invites the latter. Counting the
+// user's own file as an orphan would put it in the summary log on every
+// launch forever, which contract §9 forbids.
+- (void)testRow07UserAuthoredFileWithNoProvenanceIsNotAnOrphan
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"a" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSString *aPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"a" toPath:aPath];
+    // Removed from the bundle, but we placed it once: a real orphan.
+    NSString *gonePath = [userRoot stringByAppendingPathComponent:@"Styles/GONE.css"];
+    [self writeString:@"old" toPath:gonePath];
+    // Never shipped by us at all: the user's own file.
+    NSString *minePath = [userRoot stringByAppendingPathComponent:@"Styles/Mine.css"];
+    [self writeString:@"mine" toPath:minePath];
+    [self writeProvenanceFiles:@{@"Styles/A.css": [self sha256OfString:@"a"],
+                                  @"Styles/GONE.css": [self sha256OfString:@"old"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    NSDate *mineMod = [self modDateAtPath:minePath];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqual(report.orphanedCount, 1u,
+                   @"Only Styles/GONE.css had a provenance entry, so only it "
+                   @"is an orphan; Styles/Mine.css is the user's own file");
+    XCTAssertTrue([self.fm fileExistsAtPath:minePath],
+                  @"The user's own file must be left on disk (row 7)");
+    XCTAssertEqualObjects([self.fm contentsAtPath:minePath],
+                          [@"mine" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertEqualObjects([self modDateAtPath:minePath], mineMod,
+                          @"The user's own file must not be written to");
+    XCTAssertNil(report.manifest[@"Styles/Mine.css"],
+                 @"A file we never placed gets no provenance entry (row 7)");
+    XCTAssertEqualObjects([self.fm contentsAtPath:gonePath],
+                          [@"old" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"The genuine orphan is still never deleted");
+}
+
 #pragma mark - Row 8: provenance manifest missing
 
 - (void)testRow08ManifestMissingClassifiesFromBundleAndHistory
@@ -936,6 +980,51 @@
                           @"design §4.2 step 6)");
     XCTAssertFalse(report2.manifestWritten);
     XCTAssertEqual(report2.copiedCount + report2.refreshedCount, 0u);
+}
+
+#pragma mark - §9: the summary log gate is silent in the steady state
+
+// The summary NSLog fires when copied + refreshed > 0, orphanedCount > 0, or
+// the manifest was rewritten. NSLog output is awkward to capture, so this
+// asserts the observable report the gate is computed from: for a user with a
+// custom style, every term must be zero/false on the second and every later
+// launch.
+- (void)testSteadyStateWithUserAuthoredFileLeavesLogGateClosed
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"a" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    // The user's own style, present before the very first sync and never
+    // shipped by us.
+    NSString *minePath = [userRoot stringByAppendingPathComponent:@"Styles/Mine.css"];
+    [self writeString:@"mine" toPath:minePath];
+
+    MPBundledResourceSyncReport *report1 =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    // Sanity: the first sync must actually have done work, or "quiet
+    // afterwards" would be satisfiable by a sync that never does anything.
+    XCTAssertEqual(report1.copiedCount, 1u,
+                   @"First sync must actually have copied Styles/A.css");
+    XCTAssertTrue(report1.manifestWritten);
+    XCTAssertEqual(report1.orphanedCount, 0u,
+                   @"The user's own file is not an orphan even on the first "
+                   @"sync — it never had a provenance entry to drop");
+
+    NSDate *mineMod1 = [self modDateAtPath:minePath];
+
+    MPBundledResourceSyncReport *report2 =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqual(report2.copiedCount + report2.refreshedCount, 0u);
+    XCTAssertEqual(report2.orphanedCount, 0u,
+                   @"A user-authored file must not be counted as an orphan, "
+                   @"or the summary log fires on every launch forever (§9)");
+    XCTAssertFalse(report2.manifestWritten);
+    XCTAssertEqualObjects([self modDateAtPath:minePath], mineMod1,
+                          @"The user's own file must still be untouched");
+    XCTAssertNil(report2.manifest[@"Styles/Mine.css"]);
 }
 
 #pragma mark - §7.4: symlinked directories

--- a/MacDownTests/MPBundledResourceSyncTests.m
+++ b/MacDownTests/MPBundledResourceSyncTests.m
@@ -1,0 +1,1353 @@
+//
+//  MPBundledResourceSyncTests.m
+//  MacDown 3000
+//
+//  Filesystem-orchestrating tests for MPSyncBundledResourcesInPaths: the
+//  twelve-row decision table end to end (design §9.1), plus idempotence,
+//  symlinked directories, the bundle-enumeration guard, nil roots,
+//  permissions, case sensitivity, and the mandatory temp-root safety guard
+//  (design §9.2, contract §11, design §6 R6).
+//
+//  Written against the design (issue-548-design.md) and the contract
+//  (issue-548-requirements-v2.md), NOT against the implementation, which is
+//  a deliberate stub at the time these tests were written. Every test here
+//  must fail on assertions against the real behavior described in the
+//  contract's twelve-row decision table (contract §6) until
+//  MPBundledResourceSync.m is implemented.
+//
+//  Related to GitHub issue #548.
+//
+
+#import <XCTest/XCTest.h>
+#import <sys/stat.h>
+#import <CommonCrypto/CommonDigest.h>
+#import "MPBundledResourceSync.h"
+
+@interface MPBundledResourceSyncTests : XCTestCase
+@property (strong) NSString *tempDir;
+@property (strong) NSFileManager *fm;
+@end
+
+@implementation MPBundledResourceSyncTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.fm = [NSFileManager defaultManager];
+    self.tempDir = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+    [self.fm createDirectoryAtPath:self.tempDir
+        withIntermediateDirectories:YES
+                         attributes:nil
+                              error:nil];
+}
+
+- (void)tearDown
+{
+    [self.fm removeItemAtPath:self.tempDir error:nil];
+    [super tearDown];
+}
+
+#pragma mark - Mandatory safety infrastructure (contract §11, design §6 R6)
+
+// The predicate a refactor could silently stop guarding with. It must
+// resolve symlinks on BOTH sides of the prefix check (design §6 R6):
+// macOS's /var -> /private/var symlink otherwise makes the check pass or
+// fail inconsistently depending on how the candidate path was spelled.
+- (BOOL)mp_pathIsUnderTemporaryDirectory:(NSString *)path
+{
+    if (path.length == 0)
+        return NO;
+    NSString *resolvedPath = [[NSURL fileURLWithPath:path]
+        URLByResolvingSymlinksInPath].path;
+    NSString *resolvedTempRoot = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+        URLByResolvingSymlinksInPath].path;
+    if (![resolvedPath hasSuffix:@"/"])
+        resolvedPath = [resolvedPath stringByAppendingString:@"/"];
+    if (![resolvedTempRoot hasSuffix:@"/"])
+        resolvedTempRoot = [resolvedTempRoot stringByAppendingString:@"/"];
+    return [resolvedPath hasPrefix:resolvedTempRoot];
+}
+
+// Mandatory shared factory (contract §11): creates <tempDir>/user and
+// <tempDir>/bundle and asserts BOTH resolve under NSTemporaryDirectory()
+// before returning them. If a refactor ever lets a real path reach the
+// sync logic under test, this guard fails loudly and immediately rather
+// than letting a test rewrite a developer's actual themes.
+- (void)makeRootsUser:(NSString **)userRootOut bundle:(NSString **)bundleRootOut
+{
+    NSString *userRoot = [self.tempDir stringByAppendingPathComponent:@"user"];
+    NSString *bundleRoot = [self.tempDir stringByAppendingPathComponent:@"bundle"];
+
+    XCTAssertTrue([self mp_pathIsUnderTemporaryDirectory:userRoot],
+                  @"Refusing to hand out a user root outside "
+                  @"NSTemporaryDirectory(): %@", userRoot);
+    XCTAssertTrue([self mp_pathIsUnderTemporaryDirectory:bundleRoot],
+                  @"Refusing to hand out a bundle root outside "
+                  @"NSTemporaryDirectory(): %@", bundleRoot);
+
+    [self.fm createDirectoryAtPath:bundleRoot
+        withIntermediateDirectories:YES attributes:nil error:nil];
+    // userRoot is deliberately NOT created here — several tests (row 1)
+    // require it to be absent. Callers create it when they need it to exist.
+
+    if (userRootOut) *userRootOut = userRoot;
+    if (bundleRootOut) *bundleRootOut = bundleRoot;
+}
+
+- (void)testTempRootSafetyGuardRejectsNonTemporaryPath
+{
+    XCTAssertFalse([self mp_pathIsUnderTemporaryDirectory:
+                    @"/Users/x/Library/Application Support/MacDown 3000"],
+                   @"The guard must reject a real Application Support path");
+    XCTAssertFalse([self mp_pathIsUnderTemporaryDirectory:nil]);
+    XCTAssertFalse([self mp_pathIsUnderTemporaryDirectory:@""]);
+
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    XCTAssertTrue([self mp_pathIsUnderTemporaryDirectory:userRoot],
+                  @"The factory's own roots must pass the guard");
+    XCTAssertTrue([self mp_pathIsUnderTemporaryDirectory:bundleRoot],
+                  @"The factory's own roots must pass the guard");
+}
+
+#pragma mark - Helpers
+
+- (void)writeString:(NSString *)string toPath:(NSString *)path
+{
+    NSString *dir = [path stringByDeletingLastPathComponent];
+    if (![self.fm fileExistsAtPath:dir])
+        [self.fm createDirectoryAtPath:dir withIntermediateDirectories:YES
+                             attributes:nil error:nil];
+    BOOL ok = [string writeToFile:path atomically:YES
+                          encoding:NSUTF8StringEncoding error:nil];
+    XCTAssertTrue(ok, @"Test setup failed to write %@", path);
+}
+
+// Computes the expected digest independently of the production code under
+// test (MPSHA256HexOfData is itself part of the stub and currently returns
+// nil for everything, so leaning on it here would make every assertion
+// below compare nil against nil and pass vacuously against the stub).
+// CommonCrypto is already an SDK dependency per the contract (§9).
+- (NSString *)sha256OfString:(NSString *)string
+{
+    NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
+    unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
+    NSMutableString *hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++)
+        [hex appendFormat:@"%02x", digest[i]];
+    return [hex copy];
+}
+
+- (NSDictionary *)readManifestJSONRawAtPath:(NSString *)path
+{
+    NSData *data = [NSData dataWithContentsOfFile:path];
+    if (!data)
+        return nil;
+    return [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+}
+
+- (void)writeProvenanceFiles:(NSDictionary<NSString *, NSString *> *)files
+                       atPath:(NSString *)path
+{
+    NSDictionary *doc = @{@"version": @1, @"files": files ?: @{}};
+    NSData *data = [NSJSONSerialization dataWithJSONObject:doc
+                                                     options:NSJSONWritingPrettyPrinted
+                                                       error:nil];
+    NSString *dir = [path stringByDeletingLastPathComponent];
+    if (![self.fm fileExistsAtPath:dir])
+        [self.fm createDirectoryAtPath:dir withIntermediateDirectories:YES
+                             attributes:nil error:nil];
+    [data writeToFile:path atomically:YES];
+}
+
+- (void)writeHistoryFiles:(NSDictionary<NSString *, NSArray<NSString *> *> *)files
+                    atPath:(NSString *)path
+{
+    NSDictionary *doc = @{@"version": @1, @"tags": @[], @"files": files ?: @{}};
+    NSData *data = [NSJSONSerialization dataWithJSONObject:doc
+                                                     options:NSJSONWritingPrettyPrinted
+                                                       error:nil];
+    NSString *dir = [path stringByDeletingLastPathComponent];
+    if (![self.fm fileExistsAtPath:dir])
+        [self.fm createDirectoryAtPath:dir withIntermediateDirectories:YES
+                             attributes:nil error:nil];
+    [data writeToFile:path atomically:YES];
+}
+
+- (unsigned long long)inodeAtPath:(NSString *)path
+{
+    NSDictionary *attrs = [self.fm attributesOfItemAtPath:path error:nil];
+    return [attrs[NSFileSystemFileNumber] unsignedLongLongValue];
+}
+
+- (NSDate *)modDateAtPath:(NSString *)path
+{
+    NSDictionary *attrs = [self.fm attributesOfItemAtPath:path error:nil];
+    return attrs[NSFileModificationDate];
+}
+
+- (NSString *)provenancePathForUserRoot:(NSString *)userRoot
+{
+    return MPProvenanceManifestPathInRoot(userRoot);
+}
+
+- (NSString *)historyPathForBundleRoot:(NSString *)bundleRoot
+{
+    return MPHistoryManifestPathInRoot(bundleRoot);
+}
+
+#pragma mark - Row 1: first run ever, data directory absent
+
+- (void)testRow01FirstRunCreatesDirectoryCopiesAllFilesAndWritesManifest
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    // userRoot intentionally not created — this is the "absent" case.
+    XCTAssertFalse([self.fm fileExistsAtPath:userRoot]);
+
+    [self writeString:@"a" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"t" toPath:[bundleRoot stringByAppendingPathComponent:@"Themes/T.style"]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertNotNil(report);
+    XCTAssertFalse(report.aborted);
+    NSString *aPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    NSString *tPath = [userRoot stringByAppendingPathComponent:@"Themes/T.style"];
+    XCTAssertEqualObjects([self.fm contentsAtPath:aPath],
+                          [@"a" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertEqualObjects([self.fm contentsAtPath:tPath],
+                          [@"t" dataUsingEncoding:NSUTF8StringEncoding]);
+
+    NSDictionary *manifest = report.manifest;
+    XCTAssertEqual(manifest.count, 2u);
+    XCTAssertEqualObjects(manifest[@"Styles/A.css"], [self sha256OfString:@"a"]);
+    XCTAssertEqualObjects(manifest[@"Themes/T.style"], [self sha256OfString:@"t"]);
+    XCTAssertEqual(report.copiedCount, 2u);
+    XCTAssertEqual(report.refreshedCount, 0u);
+}
+
+#pragma mark - Row 2: absent file is copied and recorded
+
+- (void)testRow02AbsentFileIsCopiedAndRecorded
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"a" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"b" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/B.css"]];
+
+    NSString *bPath = [userRoot stringByAppendingPathComponent:@"Styles/B.css"];
+    [self writeString:@"b" toPath:bPath]; // matches bundle bytes exactly
+    [self writeProvenanceFiles:@{@"Styles/B.css": [self sha256OfString:@"b"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    NSDate *bModBefore = [self modDateAtPath:bPath];
+    unsigned long long bInodeBefore = [self inodeAtPath:bPath];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    NSString *aPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    XCTAssertEqualObjects([self.fm contentsAtPath:aPath],
+                          [@"a" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertEqualObjects(report.manifest[@"Styles/A.css"], [self sha256OfString:@"a"]);
+    XCTAssertEqualObjects(report.manifest[@"Styles/B.css"], [self sha256OfString:@"b"]);
+    XCTAssertEqual(report.copiedCount, 1u, @"only A.css should have been copied");
+
+    // B.css must be untouched: same modification date AND same inode.
+    XCTAssertEqualObjects([self modDateAtPath:bPath], bModBefore,
+                          @"B.css's modification date must be unchanged");
+    XCTAssertEqual([self inodeAtPath:bPath], bInodeBefore,
+                   @"B.css's inode must be unchanged");
+}
+
+#pragma mark - Row 3: present, pristine, differing -> refresh
+
+- (void)testRow03PristineDifferingIsRefreshed
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSString *userPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"v1" toPath:userPath];
+    [self writeProvenanceFiles:@{@"Styles/A.css": [self sha256OfString:@"v1"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqualObjects([self.fm contentsAtPath:userPath],
+                          [@"v2" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertEqualObjects(report.manifest[@"Styles/A.css"], [self sha256OfString:@"v2"]);
+    XCTAssertEqual(report.refreshedCount, 1u);
+}
+
+- (void)testRow03RefreshIsAtomicAndLeavesNoResidue
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSString *userPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"v1" toPath:userPath];
+    [self writeProvenanceFiles:@{@"Styles/A.css": [self sha256OfString:@"v1"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    unsigned long long inodeBefore = [self inodeAtPath:userPath];
+
+    MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    unsigned long long inodeAfter = [self inodeAtPath:userPath];
+    XCTAssertNotEqual(inodeBefore, inodeAfter,
+                      @"Refresh must replace the file (new inode), never "
+                      @"truncate-in-place (same inode)");
+
+    NSString *stylesDir = [userRoot stringByAppendingPathComponent:@"Styles"];
+    NSArray<NSString *> *entries = [self.fm contentsOfDirectoryAtPath:stylesDir
+                                                                 error:nil];
+    XCTAssertEqualObjects(entries, @[@"A.css"],
+                          @"No .tmp/.orig/backup residue may remain in the "
+                          @"directory after a refresh, got: %@", entries);
+}
+
+#pragma mark - Row 4: present, pristine, equal to bundle -> record only
+
+- (void)testRow04PristineEqualToBundleIsNotWrittenAndProvenanceBackfilled
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSString *userPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"v2" toPath:userPath];
+    // provenance empty: file exists, but no record of us ever placing it.
+    [self writeProvenanceFiles:@{} atPath:[self provenancePathForUserRoot:userRoot]];
+
+    NSDate *modBefore = [self modDateAtPath:userPath];
+    unsigned long long inodeBefore = [self inodeAtPath:userPath];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqualObjects(report.manifest[@"Styles/A.css"], [self sha256OfString:@"v2"]);
+    XCTAssertEqualObjects([self modDateAtPath:userPath], modBefore,
+                          @"Row 4 must never write to the file: mod date "
+                          @"must be unchanged");
+    XCTAssertEqual([self inodeAtPath:userPath], inodeBefore,
+                   @"Row 4 must never write to the file: inode must be "
+                   @"unchanged");
+    XCTAssertEqual(report.unchangedCount, 1u);
+    XCTAssertEqual(report.refreshedCount, 0u);
+    XCTAssertEqual(report.copiedCount, 0u);
+}
+
+#pragma mark - Row 5: present, modified -> left untouched
+
+- (void)testRow05ModifiedFileIsLeftUntouched
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSString *userPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"MY EDITS" toPath:userPath];
+    [self writeProvenanceFiles:@{@"Styles/A.css": [self sha256OfString:@"v1"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+    [self writeHistoryFiles:@{@"Styles/A.css": @[[self sha256OfString:@"v1"]]}
+                      atPath:[self historyPathForBundleRoot:bundleRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqualObjects([self.fm contentsAtPath:userPath],
+                          [@"MY EDITS" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertEqual(report.modifiedCount, 1u);
+}
+
+- (void)testRow05ModifiedFileGetsNoProvenanceEntryAndNoBackup
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSString *userPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"MY EDITS" toPath:userPath];
+    // A companion pristine, differing file in the same directory: it MUST
+    // be refreshed by this same sync. Without this, every assertion below
+    // is satisfiable by a no-op stub that touches nothing at all — this
+    // file makes that impossible, since the stub cannot produce a
+    // refreshed B.css.
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/B.css"]];
+    NSString *bPath = [userRoot stringByAppendingPathComponent:@"Styles/B.css"];
+    [self writeString:@"v1" toPath:bPath];
+    [self writeProvenanceFiles:@{@"Styles/A.css": [self sha256OfString:@"v1"],
+                                  @"Styles/B.css": [self sha256OfString:@"v1"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+    [self writeHistoryFiles:@{@"Styles/A.css": @[[self sha256OfString:@"v1"]]}
+                      atPath:[self historyPathForBundleRoot:bundleRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqualObjects([self.fm contentsAtPath:bPath],
+                          [@"v2" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"Sanity check that this sync actually performed "
+                          @"real work: the companion pristine file must "
+                          @"have been refreshed");
+    XCTAssertNil(report.manifest[@"Styles/A.css"],
+                @"A modified file must get no provenance entry");
+    NSString *stylesDir = [userRoot stringByAppendingPathComponent:@"Styles"];
+    NSArray<NSString *> *entries =
+        [[self.fm contentsOfDirectoryAtPath:stylesDir error:nil]
+            sortedArrayUsingSelector:@selector(compare:)];
+    XCTAssertEqualObjects(entries, (@[@"A.css", @"B.css"]),
+                          @"No .orig/.bak file may be created, got: %@",
+                          entries);
+}
+
+#pragma mark - Row 6: new bundle file, absent from target -> copy
+
+- (void)testRow06NewBundleFileIsCopied
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"a" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"new" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/NEW.css"]];
+    NSString *aPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"a" toPath:aPath];
+    [self writeProvenanceFiles:@{@"Styles/A.css": [self sha256OfString:@"a"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    NSString *newPath = [userRoot stringByAppendingPathComponent:@"Styles/NEW.css"];
+    XCTAssertEqualObjects([self.fm contentsAtPath:newPath],
+                          [@"new" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertEqualObjects(report.manifest[@"Styles/A.css"], [self sha256OfString:@"a"]);
+    XCTAssertEqualObjects(report.manifest[@"Styles/NEW.css"], [self sha256OfString:@"new"]);
+    XCTAssertEqual(report.copiedCount, 1u);
+}
+
+#pragma mark - Row 7: file removed from bundle -> never delete, drop entry
+
+- (void)testRow07FileRemovedFromBundleIsNeverDeleted
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"a" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSString *aPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"a" toPath:aPath];
+    NSString *gonePath = [userRoot stringByAppendingPathComponent:@"Styles/GONE.css"];
+    [self writeString:@"old" toPath:gonePath];
+    [self writeProvenanceFiles:@{@"Styles/A.css": [self sha256OfString:@"a"],
+                                  @"Styles/GONE.css": [self sha256OfString:@"old"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertTrue([self.fm fileExistsAtPath:gonePath]);
+    XCTAssertEqualObjects([self.fm contentsAtPath:gonePath],
+                          [@"old" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertEqual(report.orphanedCount, 1u);
+}
+
+- (void)testRow07ProvenanceEntryForRemovedFileIsDropped
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"a" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSString *aPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"a" toPath:aPath];
+    NSString *gonePath = [userRoot stringByAppendingPathComponent:@"Styles/GONE.css"];
+    [self writeString:@"old" toPath:gonePath];
+    [self writeProvenanceFiles:@{@"Styles/A.css": [self sha256OfString:@"a"],
+                                  @"Styles/GONE.css": [self sha256OfString:@"old"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqualObjects([NSSet setWithArray:report.manifest.allKeys],
+                          [NSSet setWithArray:@[@"Styles/A.css"]],
+                          @"Styles/GONE.css's provenance entry must be "
+                          @"pruned (§7.5), got keys: %@", report.manifest.allKeys);
+}
+
+#pragma mark - Row 8: provenance manifest missing
+
+- (void)testRow08ManifestMissingClassifiesFromBundleAndHistory
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    // No provenance file written at all.
+
+    [self writeString:@"v3" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"v3" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/B.css"]];
+    [self writeString:@"v3" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/C.css"]];
+
+    NSString *aPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    NSString *bPath = [userRoot stringByAppendingPathComponent:@"Styles/B.css"];
+    NSString *cPath = [userRoot stringByAppendingPathComponent:@"Styles/C.css"];
+    [self writeString:@"v1" toPath:aPath];
+    [self writeString:@"v3" toPath:bPath];
+    [self writeString:@"mine" toPath:cPath];
+
+    [self writeHistoryFiles:@{@"Styles/A.css": @[[self sha256OfString:@"v1"],
+                                                   [self sha256OfString:@"v2"]]}
+                      atPath:[self historyPathForBundleRoot:bundleRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertFalse(report.aborted);
+    XCTAssertEqualObjects([self.fm contentsAtPath:aPath],
+                          [@"v3" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"A.css matches history -> pristine -> refreshed "
+                          @"to current bundle bytes");
+    XCTAssertEqualObjects([self.fm contentsAtPath:bPath],
+                          [@"v3" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"B.css already equals bundle -> untouched");
+    XCTAssertEqualObjects([NSSet setWithArray:report.manifest.allKeys],
+                          [NSSet setWithArray:@[@"Styles/A.css", @"Styles/B.css"]]);
+}
+
+- (void)testRow08ManifestMissingNeverOverwritesUnknownBytes
+{
+    // §6.1 step 3 — the single highest-risk line in the requirements.
+    // Absence of a provenance manifest must NEVER be read as license to
+    // overwrite bytes that cannot be proven pristine.
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    // No provenance file written at all.
+
+    [self writeString:@"v3" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"v3" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/B.css"]];
+    [self writeString:@"v3" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/C.css"]];
+
+    NSString *cPath = [userRoot stringByAppendingPathComponent:@"Styles/C.css"];
+    [self writeString:@"v1" toPath:[userRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"v3" toPath:[userRoot stringByAppendingPathComponent:@"Styles/B.css"]];
+    [self writeString:@"mine" toPath:cPath];
+
+    [self writeHistoryFiles:@{@"Styles/A.css": @[[self sha256OfString:@"v1"],
+                                                   [self sha256OfString:@"v2"]]}
+                      atPath:[self historyPathForBundleRoot:bundleRoot]];
+    // Deliberately: no history entry at all for C.css, and its bytes match
+    // neither the current bundle nor any known history digest.
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqualObjects([self.fm contentsAtPath:cPath],
+                          [@"mine" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"C.css's unrecognised bytes must be left "
+                          @"completely alone");
+    XCTAssertNil(report.manifest[@"Styles/C.css"],
+                @"C.css must get no provenance entry — a manifest entry "
+                @"would misrepresent bytes we did not place");
+    XCTAssertEqual(report.modifiedCount, 1u);
+}
+
+#pragma mark - Row 9: provenance manifest corrupt
+
+- (void)testRow09CorruptManifestBehavesExactlyLikeMissing
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"v3" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"v3" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/B.css"]];
+    [self writeString:@"v3" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/C.css"]];
+    [self writeString:@"v1" toPath:[userRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"v3" toPath:[userRoot stringByAppendingPathComponent:@"Styles/B.css"]];
+    [self writeString:@"mine" toPath:[userRoot stringByAppendingPathComponent:@"Styles/C.css"]];
+    [self writeHistoryFiles:@{@"Styles/A.css": @[[self sha256OfString:@"v1"],
+                                                   [self sha256OfString:@"v2"]]}
+                      atPath:[self historyPathForBundleRoot:bundleRoot]];
+
+    // Truncated JSON, simulating corruption.
+    [self writeString:@"{\"version\":1,\"files\":"
+                toPath:[self provenancePathForUserRoot:userRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertFalse(report.aborted);
+    XCTAssertEqualObjects([NSSet setWithArray:report.manifest.allKeys],
+                          [NSSet setWithArray:@[@"Styles/A.css", @"Styles/B.css"]],
+                          @"A corrupt manifest must degrade to exactly the "
+                          @"row-8 (missing manifest) outcome");
+    XCTAssertEqualObjects([self.fm contentsAtPath:[userRoot stringByAppendingPathComponent:@"Styles/C.css"]],
+                          [@"mine" dataUsingEncoding:NSUTF8StringEncoding]);
+}
+
+- (void)testRow09MalformedShapesAllDegradeToMissing
+{
+    NSArray *malformedBodies = @[
+        @"[1,2,3]",
+        @"\"hello\"",
+        @"{\"version\":99,\"files\":{}}",
+        @"{}",
+        @"",
+    ];
+
+    for (NSString *body in malformedBodies) {
+        NSString *userRoot, *bundleRoot;
+        [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+        [self writeString:@"v3" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+        NSString *aPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+        [self writeString:@"v1" toPath:aPath];
+        [self writeHistoryFiles:@{@"Styles/A.css": @[[self sha256OfString:@"v1"]]}
+                          atPath:[self historyPathForBundleRoot:bundleRoot]];
+        [self writeString:body toPath:[self provenancePathForUserRoot:userRoot]];
+
+        MPBundledResourceSyncReport *report =
+            MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+        XCTAssertFalse(report.aborted, @"body=%@", body);
+        XCTAssertEqualObjects([self.fm contentsAtPath:aPath],
+                              [@"v3" dataUsingEncoding:NSUTF8StringEncoding],
+                              @"body=%@ must degrade to row 8", body);
+        XCTAssertEqualObjects(report.manifest[@"Styles/A.css"],
+                              [self sha256OfString:@"v3"], @"body=%@", body);
+
+        // A valid manifest must exist on disk afterwards.
+        NSDictionary *onDisk = [self readManifestJSONRawAtPath:
+                                [self provenancePathForUserRoot:userRoot]];
+        XCTAssertNotNil(onDisk, @"body=%@ must leave a valid manifest on disk", body);
+
+        [self.fm removeItemAtPath:self.tempDir error:nil];
+        [self.fm createDirectoryAtPath:self.tempDir
+            withIntermediateDirectories:YES attributes:nil error:nil];
+    }
+}
+
+#pragma mark - Row 10: target entry not a regular file
+
+- (void)testRow10SymlinkTargetIsSkippedAndNotFollowed
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self.fm createDirectoryAtPath:userRoot withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+
+    NSString *outsidePath = [self.tempDir stringByAppendingPathComponent:@"outside.css"];
+    [self writeString:@"SECRET" toPath:outsidePath];
+
+    NSString *stylesDir = [userRoot stringByAppendingPathComponent:@"Styles"];
+    [self.fm createDirectoryAtPath:stylesDir withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+    NSString *linkPath = [stylesDir stringByAppendingPathComponent:@"A.css"];
+    NSError *linkError = nil;
+    BOOL linked = [self.fm createSymbolicLinkAtPath:linkPath
+                                 withDestinationPath:outsidePath
+                                               error:&linkError];
+    XCTAssertTrue(linked, @"Test setup: failed to create symlink: %@", linkError);
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    NSDictionary *attrs = [self.fm attributesOfItemAtPath:linkPath error:nil];
+    XCTAssertEqualObjects(attrs[NSFileType], NSFileTypeSymbolicLink,
+                          @"The symlink itself must remain a symlink");
+    XCTAssertEqualObjects([self.fm contentsAtPath:outsidePath],
+                          [@"SECRET" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"We must never write through the symlink");
+    XCTAssertNil(report.manifest[@"Styles/A.css"]);
+    XCTAssertEqual(report.skippedCount, 1u);
+}
+
+- (void)testRow10DirectoryEntryIsSkipped
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self.fm createDirectoryAtPath:userRoot withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+
+    NSString *dirAsFilePath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self.fm createDirectoryAtPath:dirAsFilePath withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+    NSString *innerFilePath = [dirAsFilePath stringByAppendingPathComponent:@"inner.txt"];
+    [self writeString:@"inner" toPath:innerFilePath];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    BOOL isDir = NO;
+    XCTAssertTrue([self.fm fileExistsAtPath:dirAsFilePath isDirectory:&isDir]);
+    XCTAssertTrue(isDir, @"Must still be a directory");
+    XCTAssertTrue([self.fm fileExistsAtPath:innerFilePath],
+                  @"Contents of the directory must remain intact");
+    XCTAssertNil(report.manifest[@"Styles/A.css"]);
+    XCTAssertEqual(report.skippedCount, 1u);
+}
+
+- (void)testRow10FifoEntryIsSkipped
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self.fm createDirectoryAtPath:userRoot withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    // Companion normal file, absent from target, that must be copied by
+    // this same sync — proves this test is not satisfiable by a no-op
+    // stub that never opens anything, FIFO or otherwise.
+    [self writeString:@"n" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/NORMAL.css"]];
+
+    NSString *stylesDir = [userRoot stringByAppendingPathComponent:@"Styles"];
+    [self.fm createDirectoryAtPath:stylesDir withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+    NSString *fifoPath = [stylesDir stringByAppendingPathComponent:@"A.css"];
+
+    int rc = mkfifo(fifoPath.fileSystemRepresentation, 0666);
+    XCTAssertEqual(rc, 0, @"Test setup: mkfifo failed: %s", strerror(errno));
+
+    // The test COMPLETING is itself the proof the sync never opened the
+    // FIFO (open(2) on a FIFO with no reader/writer on the other end
+    // blocks). We do not add our own timeout guard around the call under
+    // test — that would hide a real hang instead of surfacing it as a
+    // test-suite timeout, which is the loud failure we want if this
+    // regresses.
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    // NSFileType for a FIFO can be reported inconsistently by
+    // NSFileManager across OS versions; assert via stat(2) directly for an
+    // unambiguous check that it is still a FIFO and was never opened
+    // and replaced.
+    struct stat st;
+    XCTAssertEqual(stat(fifoPath.fileSystemRepresentation, &st), 0);
+    XCTAssertTrue(S_ISFIFO(st.st_mode), @"Must still be a FIFO");
+    XCTAssertNil(report.manifest[@"Styles/A.css"]);
+    XCTAssertEqual(report.skippedCount, 1u);
+    XCTAssertEqualObjects([self.fm contentsAtPath:
+                           [stylesDir stringByAppendingPathComponent:@"NORMAL.css"]],
+                          [@"n" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"Sanity check that this sync actually performed "
+                          @"real work alongside skipping the FIFO");
+}
+
+#pragma mark - Row 11: per-file I/O failure
+
+- (void)testRow11PerFileFailureIsSkippedAndLoopContinues
+{
+    XCTSkipIf(geteuid() == 0, @"root bypasses mode bits");
+
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self.fm createDirectoryAtPath:userRoot withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/B.css"]];
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/C.css"]];
+
+    NSString *aPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    NSString *bPath = [userRoot stringByAppendingPathComponent:@"Styles/B.css"];
+    NSString *cPath = [userRoot stringByAppendingPathComponent:@"Styles/C.css"];
+    [self writeString:@"v1" toPath:aPath];
+    [self writeString:@"v1" toPath:bPath];
+    [self writeString:@"v1" toPath:cPath];
+    [self writeProvenanceFiles:@{@"Styles/A.css": [self sha256OfString:@"v1"],
+                                  @"Styles/B.css": [self sha256OfString:@"v1"],
+                                  @"Styles/C.css": [self sha256OfString:@"v1"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    NSData *originalBBytes = [self.fm contentsAtPath:bPath];
+    NSError *chmodError = nil;
+    BOOL chmodOk = [self.fm setAttributes:@{NSFilePosixPermissions: @(0000)}
+                              ofItemAtPath:bPath
+                                     error:&chmodError];
+    XCTAssertTrue(chmodOk, @"Test setup: chmod failed: %@", chmodError);
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    // Restore permissions so tearDown can clean up.
+    [self.fm setAttributes:@{NSFilePosixPermissions: @(0644)}
+               ofItemAtPath:bPath error:nil];
+
+    XCTAssertNotNil(report);
+    XCTAssertEqualObjects([self.fm contentsAtPath:aPath],
+                          [@"v2" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertEqualObjects([self.fm contentsAtPath:cPath],
+                          [@"v2" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertNil(report.manifest[@"Styles/B.css"],
+                @"A failed file must get no provenance entry");
+    XCTAssertEqualObjects([self.fm contentsAtPath:bPath], originalBBytes,
+                          @"B.css's original bytes must be unchanged");
+    XCTAssertEqual(report.failedCount, 1u);
+    XCTAssertEqual(report.refreshedCount, 2u);
+}
+
+#pragma mark - Row 12: downgrade
+
+- (void)testRow12DowngradeRevertsPristineFileToOlderBundleBytes
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"v0.3-bytes" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSString *userPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"v0.7-bytes" toPath:userPath];
+    [self writeProvenanceFiles:@{@"Styles/A.css": [self sha256OfString:@"v0.7-bytes"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqualObjects([self.fm contentsAtPath:userPath],
+                          [@"v0.3-bytes" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"§6.2: pristine files always track the currently "
+                          @"installed bundle, even backwards — this is "
+                          @"intended, not a bug");
+    XCTAssertEqualObjects(report.manifest[@"Styles/A.css"],
+                          [self sha256OfString:@"v0.3-bytes"]);
+    XCTAssertEqual(report.refreshedCount, 1u);
+}
+
+- (void)testRow12DowngradeDoesNotRevertModifiedFile
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"v0.3-bytes" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSString *userPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"MY EDITS" toPath:userPath];
+    [self writeProvenanceFiles:@{@"Styles/A.css": [self sha256OfString:@"v0.7-bytes"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqualObjects([self.fm contentsAtPath:userPath],
+                          [@"MY EDITS" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertNil(report.manifest[@"Styles/A.css"]);
+    XCTAssertEqual(report.modifiedCount, 1u);
+}
+
+#pragma mark - §9.2: idempotence (B3)
+
+- (void)testIdempotenceSecondRunPerformsZeroWrites
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Themes/T.style"]];
+
+    // First sync brings the user root to steady state.
+    MPBundledResourceSyncReport *report1 =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    NSString *aPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    NSString *tPath = [userRoot stringByAppendingPathComponent:@"Themes/T.style"];
+    NSString *manifestPath = [self provenancePathForUserRoot:userRoot];
+
+    // Sanity check: the first sync must actually have reached steady
+    // state by doing real work. Without this, "no writes on the second
+    // run" is satisfiable by a stub that never writes on ANY run.
+    XCTAssertEqualObjects([self.fm contentsAtPath:aPath],
+                          [@"v2" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"First sync must actually have copied A.css");
+    XCTAssertEqualObjects([self.fm contentsAtPath:tPath],
+                          [@"v2" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"First sync must actually have copied T.style");
+    XCTAssertEqual(report1.copiedCount, 2u);
+    XCTAssertTrue(report1.manifestWritten);
+
+    NSDate *aMod1 = [self modDateAtPath:aPath];
+    NSDate *tMod1 = [self modDateAtPath:tPath];
+    unsigned long long aInode1 = [self inodeAtPath:aPath];
+    unsigned long long tInode1 = [self inodeAtPath:tPath];
+    NSDate *manifestMod1 = [self modDateAtPath:manifestPath];
+
+    MPBundledResourceSyncReport *report2 =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqualObjects([self modDateAtPath:aPath], aMod1);
+    XCTAssertEqualObjects([self modDateAtPath:tPath], tMod1);
+    XCTAssertEqual([self inodeAtPath:aPath], aInode1);
+    XCTAssertEqual([self inodeAtPath:tPath], tInode1);
+    XCTAssertEqualObjects([self modDateAtPath:manifestPath], manifestMod1,
+                          @"Manifest must not be rewritten on the second run");
+    XCTAssertFalse(report2.manifestWritten);
+    XCTAssertEqual(report2.copiedCount + report2.refreshedCount, 0u);
+}
+
+- (void)testIdempotenceWithModifiedFilePresentStillPerformsZeroWrites
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSString *userPath = [userRoot stringByAppendingPathComponent:@"Styles/A.css"];
+    [self writeString:@"MY EDITS" toPath:userPath];
+    // Companion file, absent from target, that the first sync must
+    // actually copy. Without this, "zero writes on the second run" is
+    // satisfiable by a stub that never writes on either run.
+    [self writeString:@"n" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/NORMAL.css"]];
+    [self writeProvenanceFiles:@{} atPath:[self provenancePathForUserRoot:userRoot]];
+    [self writeHistoryFiles:@{} atPath:[self historyPathForBundleRoot:bundleRoot]];
+
+    MPBundledResourceSyncReport *report1 =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    NSString *normalPath = [userRoot stringByAppendingPathComponent:@"Styles/NORMAL.css"];
+    XCTAssertEqualObjects([self.fm contentsAtPath:normalPath],
+                          [@"n" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"First sync must actually have copied the "
+                          @"companion file");
+    XCTAssertEqual(report1.copiedCount, 1u);
+    XCTAssertEqual(report1.modifiedCount, 1u);
+
+    NSString *manifestPath = [self provenancePathForUserRoot:userRoot];
+    NSDate *manifestMod1 = [self modDateAtPath:manifestPath];
+    NSDate *fileMod1 = [self modDateAtPath:userPath];
+    NSDate *normalMod1 = [self modDateAtPath:normalPath];
+
+    MPBundledResourceSyncReport *report2 =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqualObjects([self modDateAtPath:userPath], fileMod1);
+    XCTAssertEqualObjects([self modDateAtPath:normalPath], normalMod1);
+    XCTAssertEqualObjects([self modDateAtPath:manifestPath], manifestMod1,
+                          @"A permanently modified file must not cause a "
+                          @"manifest rewrite on every run (log-spam trap, "
+                          @"design §4.2 step 6)");
+    XCTAssertFalse(report2.manifestWritten);
+    XCTAssertEqual(report2.copiedCount + report2.refreshedCount, 0u);
+}
+
+#pragma mark - §7.4: symlinked directories
+
+- (void)testSymlinkedStylesDirectoryIsNotClobbered
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self.fm createDirectoryAtPath:userRoot withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/PRISTINE.css"]];
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/MOD.css"]];
+
+    NSString *externalDir = [self.tempDir stringByAppendingPathComponent:@"external-styles"];
+    [self.fm createDirectoryAtPath:externalDir withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+    NSString *pristinePath = [externalDir stringByAppendingPathComponent:@"PRISTINE.css"];
+    NSString *modPath = [externalDir stringByAppendingPathComponent:@"MOD.css"];
+    [self writeString:@"v1" toPath:pristinePath];
+    [self writeString:@"MY EDITS" toPath:modPath];
+
+    [self writeProvenanceFiles:@{@"Styles/PRISTINE.css": [self sha256OfString:@"v1"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    NSString *stylesLinkPath = [userRoot stringByAppendingPathComponent:@"Styles"];
+    NSError *linkError = nil;
+    BOOL linked = [self.fm createSymbolicLinkAtPath:stylesLinkPath
+                                 withDestinationPath:externalDir
+                                               error:&linkError];
+    XCTAssertTrue(linked, @"Test setup: %@", linkError);
+
+    MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    NSDictionary *linkAttrs = [self.fm attributesOfItemAtPath:stylesLinkPath
+                                                          error:nil];
+    XCTAssertEqualObjects(linkAttrs[NSFileType], NSFileTypeSymbolicLink,
+                          @"Styles must remain a symlink — the "
+                          @"directory-absent branch must never fire");
+    NSString *linkDest = [self.fm destinationOfSymbolicLinkAtPath:stylesLinkPath
+                                                              error:nil];
+    XCTAssertEqualObjects([linkDest stringByStandardizingPath],
+                          [externalDir stringByStandardizingPath]);
+
+    XCTAssertEqualObjects([self.fm contentsAtPath:pristinePath],
+                          [@"v2" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"The pristine file must be refreshed INSIDE the "
+                          @"linked directory");
+    XCTAssertEqualObjects([self.fm contentsAtPath:modPath],
+                          [@"MY EDITS" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"The modified file must survive");
+}
+
+- (void)testSymlinkedUserRootIsNotClobbered
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    NSString *realUserDir = [self.tempDir stringByAppendingPathComponent:@"real-user-root"];
+    [self.fm createDirectoryAtPath:realUserDir withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+
+    NSError *linkError = nil;
+    BOOL linked = [self.fm createSymbolicLinkAtPath:userRoot
+                                 withDestinationPath:realUserDir
+                                               error:&linkError];
+    XCTAssertTrue(linked, @"Test setup: %@", linkError);
+    XCTAssertTrue([self mp_pathIsUnderTemporaryDirectory:userRoot],
+                  @"The symlink path itself must still resolve under "
+                  @"NSTemporaryDirectory() — required for this test to be "
+                  @"a valid use of the safety factory");
+
+    [self writeString:@"a" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+
+    MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    NSDictionary *attrs = [self.fm attributesOfItemAtPath:userRoot error:nil];
+    XCTAssertEqualObjects(attrs[NSFileType], NSFileTypeSymbolicLink,
+                          @"userRoot symlink must survive");
+    NSString *realAPath = [realUserDir stringByAppendingPathComponent:@"Styles/A.css"];
+    XCTAssertEqualObjects([self.fm contentsAtPath:realAPath],
+                          [@"a" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"Files must land through the symlink into the "
+                          @"real directory");
+}
+
+- (void)testSymlinkInsideLinkedDirectoryIsStillSkipped
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self.fm createDirectoryAtPath:userRoot withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+
+    [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+
+    NSString *externalDir = [self.tempDir stringByAppendingPathComponent:@"external-styles-2"];
+    [self.fm createDirectoryAtPath:externalDir withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+    NSString *outsidePath = [self.tempDir stringByAppendingPathComponent:@"outside2.css"];
+    [self writeString:@"SECRET" toPath:outsidePath];
+    NSString *innerLinkPath = [externalDir stringByAppendingPathComponent:@"A.css"];
+    [self.fm createSymbolicLinkAtPath:innerLinkPath
+                   withDestinationPath:outsidePath error:nil];
+
+    NSString *stylesLinkPath = [userRoot stringByAppendingPathComponent:@"Styles"];
+    [self.fm createSymbolicLinkAtPath:stylesLinkPath
+                   withDestinationPath:externalDir error:nil];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    NSDictionary *innerAttrs = [self.fm attributesOfItemAtPath:innerLinkPath
+                                                           error:nil];
+    XCTAssertEqualObjects(innerAttrs[NSFileType], NSFileTypeSymbolicLink,
+                          @"An entry inside a linked directory that is "
+                          @"itself a symlink must still be skipped (row 10)");
+    XCTAssertNil(report.manifest[@"Styles/A.css"]);
+}
+
+#pragma mark - Bundle-side non-regular entries
+
+- (void)testNonRegularBundleEntryIsIgnored
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    NSString *stylesBundleDir = [bundleRoot stringByAppendingPathComponent:@"Styles"];
+    [self.fm createDirectoryAtPath:stylesBundleDir withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+    NSString *outsidePath = [self.tempDir stringByAppendingPathComponent:@"bundle-outside.css"];
+    [self writeString:@"x" toPath:outsidePath];
+    NSString *bundleLinkPath = [stylesBundleDir stringByAppendingPathComponent:@"LINK.css"];
+    [self.fm createSymbolicLinkAtPath:bundleLinkPath
+                   withDestinationPath:outsidePath error:nil];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertNil(report.manifest[@"Styles/LINK.css"]);
+    NSString *targetLinkPath = [userRoot stringByAppendingPathComponent:@"Styles/LINK.css"];
+    XCTAssertFalse([self.fm fileExistsAtPath:targetLinkPath],
+                   @"A symlink in the bundle must not be copied");
+    XCTAssertEqual(report.failedCount, 0u,
+                   @"A non-regular bundle entry is ignored, not a failure");
+}
+
+#pragma mark - §9.2: bundle-enumeration guard (R4)
+
+- (void)testBundleEnumerationFailureDoesNotEraseProvenance
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self.fm createDirectoryAtPath:userRoot withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+
+    [self writeString:@"a" toPath:[userRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    NSDictionary *provenanceFiles = @{@"Styles/A.css": [self sha256OfString:@"a"]};
+    NSString *manifestPath = [self provenancePathForUserRoot:userRoot];
+    [self writeProvenanceFiles:provenanceFiles atPath:manifestPath];
+    NSData *manifestBytesBefore = [NSData dataWithContentsOfFile:manifestPath];
+
+    NSString *nonexistentBundleRoot = [self.tempDir
+        stringByAppendingPathComponent:@"does-not-exist"];
+    XCTAssertTrue([self mp_pathIsUnderTemporaryDirectory:nonexistentBundleRoot]);
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, nonexistentBundleRoot);
+
+    XCTAssertTrue(report.aborted);
+    NSData *manifestBytesAfter = [NSData dataWithContentsOfFile:manifestPath];
+    XCTAssertEqualObjects(manifestBytesAfter, manifestBytesBefore,
+                          @"Manifest bytes must be byte-identical after an "
+                          @"enumeration failure");
+    XCTAssertEqualObjects([self.fm contentsAtPath:
+                           [userRoot stringByAppendingPathComponent:@"Styles/A.css"]],
+                          [@"a" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"No user file may be touched");
+}
+
+- (void)testPartialBundleEnumerationFailureDoesNotEraseProvenance
+{
+    // The test that catches the bug the design review found: an
+    // enumeration failure limited to ONE bundle directory (here, Themes/)
+    // must still abort the ENTIRE sync without writing a manifest, rather
+    // than silently erasing only that directory's provenance.
+    XCTSkipIf(geteuid() == 0, @"root bypasses mode bits");
+
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self.fm createDirectoryAtPath:userRoot withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+
+    NSString *stylesBundleDir = [bundleRoot stringByAppendingPathComponent:@"Styles"];
+    NSString *themesBundleDir = [bundleRoot stringByAppendingPathComponent:@"Themes"];
+    [self writeString:@"a" toPath:[stylesBundleDir stringByAppendingPathComponent:@"A.css"]];
+    [self.fm createDirectoryAtPath:themesBundleDir withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+    [self writeString:@"t" toPath:[themesBundleDir stringByAppendingPathComponent:@"T.style"]];
+
+    [self writeString:@"a" toPath:[userRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"t" toPath:[userRoot stringByAppendingPathComponent:@"Themes/T.style"]];
+
+    NSDictionary *provenanceFiles = @{
+        @"Styles/A.css": [self sha256OfString:@"a"],
+        @"Themes/T.style": [self sha256OfString:@"t"],
+    };
+    NSString *manifestPath = [self provenancePathForUserRoot:userRoot];
+    [self writeProvenanceFiles:provenanceFiles atPath:manifestPath];
+    NSData *manifestBytesBefore = [NSData dataWithContentsOfFile:manifestPath];
+
+    // Styles/ stays readable; Themes/ becomes unreadable.
+    NSError *chmodError = nil;
+    BOOL chmodOk = [self.fm setAttributes:@{NSFilePosixPermissions: @(0000)}
+                              ofItemAtPath:themesBundleDir
+                                     error:&chmodError];
+    XCTAssertTrue(chmodOk, @"Test setup: chmod failed: %@", chmodError);
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    // Restore permissions so tearDown can clean up.
+    [self.fm setAttributes:@{NSFilePosixPermissions: @(0755)}
+               ofItemAtPath:themesBundleDir error:nil];
+
+    XCTAssertTrue(report.aborted,
+                  @"A single unreadable bundle directory must abort the "
+                  @"whole sync, per design §4.2 step 2 / contract R4");
+    NSData *manifestBytesAfter = [NSData dataWithContentsOfFile:manifestPath];
+    XCTAssertEqualObjects(manifestBytesAfter, manifestBytesBefore,
+                          @"Manifest bytes must be byte-identical — "
+                          @"including the Styles/ entry, which enumerated "
+                          @"successfully — after a partial enumeration "
+                          @"failure");
+    XCTAssertEqualObjects([self.fm contentsAtPath:
+                           [userRoot stringByAppendingPathComponent:@"Styles/A.css"]],
+                          [@"a" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertEqualObjects([self.fm contentsAtPath:
+                           [userRoot stringByAppendingPathComponent:@"Themes/T.style"]],
+                          [@"t" dataUsingEncoding:NSUTF8StringEncoding]);
+}
+
+- (void)testEmptyBundleDirectoryIsNotTreatedAsEnumerationFailure
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self.fm createDirectoryAtPath:userRoot withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+
+    NSString *stylesBundleDir = [bundleRoot stringByAppendingPathComponent:@"Styles"];
+    NSString *themesBundleDir = [bundleRoot stringByAppendingPathComponent:@"Themes"];
+    [self writeString:@"a" toPath:[stylesBundleDir stringByAppendingPathComponent:@"A.css"]];
+    // Themes/ exists, is readable, and genuinely contains zero files.
+    [self.fm createDirectoryAtPath:themesBundleDir withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+
+    NSString *themeUserPath = [userRoot stringByAppendingPathComponent:@"Themes/OldTheme.style"];
+    [self writeString:@"old" toPath:themeUserPath];
+    [self writeProvenanceFiles:@{@"Themes/OldTheme.style": [self sha256OfString:@"old"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertFalse(report.aborted,
+                   @"A directory that genuinely enumerates to zero entries "
+                   @"is not an enumeration failure and must not abort");
+    XCTAssertTrue([self.fm fileExistsAtPath:themeUserPath],
+                  @"The now-orphaned theme file must be left on disk");
+    XCTAssertNil(report.manifest[@"Themes/OldTheme.style"],
+                @"It is orphaned (row 7): dropped from the manifest, not "
+                @"deleted from disk");
+    XCTAssertEqual(report.orphanedCount, 1u);
+}
+
+#pragma mark - §9.2: nil roots
+
+- (void)testNilRootsAreNoOp
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self writeString:@"a" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+
+    MPBundledResourceSyncReport *bothNil = MPSyncBundledResourcesInPaths(nil, nil);
+    XCTAssertNotNil(bothNil);
+    XCTAssertTrue(bothNil.aborted);
+    XCTAssertEqual(bothNil.manifest.count, 0u);
+
+    MPBundledResourceSyncReport *userNil = MPSyncBundledResourcesInPaths(nil, bundleRoot);
+    XCTAssertTrue(userNil.aborted);
+    XCTAssertEqual(userNil.manifest.count, 0u);
+
+    MPBundledResourceSyncReport *bundleNil = MPSyncBundledResourcesInPaths(userRoot, nil);
+    XCTAssertTrue(bundleNil.aborted);
+    XCTAssertEqual(bundleNil.manifest.count, 0u);
+
+    XCTAssertFalse([self.fm fileExistsAtPath:userRoot],
+                   @"Nothing must be created when either root is nil");
+}
+
+#pragma mark - §9.2: permissions
+
+- (void)testPermissionDeniedOnManifestWriteIsNonFatal
+{
+    XCTSkipIf(geteuid() == 0, @"root bypasses mode bits");
+
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self.fm createDirectoryAtPath:userRoot withIntermediateDirectories:YES
+                         attributes:nil error:nil];
+    [self writeString:@"a" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    [self writeString:@"a" toPath:[userRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+
+    // Sync once so the manifest exists, then lock the directory down so a
+    // rewrite attempt fails.
+    MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    // A new bundle file forces a manifest change on the next run.
+    [self writeString:@"b" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/B.css"]];
+
+    NSError *chmodError = nil;
+    BOOL chmodOk = [self.fm setAttributes:@{NSFilePosixPermissions: @(0500)}
+                              ofItemAtPath:userRoot
+                                     error:&chmodError];
+    XCTAssertTrue(chmodOk, @"Test setup: chmod failed: %@", chmodError);
+
+    MPBundledResourceSyncReport *report = nil;
+    XCTAssertNoThrow(report = MPSyncBundledResourcesInPaths(userRoot, bundleRoot));
+
+    [self.fm setAttributes:@{NSFilePosixPermissions: @(0755)}
+               ofItemAtPath:userRoot error:nil];
+
+    XCTAssertNotNil(report);
+    XCTAssertFalse(report.manifestWritten,
+                   @"A permission-denied manifest write must be reported "
+                   @"as not-written, not crash the sync");
+}
+
+#pragma mark - §7.2: case sensitivity
+
+- (void)testManifestKeysAreCaseSensitive
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    NSString *bundlePath = [bundleRoot stringByAppendingPathComponent:@"Themes/Mou Night.style"];
+    [self writeString:@"v2" toPath:bundlePath];
+    NSString *userPath = [userRoot stringByAppendingPathComponent:@"Themes/Mou Night.style"];
+    [self writeString:@"v1" toPath:userPath];
+
+    // Mis-cased key: lowercase "mou night.style" instead of the bundle's
+    // "Mou Night.style".
+    [self writeProvenanceFiles:@{@"Themes/mou night.style": [self sha256OfString:@"v1"]}
+                         atPath:[self provenancePathForUserRoot:userRoot]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    XCTAssertEqualObjects([self.fm contentsAtPath:userPath],
+                          [@"v1" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"The mis-cased provenance entry must not match: "
+                          @"the file is therefore unclassifiable as "
+                          @"pristine and must be left untouched");
+    XCTAssertNil(report.manifest[@"Themes/Mou Night.style"]);
+    XCTAssertNil(report.manifest[@"Themes/mou night.style"]);
+    XCTAssertEqual(report.modifiedCount, 1u);
+}
+
+- (void)testManifestKeysUseBundleSpelling
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+
+    NSString *name = @"Google Docs.css";
+    [self writeString:@"g" toPath:[bundleRoot stringByAppendingPathComponent:
+                                    [@"Styles" stringByAppendingPathComponent:name]]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    NSString *expectedKey = [@"Styles" stringByAppendingPathComponent:name];
+    XCTAssertEqualObjects(report.manifest[expectedKey], [self sha256OfString:@"g"],
+                          @"Manifest key must exactly match the bundle's "
+                          @"spelling, including the space, no escaping, no "
+                          @"normalisation. Keys present: %@",
+                          report.manifest.allKeys);
+}
+
+#pragma mark - §9.2: never touches real Application Support
+
+- (void)testSyncNeverTouchesRealApplicationSupport
+{
+    NSString *userRoot, *bundleRoot;
+    [self makeRootsUser:&userRoot bundle:&bundleRoot];
+    [self writeString:@"a" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+
+    MPBundledResourceSyncReport *report =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+
+    // The manifest must be non-trivially populated for this test to prove
+    // anything (a stub returning an empty manifest would vacuously pass
+    // an empty loop below).
+    XCTAssertGreaterThan(report.manifest.count, 0u,
+                         @"Sync must actually have synced something for "
+                         @"this test to be meaningful");
+
+    NSString *resolvedUserRoot = [[NSURL fileURLWithPath:userRoot]
+        URLByResolvingSymlinksInPath].path;
+    for (NSString *key in report.manifest) {
+        NSString *fullPath = [userRoot stringByAppendingPathComponent:key];
+        NSString *resolvedFullPath = [[NSURL fileURLWithPath:fullPath]
+            URLByResolvingSymlinksInPath].path;
+        XCTAssertTrue([resolvedFullPath hasPrefix:resolvedUserRoot],
+                      @"Every written path must resolve under the injected "
+                      @"fake user root, never a real one: %@", fullPath);
+    }
+}
+
+@end

--- a/MacDownTests/MPBundledResourceSyncTests.m
+++ b/MacDownTests/MPBundledResourceSyncTests.m
@@ -20,6 +20,8 @@
 
 #import <XCTest/XCTest.h>
 #import <sys/stat.h>
+#import <errno.h>
+#import <string.h>
 #import <CommonCrypto/CommonDigest.h>
 #import "MPBundledResourceSync.h"
 
@@ -1027,6 +1029,11 @@
                          attributes:nil error:nil];
 
     [self writeString:@"v2" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/A.css"]];
+    // Companion normal file, absent from target, inside the SAME linked
+    // directory. It must be copied by this same sync — without this, an
+    // untouched symlink and an empty manifest are both satisfiable by a
+    // no-op stub.
+    [self writeString:@"n" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/NORMAL.css"]];
 
     NSString *externalDir = [self.tempDir stringByAppendingPathComponent:@"external-styles-2"];
     [self.fm createDirectoryAtPath:externalDir withIntermediateDirectories:YES
@@ -1050,6 +1057,12 @@
                           @"An entry inside a linked directory that is "
                           @"itself a symlink must still be skipped (row 10)");
     XCTAssertNil(report.manifest[@"Styles/A.css"]);
+    XCTAssertEqualObjects([self.fm contentsAtPath:
+                           [externalDir stringByAppendingPathComponent:@"NORMAL.css"]],
+                          [@"n" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"Sanity check that this sync actually performed "
+                          @"real work inside the linked directory");
+    XCTAssertEqual(report.skippedCount, 1u);
 }
 
 #pragma mark - Bundle-side non-regular entries
@@ -1067,6 +1080,10 @@
     NSString *bundleLinkPath = [stylesBundleDir stringByAppendingPathComponent:@"LINK.css"];
     [self.fm createSymbolicLinkAtPath:bundleLinkPath
                    withDestinationPath:outsidePath error:nil];
+    // Companion regular bundle file, absent from target, that must
+    // actually be copied by this same sync — without this, "the symlink
+    // was not copied" is trivially satisfiable by a no-op stub.
+    [self writeString:@"n" toPath:[stylesBundleDir stringByAppendingPathComponent:@"NORMAL.css"]];
 
     MPBundledResourceSyncReport *report =
         MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
@@ -1077,6 +1094,12 @@
                    @"A symlink in the bundle must not be copied");
     XCTAssertEqual(report.failedCount, 0u,
                    @"A non-regular bundle entry is ignored, not a failure");
+    XCTAssertEqualObjects([self.fm contentsAtPath:
+                           [userRoot stringByAppendingPathComponent:@"Styles/NORMAL.css"]],
+                          [@"n" dataUsingEncoding:NSUTF8StringEncoding],
+                          @"Sanity check that this sync actually performed "
+                          @"real work alongside ignoring the bundle symlink");
+    XCTAssertEqual(report.copiedCount, 1u);
 }
 
 #pragma mark - §9.2: bundle-enumeration guard (R4)
@@ -1247,7 +1270,15 @@
 
     // Sync once so the manifest exists, then lock the directory down so a
     // rewrite attempt fails.
-    MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+    MPBundledResourceSyncReport *report1 =
+        MPSyncBundledResourcesInPaths(userRoot, bundleRoot);
+    NSString *manifestPath = [self provenancePathForUserRoot:userRoot];
+    // Sanity check: the first, unrestricted sync must actually have
+    // written a real manifest — otherwise "manifestWritten == NO" on the
+    // second run proves nothing.
+    XCTAssertTrue(report1.manifestWritten);
+    XCTAssertTrue([self.fm fileExistsAtPath:manifestPath]);
+    XCTAssertGreaterThan(report1.manifest.count, 0u);
 
     // A new bundle file forces a manifest change on the next run.
     [self writeString:@"b" toPath:[bundleRoot stringByAppendingPathComponent:@"Styles/B.css"]];

--- a/MacDownTests/MPBundledResourceSyncTests.m
+++ b/MacDownTests/MPBundledResourceSyncTests.m
@@ -8,12 +8,20 @@
 //  permissions, case sensitivity, and the mandatory temp-root safety guard
 //  (design §9.2, contract §11, design §6 R6).
 //
-//  Written against the design (issue-548-design.md) and the contract
-//  (issue-548-requirements-v2.md), NOT against the implementation, which is
-//  a deliberate stub at the time these tests were written. Every test here
-//  must fail on assertions against the real behavior described in the
-//  contract's twelve-row decision table (contract §6) until
-//  MPBundledResourceSync.m is implemented.
+//  These tests were written against the specification before the
+//  implementation existed, so they follow the contract's twelve-row decision
+//  table (contract §6) rather than mirroring the structure of
+//  MPBundledResourceSync.m.
+//
+//  The cited "contract §…" and "design §…" sections refer to the requirements
+//  and design documents posted on GitHub issue #548.
+//
+//  HEADS UP, RUNNING THIS LOCALLY: MacDownTests is app-hosted, so launching
+//  the suite runs the real -[MPMainController copyFiles] against your own
+//  ~/Library/Application Support/MacDown 3000/. That used to be able only to
+//  add a missing bundled file; it can now atomically replace a pristine one
+//  so it matches the branch under test. Files you have edited yourself are
+//  never touched.
 //
 //  Related to GitHub issue #548.
 //
@@ -1272,7 +1280,7 @@
 
     XCTAssertTrue(report.aborted,
                   @"A single unreadable bundle directory must abort the "
-                  @"whole sync, per design §4.2 step 2 / contract R4");
+                  @"whole sync, per design §4.2 step 2 / design R4");
     NSData *manifestBytesAfter = [NSData dataWithContentsOfFile:manifestPath];
     XCTAssertEqualObjects(manifestBytesAfter, manifestBytesBefore,
                           @"Manifest bytes must be byte-identical — "

--- a/MacDownTests/MPBundledResourceSyncTests.m
+++ b/MacDownTests/MPBundledResourceSyncTests.m
@@ -1491,13 +1491,14 @@
 //
 // and it depends on Styles/ and Themes/ being readable directories directly
 // inside that resource path. If a resource-layout change in project.pbxproj
-// ever moved, renamed or nested either of them, the sync would abort (see
-// MPBundledResourceSync.h on `aborted`: "either of the bundle's Styles and
-// Themes directories fails to enumerate"), write nothing, and never refresh
-// anybody's styles again — while every fake-root test above stayed green.
-// That is exactly the class of silent failure that
-// MacDownTests/MPTerminalPreferencesTests.m exhibits today, and this test is
-// the tripwire for it.
+// ever moved, renamed or nested either of them, MPDirectoryEntryNames would
+// find nothing there — a missing directory is not an enumeration failure
+// (see MPBundledResourceSync.m) — so the sync would not abort. Instead every
+// file already on disk would classify as row 7 (Forget): its provenance
+// entry gets dropped and it is never refreshed again, silently, while every
+// fake-root test above stayed green. (An unreadable directory, or Styles/
+// replaced by a plain file, is the case that does abort.) This test is the
+// tripwire for the silent case.
 //
 // WHY THIS TEST IS EXEMPT FROM makeRootsUser:bundle:. The temp-root safety
 // factory is mandatory for anything that calls the sync, because the sync

--- a/MacDownTests/MPBundledResourceSyncTests.m
+++ b/MacDownTests/MPBundledResourceSyncTests.m
@@ -22,6 +22,7 @@
 #import <sys/stat.h>
 #import <errno.h>
 #import <string.h>
+#import <unistd.h>
 #import <CommonCrypto/CommonDigest.h>
 #import "MPBundledResourceSync.h"
 
@@ -520,7 +521,7 @@
                           [@"v3" dataUsingEncoding:NSUTF8StringEncoding],
                           @"B.css already equals bundle -> untouched");
     XCTAssertEqualObjects([NSSet setWithArray:report.manifest.allKeys],
-                          [NSSet setWithArray:@[@"Styles/A.css", @"Styles/B.css"]]);
+                          ([NSSet setWithArray:@[@"Styles/A.css", @"Styles/B.css"]]));
 }
 
 - (void)testRow08ManifestMissingNeverOverwritesUnknownBytes
@@ -586,7 +587,7 @@
 
     XCTAssertFalse(report.aborted);
     XCTAssertEqualObjects([NSSet setWithArray:report.manifest.allKeys],
-                          [NSSet setWithArray:@[@"Styles/A.css", @"Styles/B.css"]],
+                          ([NSSet setWithArray:@[@"Styles/A.css", @"Styles/B.css"]]),
                           @"A corrupt manifest must degrade to exactly the "
                           @"row-8 (missing manifest) outcome");
     XCTAssertEqualObjects([self.fm contentsAtPath:[userRoot stringByAppendingPathComponent:@"Styles/C.css"]],

--- a/MacDownTests/MPDocumentStyleUpdateTests.m
+++ b/MacDownTests/MPDocumentStyleUpdateTests.m
@@ -567,8 +567,10 @@ NS_INLINE BOOL MPAreNilableStringsEqual(NSString *s1, NSString *s2)
 // different <link> URLs, and the second render carries no trace of the first
 // URL. The stamp is therefore keyed on the recorded change, never on the path,
 // so a contents-only change can still produce a URL the legacy WebView has
-// never cached. It also proves nothing else in the reload path moved: strip
-// the two stamps and the two rendered documents are byte-identical.
+// never cached. It also proves nothing else about the rendered document
+// moved: strip the two stamps and the two rendered documents are
+// byte-identical — the reload path proper (MPDocument/WebView) is never
+// exercised here.
 //
 // WHAT THIS TEST DOES NOT PROVE. It does not prove that a live WebView
 // refetches the stamped URL — that needs a real WebView and is out of reach

--- a/MacDownTests/MPDocumentStyleUpdateTests.m
+++ b/MacDownTests/MPDocumentStyleUpdateTests.m
@@ -552,4 +552,71 @@ NS_INLINE BOOL MPAreNilableStringsEqual(NSString *s1, NSString *s2)
                    @"Untracked bundled CSS must not be cache-busted");
 }
 
+// Contract §10 of the bundled-resource refresh (GitHub issue #548):
+// "Cache-busting from #318 must keep working. The refresh changes file
+// *contents*, not paths or the reload path. Verify that a refreshed style is
+// picked up on the next preview render exactly as a user edit is."
+//
+// That refresh introduced a genuinely new situation: before it, the app never
+// rewrote an existing bundled file, so nothing exercised "the bytes at this
+// path changed while the file name stayed put". A cache keyed on the path
+// alone would keep serving the old CSS.
+//
+// WHAT THIS TEST PROVES. Rendering twice over the *same* style path, with
+// only the recorded stamp differing between the two renders, yields two
+// different <link> URLs, and the second render carries no trace of the first
+// URL. The stamp is therefore keyed on the recorded change, never on the path,
+// so a contents-only change can still produce a URL the legacy WebView has
+// never cached. It also proves nothing else in the reload path moved: strip
+// the two stamps and the two rendered documents are byte-identical.
+//
+// WHAT THIS TEST DOES NOT PROVE. It does not prove that a live WebView
+// refetches the stamped URL — that needs a real WebView and is out of reach
+// headlessly. It does not read or hash the stylesheet's bytes, and it cannot:
+// production records [[NSDate date] timeIntervalSince1970], never a content
+// digest (MPDocument.m:1837 when the resource watcher reports a change to a
+// watched file, MPDocument.m:2699-2707 for an explicit Reload), so no test can
+// show the stamp is a *function* of content. And it does not run
+// MPSyncBundledResourcesInPaths: the launch-time refresh happens inside
+// -[MPMainController init], before any document or WebView exists, so its own
+// first render has no cache to defeat. What is verified is the narrower but
+// still load-bearing claim — a stylesheet whose contents change under an
+// unchanged path is linked under a changed URL, exactly as a user edit of that
+// same file already is.
+- (void)testStyleLinkStampChangesWhenContentChangesUnderUnchangedPath
+{
+    NSString *stylePath = MPStylePathForName(self.delegate.styleName);
+    XCTAssertNotNil(stylePath, @"Active style should resolve to a path");
+
+    // The preview as it stood before the file's bytes changed.
+    [self.renderer setTimestamp:1750000000 forResourcePath:stylePath];
+    NSString *before = [self renderMarkdown:@"# Hello"];
+    XCTAssertTrue([before containsString:@"GitHub2.css?t=1750000000"],
+                  @"Baseline: the active style must be stamped before the "
+                  @"contents change");
+
+    // A refresh rewrites that same file. Its name — and therefore its file://
+    // URL — is untouched; only the recorded stamp moves.
+    [self.renderer setTimestamp:1750000042 forResourcePath:stylePath];
+    NSString *after = [self renderMarkdown:@"# Hello"];
+
+    XCTAssertTrue([after containsString:@"GitHub2.css?t=1750000042"],
+                  @"A stylesheet whose contents changed under an unchanged "
+                  @"path must be linked under the new stamp");
+    XCTAssertFalse([after containsString:@"GitHub2.css?t=1750000000"],
+                   @"The previous URL must be gone — that is the one the "
+                   @"WebView already holds, with the stale bytes");
+
+    NSString *beforeUnstamped =
+        [before stringByReplacingOccurrencesOfString:@"GitHub2.css?t=1750000000"
+                                          withString:@"GitHub2.css"];
+    NSString *afterUnstamped =
+        [after stringByReplacingOccurrencesOfString:@"GitHub2.css?t=1750000042"
+                                         withString:@"GitHub2.css"];
+    XCTAssertEqualObjects(afterUnstamped, beforeUnstamped,
+                          @"Only the cache-busting query may differ: the "
+                          @"refresh changes file contents, not paths and not "
+                          @"the reload path");
+}
+
 @end

--- a/Tools/generate-bundled-resource-history.sh
+++ b/Tools/generate-bundled-resource-history.sh
@@ -1,0 +1,403 @@
+#!/bin/bash
+#
+#  generate-bundled-resource-history.sh
+#  MacDown 3000
+#
+#  Regenerates MacDown/Resources/BundledResourceHistory.json: for every file
+#  under MacDown/Resources/Styles and MacDown/Resources/Themes, the set of
+#  SHA-256 digests that file has ever had at a shipped release tag.
+#
+#  MPBundledResourceSync reads that manifest at launch to tell "this is an
+#  older bundled version, refresh it" apart from "the user edited this, leave
+#  it alone forever". A wrong digest in here destroys a user's file, so this
+#  script fails loudly rather than emit anything it cannot justify.
+#
+#  Usage:
+#      Tools/generate-bundled-resource-history.sh           # regenerate
+#      Tools/generate-bundled-resource-history.sh --check   # verify only
+#
+#  --check regenerates into a temporary file and diffs it against the
+#  committed one, exiting non-zero on drift. The generator is deterministic:
+#  re-running it against an unchanged tag set produces byte-identical output
+#  (there is deliberately no timestamp field anywhere in the manifest), so
+#  --check is meaningful and cheap enough to wire into CI.
+#
+#  This script is NOT part of the Xcode build. It is run by hand when a new
+#  release tag is cut, and the resulting JSON is committed.
+#
+#  Related to GitHub issue #548.
+#
+# ---------------------------------------------------------------------------
+#  Why hashing checked-out bytes is sound
+# ---------------------------------------------------------------------------
+#
+#  We digest the bytes committed at each tag, and claim those are the bytes
+#  that shipped inside the .app. That claim only holds if no build step ever
+#  regenerated one of these files on the release machine.
+#
+#  There is exactly one such step: the "Transpile Styles" build phase runs
+#  `make -C Tools/GitHub-style-generator/`, which regenerates
+#  MacDown/Resources/Styles/GitHub-2020.css from index.sass. That Makefile
+#  invokes `node_modules/.bin/sass` -- i.e. it cannot run at all unless an
+#  npm/yarn install has populated node_modules. The release pipeline has never
+#  had node, npm or yarn available:
+#
+#    * .github/actions/setup-macdown/action.yml has had exactly one version,
+#      commit e96c19f ("Refactor release automation and documentation", #154).
+#      It has three steps: ruby/setup-ruby@v1, `bundle exec pod install`, and
+#      `make -C Dependency/peg-markdown-highlight`. No node, ever.
+#    * .github/workflows/release.yml and its pre-refactor ancestor 0dcd4dd
+#      ("Add code signing and release automation to CI/CD", #69) have the same
+#      empty footprint across their whole history.
+#
+#  So `make` finds node_modules/.bin/sass missing, the recipe fails, and the
+#  committed GitHub-2020.css ships verbatim. check_no_node() below re-verifies
+#  this every time the generator runs; if it ever stops holding, the generator
+#  refuses to emit and you must fall back to downloading the released .app
+#  artifacts and diffing their Resources against these digests.
+#
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+fatal()
+{
+    echo >&2 "FATAL: $*"
+    exit 1
+}
+
+CHECK_ONLY=0
+case "${1-}" in
+    --check)    CHECK_ONLY=1 ;;
+    -h|--help)  sed -n '3,26p' "$0"; exit 0 ;;
+    "")         ;;
+    *)          fatal "unknown argument '$1' (expected --check or nothing)" ;;
+esac
+
+
+# --- Step 1: preflight -----------------------------------------------------
+# Same `hash <tool> || { echo >&2 …; exit; }` idiom as Tools/utils.sh:1.
+# python3 is not a new dependency: Tools/compat.py and Tools/macdown_utils.py
+# already require it.
+
+hash git 2>/dev/null || \
+    { echo >&2 "Git required, not installed.  Aborting history generation."; exit 1; }
+hash shasum 2>/dev/null || \
+    { echo >&2 "shasum required, not installed.  Aborting history generation."; exit 1; }
+hash python3 2>/dev/null || \
+    { echo >&2 "python3 required, not installed.  Aborting history generation."; exit 1; }
+
+# Run from the repository root, using the `pushd $(dirname $0)` pattern from
+# Tools/generate_version_header.sh:3-5.
+pushd "$(dirname "$0")/.." > /dev/null
+REPO_ROOT="$(pwd -P)"
+popd > /dev/null
+cd "$REPO_ROOT"
+
+readonly RESOURCE_PREFIX="MacDown/Resources/"
+readonly OUTPUT_PATH="MacDown/Resources/BundledResourceHistory.json"
+readonly RESOURCE_DIRS=(
+    "MacDown/Resources/Styles"
+    "MacDown/Resources/Themes"
+)
+
+TMPDIR_WORK="$(mktemp -d "${TMPDIR:-/tmp}/bundled-resource-history.XXXXXX")"
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+
+# --- Step 2: ensure full history -------------------------------------------
+# A CI checkout or a fresh clone may be shallow and tagless, which would
+# silently produce an empty manifest.
+
+# Retries a network command up to 4 times with 2s/4s/8s/16s backoff.
+retry_network()
+{
+    local delay=2 attempt
+    for attempt in 1 2 3 4 5; do
+        if "$@"; then
+            return 0
+        fi
+        if [ "$attempt" -eq 5 ]; then
+            return 1
+        fi
+        echo >&2 "warning: '$*' failed; retrying in ${delay}s"
+        sleep "$delay"
+        delay=$(( delay * 2 ))
+    done
+}
+
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+    retry_network git fetch --unshallow --tags || \
+        fatal "repository is shallow and could not be unshallowed; the tag history needed to build this manifest is unavailable."
+else
+    retry_network git fetch --tags || \
+        echo >&2 "warning: could not fetch tags; using local tags"
+fi
+
+
+# --- Step 3: the static no-node check, before any digesting ----------------
+#
+# Pattern note (deliberate narrowing from the original draft): the draft
+# pattern was
+#     npm|nodejs|node-version|setup-node|yarn|sass
+# `sass` has been REPLACED by `npx` and `node_modules`. Reasoning:
+#
+#   * `sass` adds no detection power. The only thing that could invalidate
+#     these digests is the Transpile Styles phase actually succeeding, and its
+#     Makefile hardcodes `node_modules/.bin/sass` -- reachable only via an
+#     npm/yarn install, which the remaining terms already catch. A
+#     brew/gem-installed dart-sass would not satisfy that path.
+#   * `sass` is the term most likely to appear innocuously: this repo really
+#     does contain Tools/GitHub-style-generator/index.sass, so a `paths:`
+#     filter, a step name, or a comment mentioning it in either file would
+#     trip the check permanently, with no way to clear it short of editing
+#     this script. A permanent false positive on a check whose only action is
+#     `exit 1` is worse than no check.
+#   * `npx` and `node_modules` are the capability markers actually missing
+#     from the draft, so the narrowed pattern strictly increases the chance of
+#     catching a genuine node/npm capability landing in the release pipeline.
+#
+# Both files currently produce zero hits under either pattern (verified).
+
+check_no_node()
+{
+    local path="$1"
+    local hits
+    hits=$(git log --all --oneline -p -- "$path" \
+           | grep -inE '^\+.*(npm|npx|node_modules|nodejs|node-version|setup-node|yarn)' || true)
+    if [ -n "$hits" ]; then
+        echo >&2 "FATAL: node/npm footprint found in $path:"
+        echo >&2 "$hits"
+        echo >&2 "The 'no node in the release pipeline' assumption no longer"
+        echo >&2 "holds, so checked-out bytes may not be the bytes that"
+        echo >&2 "shipped. Fall back to the artifact download-and-diff"
+        echo >&2 "verification before trusting these digests. Refusing to emit."
+        exit 1
+    fi
+}
+
+check_no_node .github/actions/setup-macdown/action.yml
+check_no_node .github/workflows/release.yml
+
+
+# --- Step 4: enumerate tags ------------------------------------------------
+# -beta.* and -rc.* tags are included on purpose: those were downloadable
+# releases, users ran them, and their bytes are legitimately on disk
+# somewhere. versionsort.suffix=- sorts a prerelease before its release
+# (v3000.0.7-rc.3 before v3000.0.7) instead of lexicographically after it.
+
+git -c versionsort.suffix=- tag --list 'v*' --sort=v:refname > "$TMPDIR_WORK/tags.txt"
+
+TAG_COUNT="$(grep -c . "$TMPDIR_WORK/tags.txt" || true)"
+if [ "$TAG_COUNT" -eq 0 ]; then
+    fatal "no 'v*' tags found. Emitting an empty history manifest would let every user file classify as unknown and never be refreshed; refusing to emit."
+fi
+
+
+# --- Step 5: enumerate and digest files at each tag ------------------------
+#
+# Four things here are load-bearing:
+#
+#   * `-z` plus `read -r -d ''` are mandatory, not stylistic. 19 of the 28
+#     filenames contain spaces or parentheses -- "Solarized (Dark).style",
+#     "Mou Night+.style", "Google Docs.css". Word-splitting `git ls-tree
+#     --name-only` output shreds them into fragments and either errors out or,
+#     worse, silently digests the wrong blob.
+#   * `git ls-tree -r` without `-t` lists blobs only, so trees never appear.
+#     The mode filter is still needed to skip symlinks (120000) and gitlinks
+#     (160000): the runtime never follows or hashes a non-regular file, so
+#     shipping a digest for one would be meaningless.
+#   * ENUMERATE, NEVER PROBE. Files that did not exist at a tag simply are not
+#     listed, and need no handling at all. `git show "$tag:$path"` against a
+#     hardcoded filename list is the anti-pattern: it produces "fatal: path …
+#     does not exist" and a non-zero exit under `set -e`. 22 files exist at
+#     v3000.0.0-beta.0 and 28 at v3000.0.7; enumeration absorbs the difference
+#     with zero special-casing.
+#   * `shasum -a 256` emits lowercase hex, matching CommonCrypto's "%02x" on
+#     the Objective-C side. The runtime compares digests case-sensitively.
+#
+# Step 6 -- filename changes. Keys are the path as spelled AT EACH TAG, so a
+# rename would produce two independent keys. That is correct and needs no
+# rename detection: the user has the old filename on disk, it is absent from
+# the current bundle, so the sync's row-7 rule leaves it alone forever, while
+# the new filename is covered by its own key. Content-matching heuristics
+# would only create ways to overwrite a file we cannot justify overwriting.
+# Verified, and worth re-running before assuming otherwise:
+#
+#     git log --diff-filter=R --name-status -- \
+#         'MacDown/Resources/Styles/*' 'MacDown/Resources/Themes/*'
+#
+# is empty -- this repo has never renamed one of these files.
+
+emit_pairs_for_ref()
+{
+    local ref="$1"
+    local dir entry mode path key digest
+
+    for dir in "${RESOURCE_DIRS[@]}"; do
+        git ls-tree -r -z "$ref" -- "$dir" > "$TMPDIR_WORK/ls-tree.bin"
+        while IFS= read -r -d '' entry; do
+            # "<mode> SP <type> SP <object> TAB <path>"
+            mode="${entry%% *}"
+            path="${entry#*$'\t'}"
+            case "$mode" in
+                100644|100755) ;;
+                *) continue ;;
+            esac
+            key="${path#"$RESOURCE_PREFIX"}"
+            digest="$(git cat-file blob "$ref:$path" | shasum -a 256 | cut -d' ' -f1)"
+            printf '%s\t%s\n' "$key" "$digest"
+        done < "$TMPDIR_WORK/ls-tree.bin"
+    done
+}
+
+count_regular_files_at_ref()
+{
+    local ref="$1"
+    local dir entry mode count=0
+
+    for dir in "${RESOURCE_DIRS[@]}"; do
+        git ls-tree -r -z "$ref" -- "$dir" > "$TMPDIR_WORK/ls-count.bin"
+        while IFS= read -r -d '' entry; do
+            mode="${entry%% *}"
+            case "$mode" in
+                100644|100755) count=$(( count + 1 )) ;;
+            esac
+        done < "$TMPDIR_WORK/ls-count.bin"
+    done
+    printf '%s\n' "$count"
+}
+
+{
+    while IFS= read -r tag; do
+        [ -n "$tag" ] || continue
+        emit_pairs_for_ref "$tag"
+    done < "$TMPDIR_WORK/tags.txt"
+} | LC_ALL=C sort -u > "$TMPDIR_WORK/pairs.tsv"
+
+
+# --- Step 8 (first half): self-checks on the raw pairs ---------------------
+# Run before emission so a malformed pair never reaches the output file.
+
+if [ ! -s "$TMPDIR_WORK/pairs.tsv" ]; then
+    fatal "enumerated $TAG_COUNT tag(s) but produced zero (path, digest) pairs."
+fi
+
+MALFORMED="$(LC_ALL=C grep -cvE $'^[^\t]+\t[^\t]+$' "$TMPDIR_WORK/pairs.tsv" || true)"
+if [ "$MALFORMED" -ne 0 ]; then
+    fatal "$MALFORMED line(s) of the pair stream are not exactly two tab-separated fields."
+fi
+
+BAD_DIGESTS="$(LC_ALL=C cut -f2 "$TMPDIR_WORK/pairs.tsv" \
+               | LC_ALL=C grep -vE '^[0-9a-f]{64}$' | sort -u || true)"
+if [ -n "$BAD_DIGESTS" ]; then
+    echo >&2 "$BAD_DIGESTS"
+    fatal "digest(s) above do not match ^[0-9a-f]{64}\$."
+fi
+
+BAD_KEYS="$(LC_ALL=C cut -f1 "$TMPDIR_WORK/pairs.tsv" \
+            | LC_ALL=C grep -vE '^(Styles|Themes)/[^/]+$' | sort -u || true)"
+if [ -n "$BAD_KEYS" ]; then
+    echo >&2 "$BAD_KEYS"
+    fatal "key(s) above do not match ^(Styles|Themes)/[^/]+\$."
+fi
+
+KEY_COUNT="$(LC_ALL=C cut -f1 "$TMPDIR_WORK/pairs.tsv" | LC_ALL=C sort -u | wc -l | tr -d ' ')"
+PAIR_COUNT="$(wc -l < "$TMPDIR_WORK/pairs.tsv" | tr -d ' ')"
+CURRENT_COUNT="$(count_regular_files_at_ref HEAD)"
+
+if [ "$KEY_COUNT" -lt "$CURRENT_COUNT" ]; then
+    fatal "enumeration produced $KEY_COUNT key(s) but HEAD ships $CURRENT_COUNT file(s); files were silently lost."
+fi
+
+
+# --- Step 7: deterministic emission ----------------------------------------
+# LC_ALL=C sort above and Python's sort_keys=True are both byte/codepoint
+# order, so the two agree. indent=2, ensure_ascii=False, trailing newline,
+# sorted and de-duplicated digest arrays, and NO timestamp -- a timestamp
+# would make the generator non-idempotent and turn every regeneration into an
+# unreviewable diff.
+
+LC_ALL=C python3 - "$TMPDIR_WORK/pairs.tsv" "$TMPDIR_WORK/tags.txt" \
+    > "$TMPDIR_WORK/BundledResourceHistory.json" <<'PY'
+import collections
+import json
+import re
+import sys
+
+DIGEST_RE = re.compile(r'^[0-9a-f]{64}$')
+KEY_RE = re.compile(r'^(Styles|Themes)/[^/]+$')
+
+files = collections.defaultdict(set)
+with open(sys.argv[1], encoding='utf-8') as handle:
+    for line in handle:
+        line = line.rstrip('\n')
+        if not line:
+            continue
+        key, _, digest = line.partition('\t')
+        assert KEY_RE.match(key), 'bad key: %r' % (key,)
+        assert DIGEST_RE.match(digest), 'bad digest for %r: %r' % (key, digest)
+        files[key].add(digest)
+
+with open(sys.argv[2], encoding='utf-8') as handle:
+    tags = [t.strip() for t in handle if t.strip()]
+assert tags, 'empty tag list'
+
+doc = {
+    "version": 1,
+    "tags": tags,
+    "files": {key: sorted(values) for key, values in files.items()},
+}
+json.dump(doc, sys.stdout, indent=2, sort_keys=True, ensure_ascii=False)
+sys.stdout.write("\n")
+PY
+
+
+# --- Step 8 (second half): self-checks on the emitted document -------------
+
+LC_ALL=C python3 - "$TMPDIR_WORK/BundledResourceHistory.json" "$CURRENT_COUNT" <<'PY'
+import json
+import re
+import sys
+
+DIGEST_RE = re.compile(r'^[0-9a-f]{64}$')
+KEY_RE = re.compile(r'^(Styles|Themes)/[^/]+$')
+
+with open(sys.argv[1], encoding='utf-8') as handle:
+    doc = json.load(handle)
+
+assert doc["version"] == 1, doc["version"]
+assert isinstance(doc["tags"], list) and doc["tags"], "tags"
+assert "timestamp" not in doc, "a timestamp field would break idempotence"
+
+files = doc["files"]
+for key, digests in files.items():
+    assert KEY_RE.match(key), 'bad key: %r' % (key,)
+    assert digests, 'empty digest array for %r' % (key,)
+    assert digests == sorted(set(digests)), 'unsorted/duplicated digests for %r' % (key,)
+    for digest in digests:
+        assert DIGEST_RE.match(digest), 'bad digest for %r: %r' % (key, digest)
+
+current = int(sys.argv[2])
+assert len(files) >= current, \
+    'only %d key(s) for %d shipped file(s)' % (len(files), current)
+PY
+
+
+# --- Step 9: --check mode, or write ----------------------------------------
+
+if [ "$CHECK_ONLY" -eq 1 ]; then
+    if [ ! -f "$OUTPUT_PATH" ]; then
+        fatal "$OUTPUT_PATH does not exist. Run this script without --check."
+    fi
+    if ! diff -u "$OUTPUT_PATH" "$TMPDIR_WORK/BundledResourceHistory.json"; then
+        fatal "$OUTPUT_PATH is out of date. Run Tools/generate-bundled-resource-history.sh."
+    fi
+    echo "$OUTPUT_PATH is up to date ($KEY_COUNT keys, $PAIR_COUNT digests, $TAG_COUNT tags)."
+    exit 0
+fi
+
+cat "$TMPDIR_WORK/BundledResourceHistory.json" > "$OUTPUT_PATH"
+
+BYTE_COUNT="$(wc -c < "$OUTPUT_PATH" | tr -d ' ')"
+echo "Wrote $OUTPUT_PATH: $KEY_COUNT keys, $PAIR_COUNT distinct (path, digest) pairs, $TAG_COUNT tags, $BYTE_COUNT bytes."

--- a/plans/release-checklist.md
+++ b/plans/release-checklist.md
@@ -1,9 +1,10 @@
 # MacDown Release Checklist
 
-**Quick reference:** Only three manual steps are required to release MacDown:
+**Quick reference:** Only four manual steps are required to release MacDown:
 1. Update the changelog
 2. Tag and push the version
-3. Staple the DMG (after notarization)
+3. Regenerate the bundled resource history
+4. Staple the DMG (after notarization)
 
 See `plans/release-process.md` for detailed instructions.
 
@@ -46,7 +47,23 @@ See `plans/release-process.md` for detailed instructions.
 
 ---
 
-## Step 3: Staple and Publish
+## Step 3: Regenerate the Bundled Resource History
+
+The new tag exists now, so record what shipped in it — files from an untagged
+release can never be classified, and the user who loses their provenance
+manifest loses the recovery path with it.
+
+- [ ] **Regenerate and commit the history manifest**
+  ```bash
+  Tools/generate-bundled-resource-history.sh
+  git add MacDown/Resources/BundledResourceHistory.json
+  git commit -m "Record bundled resource digests for v0.9.0"
+  git push origin main
+  ```
+
+---
+
+## Step 4: Staple and Publish
 
 Once you receive the notarization approval email:
 
@@ -78,7 +95,8 @@ The workflow handles everything else:
 - ✅ Submits for Apple notarization
 - ✅ Creates the GitHub release as a draft
 
-Your job is just updating the changelog, tagging, and stapling.
+Your job is just updating the changelog, tagging, regenerating the bundled
+resource history, and stapling.
 
 ---
 

--- a/plans/release-process.md
+++ b/plans/release-process.md
@@ -235,6 +235,19 @@ The recommended way to trigger a release is by creating and pushing a version ta
    - Workflow will create a **draft release**
    - Check the **Releases** page on GitHub
 
+6. **Regenerate the bundled resource history:**
+
+   The generator enumerates pushed release tags, so this must run *after* the tag is pushed — files shipped in an untagged release can never be classified, which silently breaks the recovery path for anyone who later loses their provenance manifest.
+
+   ```bash
+   Tools/generate-bundled-resource-history.sh
+   git add MacDown/Resources/BundledResourceHistory.json
+   git commit -m "Record bundled resource digests for v1.0.0"
+   git push origin main
+   ```
+
+   One consequence of this ordering: because the manifest is regenerated *after* the tag is cut, a release's own digests never ship inside that release's own app bundle — they first appear in the following release. This is unavoidable and harmless (a pristine file still matches the current bundle's digest directly), but it can surprise a reader checking a fresh install against its own release's manifest.
+
 ### Manual Trigger (Alternative)
 
 You can also manually trigger the workflow without creating a tag:


### PR DESCRIPTION
## Summary

Bundled styles and themes are copied into `~/Library/Application Support/MacDown 3000/` only when absent, so every fix we ship to an existing bundled file is invisible to anyone who has already launched the app. #443, #432 and #547 all shipped edits that no existing user has ever received.

The complication is that we invite people to edit these files (`help.md`), and #318 exists specifically so their edits show up live. So the app cannot simply overwrite. It has to distinguish a stale copy it placed itself from one the user wrote — and nothing on disk recorded that.

This adds that record, and refreshes only what it can prove is ours.

- **Provenance manifest** (`BundledResourceManifest.json`, at the data-directory root): the SHA-256 of the bytes the app most recently placed at each path.
- **Shipped-history manifest** (`BundledResourceHistory.json`, in the app bundle): every digest each file has had in a release, generated from the 16 release tags by a checked-in script. This is what rescues files already stale on disk today — without it the fix reaches nobody who currently has the bug.
- A file is refreshed only if its bytes match the provenance entry, the current bundle copy, or a shipped digest. Anything else is the user's and is left alone, with no entry recorded, which is what keeps it protected on later launches.

Scope covers `Styles/` **and** `Themes/` — one loop, one defect, and #443 already bit themes. Prism is unaffected and untouched: it is never seeded here and already falls back to the bundle.

Refreshes copy to a hidden temporary file in the same directory and then replace atomically, so a file is never briefly absent. Entries that are not regular files are skipped without being opened, and the digest helper opens non-blocking and re-checks the descriptor, so a fifo left under a bundled name cannot stall launch. A bundle directory that exists but cannot be read aborts the sync without writing anything, since an unreadable source is indistinguishable from one whose files were all removed and would otherwise drop every entry it covers.

## Related Issue

Related to #548.

The full requirements interpretation, including the decision table this is built and tested against, is on the issue: https://github.com/schuyler/macdown3000/issues/548#issuecomment-5160083149

## Judgment Calls

**Shipping the history manifest, rather than recording provenance only from here on.** Provenance alone cannot classify the files that are already stale, because those are exactly the files with no provenance. Adopting whatever is on disk as provenance is not a smaller version of this fix — it either overwrites real user edits on the second launch, or pins every existing file as unclassifiable forever. So history is load-bearing, and it is why this is larger than the bug first suggests. Its maintenance cost is bounded: it only needs to cover releases up to the one shipping this, and the generator is re-runnable if you ever want to extend it.

**Editor themes included.** The issue names stylesheets; `Themes/` shares the same loop and the same missing fallback, and #443 shipped theme edits nobody received.

**A downgrade reverts pristine files.** Installing an older version restores that version's bundled bytes. Deliberate — pristine files track whatever is installed, and user edits are still protected.

**Never deleting a file we no longer ship.** The user may have it selected as their active style.

**Withdrawn from scope:** a bundle fallback in `MPStylePathForName`/`MPThemePathForName`. It fixes zero stale files and sits on the render path, so it belongs in its own change.

**No "Restore Defaults" button.** Deleting a file and relaunching restores it, which is per-file and already works; a destructive button deserves your judgement on wording and granularity. `help.md` documents the gesture instead.

**Open question for you:** if a user edited a file *and* wants the newer bundled version, they keep their edit and never get the fix. That is the correct side of the trade, but it does mean #546's overflow persists for them until they delete their copy.

## Testing

**Baseline:** 1104 tests, 0 failures on `main` at `7767580` (run 30224808528). **Now:** 1170, 0 failures — 66 added.

- 37 tests drive the sync through injected fake bundle and user roots: all twelve decision-table rows, idempotence, symlinked resource directories, the enumeration guard, permission failures, and manifest key case sensitivity.
- 29 cover the digest helpers against known vectors, both manifest readers, and the classification function's truth table.
- Roots come from a factory that asserts both resolve under the temporary directory before any test runs, so a refactor cannot let a test write to a real Application Support directory.
- Refresh cases assert the target's inode changed and no temporary or backup residue remains, which is what distinguishes an atomic replacement from a truncate in place.
- `HGMarkdownHighlighterTests` reads the real user themes directory during app-hosted runs and is left unmodified deliberately: it is a live canary for the atomic replacement, and it passes.
- The app-launch smoke test exercises the real `copyFiles` path against the runner's home directory and passes on every leg.

One caveat worth stating: the tests were written against the specification before the implementation existed, and were reviewed for it, but the CI run intended to demonstrate them failing never executed — it died on a compile error in the test file instead. That the suite fails without the behaviour rests on review rather than on an observed red run.

`Tools/generate-bundled-resource-history.sh --check` regenerates the history manifest and diffs it against the committed copy, so drift is detectable. Re-run it after cutting a release if you want the newest bytes covered; the four styles touched by #547 are not in history yet because they are not in a tag.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q79Lih9LxX3EfcJ1LQqN8J)_