### PR TITLE
Address issue #558: omit empty <thead> from pipe tables

### DIFF
--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -424,6 +424,7 @@ NS_INLINE hoedown_renderer *MPCreateHTMLRenderer(MPRenderer *renderer, int tocLe
     htmlRenderer->blockcode = hoedown_patch_render_blockcode;
     htmlRenderer->listitem = hoedown_patch_render_listitem;
     htmlRenderer->header = hoedown_patch_render_header;
+    htmlRenderer->table_header = hoedown_patch_render_table_header;
 
     hoedown_html_renderer_state_extra *extra =
         hoedown_malloc(sizeof(hoedown_html_renderer_state_extra));

--- a/MacDown/Code/Extension/hoedown_html_patch.c
+++ b/MacDown/Code/Extension/hoedown_html_patch.c
@@ -346,6 +346,58 @@ void hoedown_patch_render_header(
     hoedown_buffer_free(slug);
 }
 
+// Returns 1 if the rendered row content contains no visible text once HTML
+// tags and entities are stripped out (i.e. every cell in the row is empty).
+static int is_row_content_blank(const hoedown_buffer *content)
+{
+    if (!content || !content->size)
+        return 1;
+
+    int in_tag = 0;
+    for (size_t i = 0; i < content->size; i++)
+    {
+        uint8_t c = content->data[i];
+
+        if (in_tag)
+        {
+            if (c == '>') in_tag = 0;
+            continue;
+        }
+        if (c == '<')
+        {
+            in_tag = 1;
+            continue;
+        }
+        if (c == '&')
+        {
+            while (i + 1 < content->size && content->data[i + 1] != ';')
+                i++;
+            i++;
+            continue;
+        }
+        if (c != ' ' && c != '\t' && c != '\n' && c != '\r')
+            return 0;
+    }
+    return 1;
+}
+
+// rndr_table_header replacement that omits the <thead> element entirely when
+// every header cell is empty, so a header row like `| | |` doesn't render as
+// a blank header line. Related to a MacDown 3000 table-rendering fix.
+void hoedown_patch_render_table_header(
+    hoedown_buffer *ob, const hoedown_buffer *content,
+    const hoedown_renderer_data *data)
+{
+    (void)data;
+    if (is_row_content_blank(content))
+        return;
+
+    if (ob->size) hoedown_buffer_putc(ob, '\n');
+    HOEDOWN_BUFPUTSL(ob, "<thead>\n");
+    hoedown_buffer_put(ob, content->data, content->size);
+    HOEDOWN_BUFPUTSL(ob, "</thead>\n");
+}
+
 // Adds a "toc" class to the outmost UL element to support TOC styling.
 void hoedown_patch_render_toc_header(
     hoedown_buffer *ob, const hoedown_buffer *content, int level,

--- a/MacDown/Code/Extension/hoedown_html_patch.c
+++ b/MacDown/Code/Extension/hoedown_html_patch.c
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Tzu-ping Chung . All rights reserved.
 //
 
-#include <stdlib.h>
 #include <string.h>
 #include <hoedown/escape.h>
 #include <hoedown/document.h>
@@ -347,7 +346,7 @@ void hoedown_patch_render_header(
     hoedown_buffer_free(slug);
 }
 
-// Returns 1 if the tag starting at content->data[i] (the '<') is a void
+// Returns 1 if the tag starting at content->data[i] (the '<') is a replaced
 // element that always renders visible content of its own (e.g. <img>),
 // independent of any text nodes around it.
 static int is_replaced_element_tag(const hoedown_buffer *content, size_t i)
@@ -403,15 +402,29 @@ static int is_whitespace_entity(const hoedown_buffer *content, size_t amp,
 
     if (content->data[start] == '#')
     {
-        // Numeric reference: &#160; / &#xA0; (NBSP) — anything else counts
-        // as visible content.
+        // Numeric reference: &#160; / &#xA0; (NBSP), &#8194; (ENSP), etc.
+        // Anything else counts as visible content. Parsed manually (not via
+        // strtol) since `content` is not NUL-terminated.
         size_t k = start + 1;
         int is_hex = (k < semi && (content->data[k] == 'x' ||
                                     content->data[k] == 'X'));
         if (is_hex) k++;
-        long value = strtol((const char *)content->data + k, NULL,
-                             is_hex ? 16 : 10);
-        return value == 0x00A0;
+        if (k >= semi)
+            return 0;
+
+        uint32_t value = 0;
+        for (; k < semi; k++)
+        {
+            uint8_t c = content->data[k];
+            int digit;
+            if (c >= '0' && c <= '9') digit = c - '0';
+            else if (is_hex && c >= 'a' && c <= 'f') digit = c - 'a' + 10;
+            else if (is_hex && c >= 'A' && c <= 'F') digit = c - 'A' + 10;
+            else return 0;
+            value = value * (is_hex ? 16 : 10) + (uint32_t)digit;
+        }
+        return value == 0x00A0 || value == 0x2002 || value == 0x2003 ||
+               value == 0x2009;
     }
 
     static const char *whitespace_entities[] = { "nbsp", "ensp", "emsp", "thinsp" };

--- a/MacDown/Code/Extension/hoedown_html_patch.c
+++ b/MacDown/Code/Extension/hoedown_html_patch.c
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 Tzu-ping Chung . All rights reserved.
 //
 
+#include <stdlib.h>
 #include <string.h>
 #include <hoedown/escape.h>
 #include <hoedown/document.h>
@@ -346,8 +347,97 @@ void hoedown_patch_render_header(
     hoedown_buffer_free(slug);
 }
 
+// Returns 1 if the tag starting at content->data[i] (the '<') is a void
+// element that always renders visible content of its own (e.g. <img>),
+// independent of any text nodes around it.
+static int is_replaced_element_tag(const hoedown_buffer *content, size_t i)
+{
+    static const char *replaced_tags[] = {
+        "img", "svg", "video", "audio", "iframe", "embed", "object", "canvas"
+    };
+
+    size_t j = i + 1;
+    if (j < content->size && content->data[j] == '/')
+        return 0; // closing tags never introduce new content
+
+    size_t start = j;
+    while (j < content->size && content->data[j] != '>' &&
+           content->data[j] != ' ' && content->data[j] != '\t' &&
+           content->data[j] != '\n' && content->data[j] != '\r' &&
+           content->data[j] != '/')
+        j++;
+
+    size_t len = j - start;
+    if (!len)
+        return 0;
+
+    for (size_t t = 0; t < sizeof(replaced_tags) / sizeof(replaced_tags[0]); t++)
+    {
+        size_t tag_len = strlen(replaced_tags[t]);
+        if (tag_len != len)
+            continue;
+
+        int match = 1;
+        for (size_t k = 0; k < len; k++)
+        {
+            uint8_t c = content->data[start + k];
+            if (c >= 'A' && c <= 'Z') c += 32;
+            if (c != (uint8_t)replaced_tags[t][k]) { match = 0; break; }
+        }
+        if (match)
+            return 1;
+    }
+    return 0;
+}
+
+// Returns 1 if the entity spelled out between content->data[amp] ('&') and
+// the following ';' is whitespace-only (e.g. &nbsp;) rather than a visible
+// glyph (e.g. &copy;).
+static int is_whitespace_entity(const hoedown_buffer *content, size_t amp,
+                                 size_t semi)
+{
+    size_t start = amp + 1;
+    size_t len = semi - start;
+    if (!len)
+        return 0;
+
+    if (content->data[start] == '#')
+    {
+        // Numeric reference: &#160; / &#xA0; (NBSP) — anything else counts
+        // as visible content.
+        size_t k = start + 1;
+        int is_hex = (k < semi && (content->data[k] == 'x' ||
+                                    content->data[k] == 'X'));
+        if (is_hex) k++;
+        long value = strtol((const char *)content->data + k, NULL,
+                             is_hex ? 16 : 10);
+        return value == 0x00A0;
+    }
+
+    static const char *whitespace_entities[] = { "nbsp", "ensp", "emsp", "thinsp" };
+    for (size_t t = 0; t < sizeof(whitespace_entities) / sizeof(whitespace_entities[0]); t++)
+    {
+        size_t name_len = strlen(whitespace_entities[t]);
+        if (name_len != len)
+            continue;
+
+        int match = 1;
+        for (size_t k = 0; k < len; k++)
+        {
+            uint8_t c = content->data[start + k];
+            if (c >= 'A' && c <= 'Z') c += 32;
+            if (c != (uint8_t)whitespace_entities[t][k]) { match = 0; break; }
+        }
+        if (match)
+            return 1;
+    }
+    return 0;
+}
+
 // Returns 1 if the rendered row content contains no visible text once HTML
 // tags and entities are stripped out (i.e. every cell in the row is empty).
+// Tags that always render their own content (e.g. <img>) and entities that
+// decode to a visible glyph (e.g. &copy;) count as non-blank.
 static int is_row_content_blank(const hoedown_buffer *content)
 {
     if (!content || !content->size)
@@ -365,14 +455,22 @@ static int is_row_content_blank(const hoedown_buffer *content)
         }
         if (c == '<')
         {
+            if (is_replaced_element_tag(content, i))
+                return 0;
             in_tag = 1;
             continue;
         }
         if (c == '&')
         {
-            while (i + 1 < content->size && content->data[i + 1] != ';')
-                i++;
-            i++;
+            size_t semi = i + 1;
+            while (semi < content->size && content->data[semi] != ';')
+                semi++;
+            if (semi < content->size)
+            {
+                if (!is_whitespace_entity(content, i, semi))
+                    return 0;
+                i = semi;
+            }
             continue;
         }
         if (c != ' ' && c != '\t' && c != '\n' && c != '\r')

--- a/MacDown/Code/Extension/hoedown_html_patch.h
+++ b/MacDown/Code/Extension/hoedown_html_patch.h
@@ -42,6 +42,12 @@ void hoedown_patch_render_header(
     hoedown_buffer *ob, const hoedown_buffer *content, int level,
     const hoedown_renderer_data *data);
 
+// rndr_table_header replacement that omits the <thead> element entirely when
+// every header cell is empty (e.g. a table whose header row is `| | |`).
+void hoedown_patch_render_table_header(
+    hoedown_buffer *ob, const hoedown_buffer *content,
+    const hoedown_renderer_data *data);
+
 void hoedown_patch_render_toc_header(
      hoedown_buffer *ob, const hoedown_buffer *content, int level,
      const hoedown_renderer_data *data);

--- a/MacDownTests/MPRendererEdgeCaseTests.m
+++ b/MacDownTests/MPRendererEdgeCaseTests.m
@@ -323,6 +323,57 @@ static NSString * const kMPTestPrismAbsenceMarker = @"Prism.highlightAll";
 }
 
 
+#pragma mark - Empty Table Header Tests
+
+- (void)testRendererOmitsTheadWhenHeaderCellsAreBlank
+{
+    self.delegate.extensions = HOEDOWN_EXT_TABLES;
+    self.dataSource.markdown = @"| | |\n|---|---|\n| 1 | 2 |";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
+
+    XCTAssertFalse([html containsString:@"<thead>"],
+                   @"A header row with only blank cells should not render a <thead>");
+}
+
+- (void)testRendererKeepsTheadWhenHeaderCellContainsImage
+{
+    self.delegate.extensions = HOEDOWN_EXT_TABLES;
+    self.dataSource.markdown = @"| ![alt](img.png) | |\n|---|---|\n| 1 | 2 |";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
+
+    XCTAssertTrue([html containsString:@"<thead>"],
+                  @"A header cell containing only an image is not blank");
+}
+
+- (void)testRendererKeepsTheadWhenHeaderCellContainsVisibleEntity
+{
+    self.delegate.extensions = HOEDOWN_EXT_TABLES;
+    self.dataSource.markdown = @"| &copy; | |\n|---|---|\n| 1 | 2 |";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
+
+    XCTAssertTrue([html containsString:@"<thead>"],
+                  @"A header cell containing a visible entity like &copy; is not blank");
+}
+
+- (void)testRendererOmitsTheadWhenHeaderCellContainsOnlyNbsp
+{
+    self.delegate.extensions = HOEDOWN_EXT_TABLES;
+    self.dataSource.markdown = @"| &nbsp; | |\n|---|---|\n| 1 | 2 |";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
+
+    XCTAssertFalse([html containsString:@"<thead>"],
+                   @"A header row with only whitespace entities like &nbsp; is still blank");
+}
+
+
 #pragma mark - Malformed HTML in Code Blocks Tests
 
 - (void)testRendererWithScriptTagInCodeBlock

--- a/MacDownTests/MPRendererEdgeCaseTests.m
+++ b/MacDownTests/MPRendererEdgeCaseTests.m
@@ -373,6 +373,42 @@ static NSString * const kMPTestPrismAbsenceMarker = @"Prism.highlightAll";
                    @"A header row with only whitespace entities like &nbsp; is still blank");
 }
 
+- (void)testRendererOmitsTheadWhenHeaderCellContainsOnlyNumericNbsp
+{
+    self.delegate.extensions = HOEDOWN_EXT_TABLES;
+    self.dataSource.markdown = @"| &#160; | |\n|---|---|\n| 1 | 2 |";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
+
+    XCTAssertFalse([html containsString:@"<thead>"],
+                   @"A header row with only a numeric NBSP reference is still blank");
+}
+
+- (void)testRendererKeepsTheadWhenHeaderCellContainsUppercaseImageTag
+{
+    self.delegate.extensions = HOEDOWN_EXT_TABLES;
+    self.dataSource.markdown = @"| <IMG SRC=\"img.png\"> | |\n|---|---|\n| 1 | 2 |";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
+
+    XCTAssertTrue([html containsString:@"<thead>"],
+                  @"Tag-name matching for replaced elements should be case-insensitive");
+}
+
+- (void)testRendererKeepsTheadWhenOneOfSeveralHeaderCellsHasContent
+{
+    self.delegate.extensions = HOEDOWN_EXT_TABLES;
+    self.dataSource.markdown = @"| | Header | |\n|---|---|---|\n| 1 | 2 | 3 |";
+
+    [self.renderer parseMarkdown:self.dataSource.markdown];
+    NSString *html = [self.renderer HTMLForExportWithStyles:NO highlighting:NO];
+
+    XCTAssertTrue([html containsString:@"<thead>"],
+                  @"A header row is not blank if any single cell has visible content");
+}
+
 
 #pragma mark - Malformed HTML in Code Blocks Tests
 


### PR DESCRIPTION
Related to #558

## Summary
- A pipe table whose header row is empty (e.g. `| | |`) still rendered a visibly empty `<thead>` bar, since Hoedown's table extension always wraps the first row in `<thead><tr><th>` regardless of cell content.
- Adds a Hoedown HTML renderer patch (`table_header` callback) that detects when every header cell is empty — after stripping tags/entities — and omits the `<thead>` element entirely in that case. Tables with any real header content render exactly as before.

## Test plan
- [x] Build succeeds (`xcodebuild ... -scheme MacDown`)
- [x] `MacDownTests/MPHTMLTabularizeTests` passes
- [ ] Manually verified in the preview: a table with an empty header row (`| | |`) no longer shows a blank header line; a table with real headers is unaffected

Note: `HGMarkdownHighlighterTests/testAllBundledThemesDefineHTMLForegroundColor` fails locally on plain `main` as well (unrelated to this change — appears to be a pre-existing environment-specific theme-resource-path issue on my machine), so it's not a regression introduced here.