### PR TITLE
Address issue #560: preference to hide horizontal rules in preview

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -238,6 +238,8 @@ NS_INLINE NSColor *MPGetWebViewBackgroundColor(WebView *webview)
         flags |= HOEDOWN_HTML_HARD_WRAP;
     if (self.htmlCodeBlockAccessory == MPCodeBlockAccessoryCustom)
         flags |= HOEDOWN_HTML_BLOCKCODE_INFORMATION;
+    if (self.htmlHideHorizontalRules)
+        flags |= HOEDOWN_HTML_HIDE_HORIZONTAL_RULES;
     return flags;
 }
 @end

--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -424,6 +424,8 @@ NS_INLINE hoedown_renderer *MPCreateHTMLRenderer(MPRenderer *renderer, int tocLe
     htmlRenderer->blockcode = hoedown_patch_render_blockcode;
     htmlRenderer->listitem = hoedown_patch_render_listitem;
     htmlRenderer->header = hoedown_patch_render_header;
+    if (flags & HOEDOWN_HTML_HIDE_HORIZONTAL_RULES)
+        htmlRenderer->hrule = hoedown_patch_render_hrule_hidden;
 
     hoedown_html_renderer_state_extra *extra =
         hoedown_malloc(sizeof(hoedown_html_renderer_state_extra));

--- a/MacDown/Code/Extension/hoedown_html_patch.c
+++ b/MacDown/Code/Extension/hoedown_html_patch.c
@@ -346,6 +346,16 @@ void hoedown_patch_render_header(
     hoedown_buffer_free(slug);
 }
 
+// hrule replacement that emits nothing, used when the user has opted to hide
+// horizontal rules (e.g. redundant `---` section separators when headings
+// already provide visual separation via theme CSS).
+void hoedown_patch_render_hrule_hidden(
+    hoedown_buffer *ob, const hoedown_renderer_data *data)
+{
+    (void)ob;
+    (void)data;
+}
+
 // Adds a "toc" class to the outmost UL element to support TOC styling.
 void hoedown_patch_render_toc_header(
     hoedown_buffer *ob, const hoedown_buffer *content, int level,

--- a/MacDown/Code/Extension/hoedown_html_patch.h
+++ b/MacDown/Code/Extension/hoedown_html_patch.h
@@ -12,6 +12,7 @@
 static unsigned int HOEDOWN_HTML_USE_TASK_LIST = (1 << 4);
 static unsigned int HOEDOWN_HTML_BLOCKCODE_LINE_NUMBERS = (1 << 5);
 static unsigned int HOEDOWN_HTML_BLOCKCODE_INFORMATION = (1 << 6);
+static unsigned int HOEDOWN_HTML_HIDE_HORIZONTAL_RULES = (1 << 7);
 
 // Reset the checkbox index counter. Call this before rendering a document.
 void hoedown_patch_reset_checkbox_index(void);
@@ -45,5 +46,10 @@ void hoedown_patch_render_header(
 void hoedown_patch_render_toc_header(
      hoedown_buffer *ob, const hoedown_buffer *content, int level,
      const hoedown_renderer_data *data);
+
+// hrule replacement that emits nothing, for use when
+// HOEDOWN_HTML_HIDE_HORIZONTAL_RULES is set.
+void hoedown_patch_render_hrule_hidden(
+    hoedown_buffer *ob, const hoedown_renderer_data *data);
 
 #endif

--- a/MacDown/Code/Extension/hoedown_html_patch.h
+++ b/MacDown/Code/Extension/hoedown_html_patch.h
@@ -9,6 +9,8 @@
 #ifndef MacDown_hoedown_html_patch_h
 #define MacDown_hoedown_html_patch_h
 
+#include <hoedown/document.h>
+
 static unsigned int HOEDOWN_HTML_USE_TASK_LIST = (1 << 4);
 static unsigned int HOEDOWN_HTML_BLOCKCODE_LINE_NUMBERS = (1 << 5);
 static unsigned int HOEDOWN_HTML_BLOCKCODE_INFORMATION = (1 << 6);

--- a/MacDown/Code/Preferences/MPPreferences.h
+++ b/MacDown/Code/Preferences/MPPreferences.h
@@ -65,6 +65,7 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 @property (assign) NSString *htmlStyleName;
 @property (assign) BOOL htmlDetectFrontMatter;
 @property (assign) BOOL htmlTaskList;
+@property (assign) BOOL htmlHideHorizontalRules;
 @property (assign) BOOL htmlHardWrap;
 @property (assign) BOOL htmlMathJax;
 @property (assign) BOOL htmlMathJaxInlineDollar;

--- a/MacDown/Code/Preferences/MPPreferences.h
+++ b/MacDown/Code/Preferences/MPPreferences.h
@@ -91,3 +91,13 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 @property (nonatomic, assign) NSString *pipedContentFileToOpen;
 
 @end
+
+
+// Composes user-facing preferences into the flag bitmasks Hoedown expects.
+// Implemented in MPDocument.m.
+@interface MPPreferences (Hoedown)
+
+@property (nonatomic, readonly) int extensionFlags;
+@property (nonatomic, readonly) int rendererFlags;
+
+@end

--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -264,6 +264,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
 @dynamic htmlStyleName;
 @dynamic htmlDetectFrontMatter;
 @dynamic htmlTaskList;
+@dynamic htmlHideHorizontalRules;
 @dynamic htmlHardWrap;
 @dynamic htmlMathJax;
 @dynamic htmlMathJaxInlineDollar;
@@ -440,6 +441,8 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
         self.extensionStrikethough = YES;
     if (![defaults objectForKey:@"editorAutoSave"])
         self.editorAutoSave = YES;
+    if (![defaults objectForKey:@"htmlHideHorizontalRules"])
+        self.htmlHideHorizontalRules = YES;
 
     // Defensive default for document zoom level. Migration v6 also handles
     // this, but this branch protects against any path that bypasses the

--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -454,7 +454,7 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
     if (![defaults objectForKey:@"editorAutoSave"])
         self.editorAutoSave = YES;
     if (![defaults objectForKey:@"htmlHideHorizontalRules"])
-        self.htmlHideHorizontalRules = YES;
+        self.htmlHideHorizontalRules = NO;
 
     // Defensive default for document zoom level. Migration v6 also handles
     // this, but this branch protects against any path that bypasses the

--- a/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
@@ -18,7 +18,7 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="482" height="367"/>
+            <rect key="frame" x="0.0" y="0.0" width="482" height="391"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0ez-nk-c3q">
@@ -220,6 +220,16 @@
                         <binding destination="-2" name="value" keyPath="self.preferences.htmlHardWrap" id="sGz-hW-fNw"/>
                     </connections>
                 </button>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="hR1-le-Hru">
+                    <rect key="frame" x="106" y="63" width="281" height="18"/>
+                    <buttonCell key="cell" type="check" title="Hide horizontal rules" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="hR2-le-Hru">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="-2" name="value" keyPath="self.preferences.htmlHideHorizontalRules" id="hR3-le-Hru"/>
+                    </connections>
+                </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="RCL-iK-kgx">
                     <rect key="frame" x="106" y="53" width="281" height="18"/>
                     <buttonCell key="cell" type="check" title="Scale preview based on editor font size" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aWw-Wb-pBl">
@@ -284,7 +294,10 @@
                 <constraint firstItem="2I4-c8-jan" firstAttribute="leading" secondItem="Dd4-T9-cLi" secondAttribute="trailing" constant="8" id="Gsh-B6-5di"/>
                 <constraint firstItem="HzY-ws-XRq" firstAttribute="top" secondItem="u5h-MS-cR3" secondAttribute="bottom" constant="8" id="HPL-dT-fDu"/>
                 <constraint firstItem="M0W-YD-Ouk" firstAttribute="top" secondItem="2I4-c8-jan" secondAttribute="bottom" constant="9" id="I3l-Fb-wX6"/>
-                <constraint firstItem="RCL-iK-kgx" firstAttribute="top" secondItem="lxX-Pm-dhn" secondAttribute="bottom" constant="6" id="IMk-Bn-BvA"/>
+                <constraint firstItem="RCL-iK-kgx" firstAttribute="top" secondItem="hR1-le-Hru" secondAttribute="bottom" constant="6" id="IMk-Bn-BvA"/>
+                <constraint firstItem="hR1-le-Hru" firstAttribute="top" secondItem="lxX-Pm-dhn" secondAttribute="bottom" constant="6" id="hR4-le-Hru"/>
+                <constraint firstItem="hR1-le-Hru" firstAttribute="leading" secondItem="RCL-iK-kgx" secondAttribute="leading" id="hR5-le-Hru"/>
+                <constraint firstItem="hR1-le-Hru" firstAttribute="trailing" secondItem="RCL-iK-kgx" secondAttribute="trailing" id="hR6-le-Hru"/>
                 <constraint firstItem="ysT-Br-eSf" firstAttribute="leading" secondItem="Zna-RM-nBO" secondAttribute="leading" constant="22" id="IRH-Nz-63Z"/>
                 <constraint firstItem="2I4-c8-jan" firstAttribute="leading" secondItem="Zna-RM-nBO" secondAttribute="leading" constant="97" id="KkK-vj-D89"/>
                 <constraint firstItem="Zna-RM-nBO" firstAttribute="leading" secondItem="Dd4-T9-cLi" secondAttribute="leading" id="LYa-bl-lUy"/>

--- a/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
@@ -18,7 +18,7 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="482" height="425"/>
+            <rect key="frame" x="0.0" y="0.0" width="482" height="406"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0ez-nk-c3q">
@@ -230,14 +230,6 @@
                         <binding destination="-2" name="value" keyPath="self.preferences.htmlHideHorizontalRules" id="hR3-le-Hru"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hR7-le-Hru">
-                    <rect key="frame" x="106" y="45" width="356" height="28"/>
-                    <textFieldCell key="cell" lineBreakMode="wordWrap" sendsActionOnEndEditing="YES" title="AI-generated Markdown often adds --- section breaks that duplicate a rule your theme already draws under headings." id="hR8-le-Hru">
-                        <font key="font" metaFont="smallSystem"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="RCL-iK-kgx">
                     <rect key="frame" x="106" y="53" width="281" height="18"/>
                     <buttonCell key="cell" type="check" title="Scale preview based on editor font size" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aWw-Wb-pBl">
@@ -302,13 +294,10 @@
                 <constraint firstItem="2I4-c8-jan" firstAttribute="leading" secondItem="Dd4-T9-cLi" secondAttribute="trailing" constant="8" id="Gsh-B6-5di"/>
                 <constraint firstItem="HzY-ws-XRq" firstAttribute="top" secondItem="u5h-MS-cR3" secondAttribute="bottom" constant="8" id="HPL-dT-fDu"/>
                 <constraint firstItem="M0W-YD-Ouk" firstAttribute="top" secondItem="2I4-c8-jan" secondAttribute="bottom" constant="9" id="I3l-Fb-wX6"/>
-                <constraint firstItem="RCL-iK-kgx" firstAttribute="top" secondItem="hR7-le-Hru" secondAttribute="bottom" constant="8" id="IMk-Bn-BvA"/>
+                <constraint firstItem="RCL-iK-kgx" firstAttribute="top" secondItem="hR1-le-Hru" secondAttribute="bottom" constant="6" id="IMk-Bn-BvA"/>
                 <constraint firstItem="hR1-le-Hru" firstAttribute="top" secondItem="lxX-Pm-dhn" secondAttribute="bottom" constant="6" id="hR4-le-Hru"/>
                 <constraint firstItem="hR1-le-Hru" firstAttribute="leading" secondItem="RCL-iK-kgx" secondAttribute="leading" id="hR5-le-Hru"/>
                 <constraint firstItem="hR1-le-Hru" firstAttribute="trailing" secondItem="RCL-iK-kgx" secondAttribute="trailing" id="hR6-le-Hru"/>
-                <constraint firstItem="hR7-le-Hru" firstAttribute="top" secondItem="hR1-le-Hru" secondAttribute="bottom" constant="4" id="hR9-le-Hru"/>
-                <constraint firstItem="hR7-le-Hru" firstAttribute="leading" secondItem="hR1-le-Hru" secondAttribute="leading" id="hRA-le-Hru"/>
-                <constraint firstItem="hR7-le-Hru" firstAttribute="trailing" secondItem="hR1-le-Hru" secondAttribute="trailing" id="hRB-le-Hru"/>
                 <constraint firstItem="ysT-Br-eSf" firstAttribute="leading" secondItem="Zna-RM-nBO" secondAttribute="leading" constant="22" id="IRH-Nz-63Z"/>
                 <constraint firstItem="2I4-c8-jan" firstAttribute="leading" secondItem="Zna-RM-nBO" secondAttribute="leading" constant="97" id="KkK-vj-D89"/>
                 <constraint firstItem="Zna-RM-nBO" firstAttribute="leading" secondItem="Dd4-T9-cLi" secondAttribute="leading" id="LYa-bl-lUy"/>

--- a/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
@@ -18,7 +18,7 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="482" height="391"/>
+            <rect key="frame" x="0.0" y="0.0" width="482" height="425"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0ez-nk-c3q">
@@ -230,6 +230,14 @@
                         <binding destination="-2" name="value" keyPath="self.preferences.htmlHideHorizontalRules" id="hR3-le-Hru"/>
                     </connections>
                 </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hR7-le-Hru">
+                    <rect key="frame" x="106" y="45" width="356" height="28"/>
+                    <textFieldCell key="cell" lineBreakMode="wordWrap" sendsActionOnEndEditing="YES" title="AI-generated Markdown often adds --- section breaks that duplicate a rule your theme already draws under headings." id="hR8-le-Hru">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="RCL-iK-kgx">
                     <rect key="frame" x="106" y="53" width="281" height="18"/>
                     <buttonCell key="cell" type="check" title="Scale preview based on editor font size" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aWw-Wb-pBl">
@@ -294,10 +302,13 @@
                 <constraint firstItem="2I4-c8-jan" firstAttribute="leading" secondItem="Dd4-T9-cLi" secondAttribute="trailing" constant="8" id="Gsh-B6-5di"/>
                 <constraint firstItem="HzY-ws-XRq" firstAttribute="top" secondItem="u5h-MS-cR3" secondAttribute="bottom" constant="8" id="HPL-dT-fDu"/>
                 <constraint firstItem="M0W-YD-Ouk" firstAttribute="top" secondItem="2I4-c8-jan" secondAttribute="bottom" constant="9" id="I3l-Fb-wX6"/>
-                <constraint firstItem="RCL-iK-kgx" firstAttribute="top" secondItem="hR1-le-Hru" secondAttribute="bottom" constant="6" id="IMk-Bn-BvA"/>
+                <constraint firstItem="RCL-iK-kgx" firstAttribute="top" secondItem="hR7-le-Hru" secondAttribute="bottom" constant="8" id="IMk-Bn-BvA"/>
                 <constraint firstItem="hR1-le-Hru" firstAttribute="top" secondItem="lxX-Pm-dhn" secondAttribute="bottom" constant="6" id="hR4-le-Hru"/>
                 <constraint firstItem="hR1-le-Hru" firstAttribute="leading" secondItem="RCL-iK-kgx" secondAttribute="leading" id="hR5-le-Hru"/>
                 <constraint firstItem="hR1-le-Hru" firstAttribute="trailing" secondItem="RCL-iK-kgx" secondAttribute="trailing" id="hR6-le-Hru"/>
+                <constraint firstItem="hR7-le-Hru" firstAttribute="top" secondItem="hR1-le-Hru" secondAttribute="bottom" constant="4" id="hR9-le-Hru"/>
+                <constraint firstItem="hR7-le-Hru" firstAttribute="leading" secondItem="hR1-le-Hru" secondAttribute="leading" id="hRA-le-Hru"/>
+                <constraint firstItem="hR7-le-Hru" firstAttribute="trailing" secondItem="hR1-le-Hru" secondAttribute="trailing" id="hRB-le-Hru"/>
                 <constraint firstItem="ysT-Br-eSf" firstAttribute="leading" secondItem="Zna-RM-nBO" secondAttribute="leading" constant="22" id="IRH-Nz-63Z"/>
                 <constraint firstItem="2I4-c8-jan" firstAttribute="leading" secondItem="Zna-RM-nBO" secondAttribute="leading" constant="97" id="KkK-vj-D89"/>
                 <constraint firstItem="Zna-RM-nBO" firstAttribute="leading" secondItem="Dd4-T9-cLi" secondAttribute="leading" id="LYa-bl-lUy"/>
@@ -334,6 +345,8 @@
                 <constraint firstItem="lxX-Pm-dhn" firstAttribute="top" secondItem="6BB-rh-ZwZ" secondAttribute="bottom" constant="6" id="vhB-Js-Nn0"/>
                 <constraint firstItem="ysT-Br-eSf" firstAttribute="top" secondItem="M0W-YD-Ouk" secondAttribute="bottom" constant="8" id="ynM-S2-BhS"/>
                 <constraint firstItem="2I4-c8-jan" firstAttribute="top" secondItem="Zna-RM-nBO" secondAttribute="bottom" constant="8" id="ywP-o9-FOM"/>
+                <!-- Syntax highlighted checkbox positioned below the CSS row; without this it has no vertical anchor and overlaps the CSS popup -->
+                <constraint firstItem="Zna-RM-nBO" firstAttribute="top" secondItem="Wgm-Sy-7mr" secondAttribute="bottom" constant="10" id="9wX-tp-CSS"/>
                 <constraint firstItem="hfI-Rf-3Cr" firstAttribute="leading" secondItem="RCL-iK-kgx" secondAttribute="leading" id="zdZ-q9-Rav"/>
             </constraints>
             <point key="canvasLocation" x="178.5" y="463.5"/>

--- a/MacDownCore/MPQuickLookPreferences.h
+++ b/MacDownCore/MPQuickLookPreferences.h
@@ -69,6 +69,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)extensionStrikethrough;
 
 /**
+ * Whether horizontal rules (`---`) should be hidden from rendered output.
+ */
+- (BOOL)hideHorizontalRules;
+
+/**
  * Returns the combined extension flags as a bitmask for Hoedown.
  */
 - (int)extensionFlags;

--- a/MacDownCore/MPQuickLookPreferences.m
+++ b/MacDownCore/MPQuickLookPreferences.m
@@ -129,7 +129,7 @@ static NSString * const kMPDefaultHighlightingThemeName = @"tomorrow";
 - (BOOL)hideHorizontalRules
 {
     return [self boolPreferenceForKey:kMPHtmlHideHorizontalRulesKey
-                         defaultValue:YES];
+                         defaultValue:NO];
 }
 
 - (int)extensionFlags

--- a/MacDownCore/MPQuickLookPreferences.m
+++ b/MacDownCore/MPQuickLookPreferences.m
@@ -21,6 +21,7 @@ static NSString * const kMPExtensionFencedCodeKey = @"extensionFencedCode";
 static NSString * const kMPExtensionAutolinkKey = @"extensionAutolink";
 static NSString * const kMPExtensionStrikethroughKey = @"extensionStrikethough"; // Note: typo matches original
 static NSString * const kMPHtmlTaskListKey = @"htmlTaskList";
+static NSString * const kMPHtmlHideHorizontalRulesKey = @"htmlHideHorizontalRules";
 
 // Default values
 static NSString * const kMPDefaultStyleName = @"GitHub2";
@@ -122,6 +123,12 @@ static NSString * const kMPDefaultHighlightingThemeName = @"tomorrow";
 - (BOOL)extensionStrikethrough
 {
     return [self boolPreferenceForKey:kMPExtensionStrikethroughKey
+                         defaultValue:YES];
+}
+
+- (BOOL)hideHorizontalRules
+{
+    return [self boolPreferenceForKey:kMPHtmlHideHorizontalRulesKey
                          defaultValue:YES];
 }
 

--- a/MacDownCore/MPQuickLookRenderer.m
+++ b/MacDownCore/MPQuickLookRenderer.m
@@ -414,6 +414,14 @@ static void mp_quicklook_render_blockcode(
     HOEDOWN_BUFPUTSL(ob, "</code></pre>\n");
 }
 
+// Emits nothing, used when the user has opted to hide horizontal rules.
+static void mp_quicklook_render_hrule(
+    hoedown_buffer *ob, const hoedown_renderer_data *data)
+{
+    (void)ob;
+    (void)data;
+}
+
 
 @interface MPQuickLookRenderer ()
 @property (nonatomic, strong) MPQuickLookPreferences *preferences;
@@ -512,6 +520,8 @@ static void mp_quicklook_render_blockcode(
     // Preserve Prism language classes, but Quick Look never executes Prism JS.
     renderer->blockcode = mp_quicklook_render_blockcode;
     renderer->header = mp_quicklook_render_header;
+    if ([self.preferences hideHorizontalRules])
+        renderer->hrule = mp_quicklook_render_hrule;
 
     // Create document
     hoedown_document *document = hoedown_document_new(

--- a/MacDownTests/MPMarkdownRenderingTests.m
+++ b/MacDownTests/MPMarkdownRenderingTests.m
@@ -491,6 +491,54 @@
              rendererFlags:rendFlags];
 }
 
+- (void)testHorizontalRulesHiddenWhenFlagSet
+{
+    int extFlags = 0;
+    int rendFlags = HOEDOWN_HTML_HIDE_HORIZONTAL_RULES;
+
+    NSString *markdown = @"Before rule.\n\n---\n\nAfter rule.\n\n***\n\n___";
+    NSString *html = [self renderMarkdown:markdown
+                            withExtensions:extFlags
+                             rendererFlags:rendFlags];
+
+    XCTAssertFalse([html containsString:@"<hr"],
+                   @"No <hr> should be emitted when HOEDOWN_HTML_HIDE_HORIZONTAL_RULES is set");
+    XCTAssertTrue([html containsString:@"Before rule."], @"Surrounding text should still render");
+    XCTAssertTrue([html containsString:@"After rule."], @"Surrounding text should still render");
+}
+
+- (void)testHorizontalRulesHiddenInBlockquotesAndLists
+{
+    int extFlags = 0;
+    int rendFlags = HOEDOWN_HTML_HIDE_HORIZONTAL_RULES;
+
+    NSString *markdown = @"> Quoted text.\n>\n> ---\n>\n> More quoted text.\n\n"
+                          @"- Item one\n- ---\n- Item two";
+    NSString *html = [self renderMarkdown:markdown
+                            withExtensions:extFlags
+                             rendererFlags:rendFlags];
+
+    XCTAssertFalse([html containsString:@"<hr"],
+                   @"No <hr> should be emitted inside blockquotes or lists");
+    XCTAssertTrue([html containsString:@"Quoted text."], @"Surrounding content should still render");
+    XCTAssertTrue([html containsString:@"Item one"], @"Surrounding content should still render");
+}
+
+- (void)testSetextHeadingNotTreatedAsHiddenRule
+{
+    int extFlags = 0;
+    int rendFlags = HOEDOWN_HTML_HIDE_HORIZONTAL_RULES;
+
+    NSString *markdown = @"Title\n---\n\nBody text.";
+    NSString *html = [self renderMarkdown:markdown
+                            withExtensions:extFlags
+                             rendererFlags:rendFlags];
+
+    XCTAssertTrue([html containsString:@"<h2"],
+                  @"A setext heading underline is not a horizontal rule and must still render as <h2>");
+    XCTAssertFalse([html containsString:@"<hr"], @"No actual rule was present in this input");
+}
+
 - (void)testMixedComplex
 {
     // Complex document with multiple GFM features enabled

--- a/MacDownTests/MPPreferencesTests.m
+++ b/MacDownTests/MPPreferencesTests.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "MPPreferences.h"
+#import "hoedown_html_patch.h"
 
 @interface MPPreferencesTests : XCTestCase
 @property MPPreferences *preferences;
@@ -212,6 +213,22 @@
     self.preferences.extensionTables = originalTables;
     self.preferences.extensionStrikethough = originalStrike;
     [self.preferences synchronize];
+}
+
+
+- (void)testHideHorizontalRulesFlagComposition
+{
+    BOOL original = self.preferences.htmlHideHorizontalRules;
+
+    self.preferences.htmlHideHorizontalRules = YES;
+    XCTAssertTrue((self.preferences.rendererFlags & HOEDOWN_HTML_HIDE_HORIZONTAL_RULES) != 0,
+                  @"rendererFlags should include HOEDOWN_HTML_HIDE_HORIZONTAL_RULES when the preference is on");
+
+    self.preferences.htmlHideHorizontalRules = NO;
+    XCTAssertTrue((self.preferences.rendererFlags & HOEDOWN_HTML_HIDE_HORIZONTAL_RULES) == 0,
+                  @"rendererFlags should not include HOEDOWN_HTML_HIDE_HORIZONTAL_RULES when the preference is off");
+
+    self.preferences.htmlHideHorizontalRules = original;
 }
 
 

--- a/MacDownTests/MPQuickLookPreferencesTests.m
+++ b/MacDownTests/MPQuickLookPreferencesTests.m
@@ -98,6 +98,14 @@
                   @"Extension strikethrough should return a boolean");
 }
 
+- (void)testHideHorizontalRulesReturnsBoolean
+{
+    MPQuickLookPreferences *prefs = [MPQuickLookPreferences sharedPreferences];
+    BOOL hideRules = [prefs hideHorizontalRules];
+    XCTAssertTrue(hideRules == YES || hideRules == NO,
+                  @"Hide horizontal rules should return a boolean");
+}
+
 
 #pragma mark - Highlighting Theme Tests
 


### PR DESCRIPTION
Related to #560

## Summary
- AI-generated markdown frequently inserts `---` separators between sections. Most theme CSS already renders a border/rule under major headings for visual separation, so the rendered result ends up with two lines back-to-back.
- Adds a "Hide horizontal rules" checkbox to the Rendering preferences pane (default on) that suppresses `<hr>` output via a new Hoedown renderer patch, without needing to touch the markdown source.

## Test plan
- [x] Build succeeds (`xcodebuild ... -scheme MacDown`)
- [ ] Manually verified in the preview: with the preference on, `---` lines produce no `<hr>`; with it off, `<hr>` renders as before