### PR TITLE
Address issue #562: follow cursor and add finer scroll-sync reference points

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -270,14 +270,20 @@ typedef NS_ENUM(NSUInteger, MPScrollOwner) {
 // kind lets validateHeaderLocationAlignment align the two sequences instead of blindly
 // assuming they correspond 1:1 by index. Header values equal the header level, matching
 // the kind codes emitted by updateHeaderLocations.js.
+//
+// Density fix (long header-sparse sections drift out of sync): paragraphs and list
+// items are also tracked as reference points, so no span between two reference points
+// is ever very long, bounding the linear-interpolation error between them.
 typedef NS_ENUM(NSInteger, MPReferenceKind) {
-    MPReferenceKindImage = 0,
-    MPReferenceKindH1    = 1,
-    MPReferenceKindH2    = 2,
-    MPReferenceKindH3    = 3,
-    MPReferenceKindH4    = 4,
-    MPReferenceKindH5    = 5,
-    MPReferenceKindH6    = 6,
+    MPReferenceKindImage     = 0,
+    MPReferenceKindH1        = 1,
+    MPReferenceKindH2        = 2,
+    MPReferenceKindH3        = 3,
+    MPReferenceKindH4        = 4,
+    MPReferenceKindH5        = 5,
+    MPReferenceKindH6        = 6,
+    MPReferenceKindParagraph = 7,
+    MPReferenceKindListItem  = 8,
 };
 
 @property (weak) IBOutlet NSToolbar *toolbar;
@@ -383,12 +389,24 @@ typedef NS_ENUM(NSInteger, MPReferenceKind) {
 
 - (void)scaleWebview;
 - (void)syncScrollers;
+- (void)syncScrollersToCursor;
 - (void)syncScrollersReverse;
 - (void)updateHeaderLocations;
 - (void)validateHeaderLocationAlignment;
 // Issue #436: Pure helpers — no view/DOM dependencies, so they are unit-testable headless.
 + (NSArray<NSNumber *> *)editorReferenceKindsForMarkdown:(NSString *)markdown
                                           outLineNumbers:(NSArray<NSNumber *> **)outLineNumbers;
+// Pure geometry helper for -syncScrollersToCursor — see its declaration further
+// down for full documentation. Declared here too so unit tests (via a category)
+// can call it directly with concrete numbers.
++ (CGFloat)previewYForCursorY:(CGFloat)cursorDocumentY
+           editorContentHeight:(CGFloat)editorContentHeight
+           editorVisibleHeight:(CGFloat)editorVisibleHeight
+           editorScrollOffsetY:(CGFloat)editorScrollOffsetY
+          previewContentHeight:(CGFloat)previewContentHeight
+          previewVisibleHeight:(CGFloat)previewVisibleHeight
+        editorHeaderLocations:(NSArray<NSNumber *> *)editorHeaderLocations
+       webViewHeaderLocations:(NSArray<NSNumber *> *)webViewHeaderLocations;
 + (void)alignEditorYs:(NSArray<NSNumber *> *)editorYs
           editorTypes:(NSArray<NSNumber *> *)editorTypes
             previewYs:(NSArray<NSNumber *> *)previewYs
@@ -2020,6 +2038,15 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 // revert to the document-wide totals.
 - (void)editorSelectionDidChange:(NSNotification *)notification
 {
+    // When Sync Panes is on, moving the cursor (click or arrow keys) refines the
+    // preview's scroll position to follow it, on top of the usual viewport-based
+    // sync. Runs independently of the word-count display preference below, since
+    // it is unrelated to that gate.
+    if (self.preferences.editorSyncScrolling && _scrollOwner == MPScrollOwnerNeither)
+    {
+        [self syncScrollersToCursor];
+    }
+
     if (!self.preferences.editorShowWordCount)
         return;
 
@@ -3366,10 +3393,11 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 }
 
 /**
- * Issue #436: Classifies the reference points (ATX/setext headers and standalone images)
- * in a markdown string, returning their kind codes (see MPReferenceKind) in document
- * order, with the matching source line numbers via outLineNumbers. This mirrors the DOM
- * detection in updateHeaderLocations.js so the editor and preview sequences agree:
+ * Issue #436: Classifies the reference points (ATX/setext headers, standalone images,
+ * paragraphs, and list items) in a markdown string, returning their kind codes (see
+ * MPReferenceKind) in document order, with the matching source line numbers via
+ * outLineNumbers. This mirrors the DOM detection in updateHeaderLocations.js so the
+ * editor and preview sequences agree:
  *
  *   - Headers inside fenced code blocks (``` or ~~~) are skipped — the DOM renders them
  *     as <pre><code>, not <hN>.
@@ -3377,6 +3405,15 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
  *   - ATX headers with 7+ hashes are not headers (CommonMark §4.2; Hoedown emits no <hN>),
  *     so they are treated as ordinary paragraph text.
  *   - Standalone whole-line images (inline or reference syntax) are kind 0.
+ *   - List item marker lines (unordered: '-'/'*'/'+'; ordered: digits followed by '.'
+ *     or ')') are kind 8, one reference point per marker line — continuation lines of
+ *     a multi-line list item are not additional reference points.
+ *   - The first line of each paragraph (a maximal run of non-blank, non-header,
+ *     non-list-item, non-HR, non-fence lines) is kind 7 — one reference point per
+ *     rendered <p>, matching how Hoedown collapses a contiguous run of text lines into
+ *     a single paragraph. A text line immediately followed by a setext underline is
+ *     NOT also emitted as a paragraph, since it becomes a header instead; committing
+ *     it is deferred via pendingParagraphLine until the following line is examined.
  *
  * Pure function: no view, layout, or DOM dependencies, so it is unit-testable headless.
  */
@@ -3397,6 +3434,8 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     static NSRegularExpression *imgRegex = nil;    // ![alt](url)
     static NSRegularExpression *imgRefRegex = nil; // ![alt][ref]
     static NSRegularExpression *hrRegex = nil;     // thematic break (-, *, _)
+    static NSRegularExpression *ulRegex = nil;     // unordered list item marker
+    static NSRegularExpression *olRegex = nil;     // ordered list item marker
     static dispatch_once_t regexOnceToken;
     dispatch_once(&regexOnceToken, ^{
         // Setext underlines: 0-3 leading spaces and trailing whitespace are allowed
@@ -3408,14 +3447,31 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
         imgRegex = [NSRegularExpression regularExpressionWithPattern:@"^!\\[[^\\]]*\\]\\([^)]*\\)$" options:0 error:NULL];
         imgRefRegex = [NSRegularExpression regularExpressionWithPattern:@"^!\\[[^\\]]*\\]\\[[^\\]]*\\]$" options:0 error:NULL];
         hrRegex = [NSRegularExpression regularExpressionWithPattern:@"^[ ]{0,3}(([-][ ]*){3,}|([*][ ]*){3,}|([_][ ]*){3,})$" options:0 error:NULL];
+        // Bullet marker + required space + content.
+        ulRegex = [NSRegularExpression regularExpressionWithPattern:@"^[ ]{0,3}[-*+][ \\t]+\\S" options:0 error:NULL];
+        // Number (1-9 digits) + '.' or ')' + required space + content.
+        olRegex = [NSRegularExpression regularExpressionWithPattern:@"^[ ]{0,3}[0-9]{1,9}[.)][ \\t]+\\S" options:0 error:NULL];
     });
 
     NSArray<NSString *> *lines = [markdown componentsSeparatedByString:@"\n"];
 
     // Setext underlines attach to a *paragraph* line. previousLineHadContent is true only
-    // after ordinary text — not after blanks, headers, HRs, images, or fence lines —
-    // so e.g. "# H\n---" is an ATX header followed by an HR, not a setext header.
+    // after ordinary text — not after blanks, headers, HRs, images, list items, or fence
+    // lines — so e.g. "# H\n---" is an ATX header followed by an HR, not a setext header.
     BOOL previousLineHadContent = NO;
+
+    // The most recently seen paragraph-start line, not yet committed as a reference
+    // point: since a text line immediately followed by a setext underline becomes a
+    // header (not a paragraph), committing a candidate paragraph start is deferred
+    // until the following line is known not to be a setext underline for it.
+    __block BOOL hasPendingParagraphLine = NO;
+    __block NSUInteger pendingParagraphLine = 0;
+
+    // Once a list-item marker line is seen, subsequent non-blank lines are treated as
+    // continuation lines of that same item (not a new paragraph) until a blank line (or
+    // another marker/header/image/HR/fence) ends the run. This keeps a multi-line list
+    // item from spawning a spurious paragraph reference point for its continuation text.
+    BOOL insideListItemContinuation = NO;
 
     // Fenced-code-block state. CommonMark: a fence opens with 3+ of ` or ~ (0-3 leading
     // spaces) and closes with a run of the same character at least as long, with nothing
@@ -3423,6 +3479,16 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
     BOOL insideFence = NO;
     unichar fenceChar = 0;
     NSUInteger fenceLength = 0;
+
+    // Commits any pending (tentative) paragraph-start line as a real reference point.
+    // Called whenever the next line turns out NOT to be a setext underline for it.
+    void (^commitPendingParagraph)(void) = ^{
+        if (hasPendingParagraphLine) {
+            [kinds addObject:@(MPReferenceKindParagraph)];
+            [lineNumbers addObject:@(pendingParagraphLine)];
+            hasPendingParagraphLine = NO;
+        }
+    };
 
     for (NSUInteger lineNumber = 0; lineNumber < lines.count; lineNumber++) {
         NSString *line = lines[lineNumber];
@@ -3436,6 +3502,8 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
         if (insideFence) {
             // Inside a fence: only a matching, long-enough, bare closing marker ends it.
             // Everything here (including the fence lines) is code, never a reference point.
+            commitPendingParagraph();
+            insideListItemContinuation = NO;
             if (isFenceMarker && markerChar == fenceChar
                     && markerLength >= fenceLength && !hasTrailingContent) {
                 insideFence = NO;
@@ -3446,6 +3514,8 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
         if (isFenceMarker) {
             // Opens a fence. The opening line itself is never a reference point.
+            commitPendingParagraph();
+            insideListItemContinuation = NO;
             insideFence = YES;
             fenceChar = markerChar;
             fenceLength = markerLength;
@@ -3458,19 +3528,29 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
         if (atxMatch) {
             NSUInteger hashCount = [atxMatch rangeAtIndex:1].length;
             if (hashCount >= 1 && hashCount <= 6) {
+                commitPendingParagraph();
+                insideListItemContinuation = NO;
                 [kinds addObject:@((NSInteger)hashCount)];
                 [lineNumbers addObject:@(lineNumber)];
                 previousLineHadContent = NO;
                 continue;
             }
             // 7+ hashes: ordinary paragraph text, which can still anchor a setext header.
+            if (!hasPendingParagraphLine && !previousLineHadContent) {
+                hasPendingParagraphLine = YES;
+                pendingParagraphLine = lineNumber;
+            }
             previousLineHadContent = YES;
             continue;
         }
 
-        // Setext underline (only valid directly under a paragraph line).
+        // Setext underline (only valid directly under a paragraph line). The pending
+        // paragraph line (if any) is the line this underline attaches to; it becomes a
+        // header instead of a paragraph, so drop the pending candidate without committing.
         if (previousLineHadContent
                 && [eqRegex numberOfMatchesInString:line options:0 range:full] > 0) {
+            hasPendingParagraphLine = NO;
+            insideListItemContinuation = NO;
             [kinds addObject:@(MPReferenceKindH1)];
             [lineNumbers addObject:@(lineNumber)];
             previousLineHadContent = NO;
@@ -3478,6 +3558,8 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
         }
         if (previousLineHadContent
                 && [dashRegex numberOfMatchesInString:line options:0 range:full] > 0) {
+            hasPendingParagraphLine = NO;
+            insideListItemContinuation = NO;
             [kinds addObject:@(MPReferenceKindH2)];
             [lineNumbers addObject:@(lineNumber)];
             previousLineHadContent = NO;
@@ -3487,6 +3569,8 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
         // Standalone whole-line image.
         if ([imgRegex numberOfMatchesInString:line options:0 range:full] > 0
                 || [imgRefRegex numberOfMatchesInString:line options:0 range:full] > 0) {
+            commitPendingParagraph();
+            insideListItemContinuation = NO;
             [kinds addObject:@(MPReferenceKindImage)];
             [lineNumbers addObject:@(lineNumber)];
             previousLineHadContent = NO;
@@ -3495,19 +3579,57 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 
         // Thematic break: not a reference point, and not paragraph text either.
         if ([hrRegex numberOfMatchesInString:line options:0 range:full] > 0) {
+            commitPendingParagraph();
+            insideListItemContinuation = NO;
             previousLineHadContent = NO;
             continue;
         }
 
-        // Blank line breaks any setext context.
+        // Blank line breaks any setext context, any paragraph run, and any list-item
+        // continuation run.
         if ([[line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] length] == 0) {
+            commitPendingParagraph();
+            insideListItemContinuation = NO;
             previousLineHadContent = NO;
             continue;
         }
 
-        // Anything else is ordinary paragraph text that can anchor a setext underline.
+        // List item marker line: takes precedence over both paragraph and setext-header
+        // eligibility (CommonMark does not allow a setext heading to consume a list-item
+        // line). One reference point per marker line; continuation lines of the same item
+        // are ordinary text lines that don't match the marker pattern, so they fall
+        // through below and are tracked via insideListItemContinuation instead.
+        if ([ulRegex numberOfMatchesInString:line options:0 range:full] > 0
+                || [olRegex numberOfMatchesInString:line options:0 range:full] > 0) {
+            commitPendingParagraph();
+            insideListItemContinuation = YES;
+            [kinds addObject:@(MPReferenceKindListItem)];
+            [lineNumbers addObject:@(lineNumber)];
+            previousLineHadContent = NO;
+            continue;
+        }
+
+        // A continuation line of the immediately preceding list item (e.g. an indented
+        // wrapped line) is not a separate reference point and does not start a new
+        // paragraph run.
+        if (insideListItemContinuation) {
+            previousLineHadContent = YES;
+            continue;
+        }
+
+        // Ordinary paragraph text that can anchor a setext underline. Only the FIRST
+        // line of a paragraph run becomes a tentative reference point; continuation
+        // lines (previousLineHadContent already YES) do not add another one.
+        if (!hasPendingParagraphLine && !previousLineHadContent) {
+            hasPendingParagraphLine = YES;
+            pendingParagraphLine = lineNumber;
+        }
         previousLineHadContent = YES;
     }
+
+    // End of document: any still-pending paragraph line was never followed by a setext
+    // underline, so commit it now.
+    commitPendingParagraph();
 
     if (outLineNumbers) *outLineNumbers = lineNumbers;
     return kinds;
@@ -3520,10 +3642,12 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
  * The two detectors (editor regex vs preview DOM) can disagree mid-document; a single
  * extra point on one side shifts every later index, which is the "synced only at the
  * start and end" bug. This computes the longest common subsequence of the two *kind*
- * sequences (matching on the coarse image-vs-header class, since the two sides legitimately
- * disagree on exact header level) and keeps only the matched points on each side. An
- * unmatched point is dropped from whichever side it appears on, so the remaining points
- * stay aligned regardless of where the divergence occurs.
+ * sequences (matching on a coarse class — image, any header level, paragraph, or list
+ * item, since the two sides legitimately disagree on exact header level but must never
+ * cross-match a paragraph against a header, or a list item against either) and keeps
+ * only the matched points on each side. An unmatched point is dropped from whichever
+ * side it appears on, so the remaining points stay aligned regardless of where the
+ * divergence occurs.
  *
  * Fallback: if the type information is missing or inconsistent with the coordinate arrays
  * (e.g. callers/tests that set only the Y arrays), it degrades to the original behavior of
@@ -3551,9 +3675,16 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
         return;
     }
 
-    // Coarse class for matching: images match images, any header matches any header.
+    // Coarse class for matching: images match images, any header matches any header,
+    // paragraphs match only paragraphs, and list items match only list items — each
+    // gets its own class so the LCS never cross-matches, e.g., a paragraph against a
+    // header just because the coarser image-vs-everything-else split would have allowed it.
     NSInteger (^classOf)(NSNumber *) = ^NSInteger(NSNumber *kind) {
-        return kind.integerValue == MPReferenceKindImage ? 0 : 1;
+        NSInteger k = kind.integerValue;
+        if (k == MPReferenceKindImage) return 0;
+        if (k == MPReferenceKindParagraph) return 2;
+        if (k == MPReferenceKindListItem) return 3;
+        return 1; // any header level h1-h6
     };
 
     // LCS over the coarse class sequences. dp[i][j] = LCS length of editor[i..] / preview[j..].
@@ -3628,7 +3759,7 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
  * Synchronizes preview pane scroll position with editor pane position.
  *
  * Algorithm:
- * 1. Find reference points (headers/images) before and after current editor position
+ * 1. Find reference points (headers/images/paragraphs/list items) before and after current editor position
  * 2. Calculate percentage scrolled between those reference points
  * 3. Apply same percentage between corresponding preview reference points
  * 4. Use "tapering" at document edges to center-align content mid-document but
@@ -3730,13 +3861,169 @@ static BOOL MPScanFenceMarker(NSString *line, unichar *outChar, NSUInteger *outL
 }
 
 /**
+ * Synchronizes preview pane scroll position with the editor's cursor position,
+ * aligning the corresponding preview content to the same on-screen row as the
+ * cursor (rather than centering the viewport, as -syncScrollers does).
+ *
+ * Algorithm:
+ * 1. Find the reference points (headers/images/paragraphs/list items) before and after the cursor's
+ *    absolute position in the editor's full document.
+ * 2. Calculate what percentage of the way the cursor is between those points.
+ * 3. Apply that percentage between the corresponding preview reference points
+ *    to find the absolute preview Y that corresponds to the cursor's line.
+ * 4. Scroll the preview so that Y lands at the same distance from the top of
+ *    the preview pane as the cursor currently sits from the top of the editor
+ *    pane, so the two lines land on the same screen row.
+ */
+- (void)syncScrollersToCursor
+{
+    if (!self.editor)
+        return;                              // Headless / nib not yet loaded.
+    if (!self.editorVisible)
+        return;                              // Cursor position is meaningless when hidden.
+
+    NSRange selection = self.editor.selectedRange;
+    NSUInteger cursorLocation = MIN(selection.location, self.editor.string.length);
+
+    // Ask the layout manager for the line fragment containing the cursor's glyph, then
+    // take its origin — this is the reliable way to get a cursor's vertical position;
+    // boundingRectForGlyphRange: with a zero-length range returns a degenerate empty
+    // rect and cannot be used to locate the cursor.
+    NSLayoutManager *cursorLayoutManager = [self.editor layoutManager];
+    NSTextContainer *cursorTextContainer = [self.editor textContainer];
+    NSUInteger cursorGlyphIndex =
+        [cursorLayoutManager glyphIndexForCharacterAtIndex:cursorLocation];
+    NSRange lineGlyphRange;
+    NSRect cursorRect;
+    if (cursorGlyphIndex < cursorLayoutManager.numberOfGlyphs)
+    {
+        cursorRect = [cursorLayoutManager lineFragmentRectForGlyphAtIndex:cursorGlyphIndex
+                                                            effectiveRange:&lineGlyphRange];
+    }
+    else
+    {
+        // Cursor is at the very end of the document, past the last glyph: use the
+        // extra line fragment rect, which NSLayoutManager always keeps up to date
+        // for the position just after the last character.
+        cursorRect = [cursorLayoutManager extraLineFragmentRect];
+    }
+
+    CGFloat previewY = [MPDocument previewYForCursorY:NSMidY(cursorRect)
+                                   editorContentHeight:ceilf(NSHeight(self.editor.enclosingScrollView.documentView.bounds))
+                                   editorVisibleHeight:ceilf(NSHeight(self.editor.enclosingScrollView.contentView.bounds))
+                                   editorScrollOffsetY:NSMinY(self.editor.enclosingScrollView.contentView.bounds)
+                                  previewContentHeight:ceilf(NSHeight(self.preview.enclosingScrollView.documentView.bounds))
+                                  previewVisibleHeight:ceilf(NSHeight(self.preview.enclosingScrollView.contentView.bounds))
+                                   editorHeaderLocations:_editorHeaderLocations
+                                  webViewHeaderLocations:_webViewHeaderLocations];
+
+    NSRect contentBounds = self.preview.enclosingScrollView.contentView.bounds;
+    contentBounds.origin.y = previewY;
+
+    // Issue #342: No flag toggles needed — previewBoundsDidChange: is guarded
+    // by scrollOwner != MPScrollOwnerPreview, which suppresses the synchronous
+    // NSViewBoundsDidChangeNotification fired by this bounds assignment.
+    self.preview.enclosingScrollView.contentView.bounds = contentBounds;
+
+    // Save this scroll position so it persists across preview refreshes
+    self.lastPreviewScrollTop = previewY;
+}
+
+/**
+ * Pure geometry helper for -syncScrollersToCursor, extracted so its math can be
+ * unit-tested with concrete numbers instead of live NSTextView/WebView geometry.
+ *
+ * Given the cursor's absolute Y position in the editor's full document, finds the
+ * corresponding absolute Y in the preview's full document (via the same
+ * reference-point bracketing/interpolation -syncScrollers uses), then converts the
+ * cursor's position within the editor's *visible viewport* to a FRACTION of that
+ * viewport's height, and applies that fraction against the preview's viewport
+ * height. The fraction (not a raw pixel offset) is what carries over correctly
+ * between the two panes, since they render at different scales (different fonts,
+ * line heights, and pane widths mean a given pixel offset represents a different
+ * amount of visual content in each).
+ */
++ (CGFloat)previewYForCursorY:(CGFloat)cursorDocumentY
+           editorContentHeight:(CGFloat)editorContentHeight
+           editorVisibleHeight:(CGFloat)editorVisibleHeight
+           editorScrollOffsetY:(CGFloat)editorScrollOffsetY
+          previewContentHeight:(CGFloat)previewContentHeight
+          previewVisibleHeight:(CGFloat)previewVisibleHeight
+        editorHeaderLocations:(NSArray<NSNumber *> *)editorHeaderLocations
+       webViewHeaderLocations:(NSArray<NSNumber *> *)webViewHeaderLocations
+{
+    NSInteger relativeHeaderIndex = -1; // -1 is start of document, before any other header
+    CGFloat minY = 0;
+    CGFloat maxY = 0;
+    BOOL foundMaxY = NO;
+
+    // Bracket the cursor's absolute document position between the nearest reference
+    // points (headers/images/paragraphs/list items), with no viewport-centering taper: unlike -syncScrollers,
+    // we want the corresponding preview row to land at an exact screen position, not a
+    // centered one.
+    for (NSNumber *headerYNum in editorHeaderLocations) {
+        CGFloat headerY = [headerYNum floatValue];
+
+        if (headerY < cursorDocumentY)
+        {
+            relativeHeaderIndex += 1;
+            minY = headerY;
+        } else if (!foundMaxY)
+        {
+            maxY = headerY;
+            foundMaxY = YES;
+        }
+    }
+
+    if (!foundMaxY)
+    {
+        // No reference point after the cursor: interpolate to the end of the document.
+        maxY = editorContentHeight;
+    }
+
+    CGFloat cursorOffsetFromMin = MAX(0, cursorDocumentY - minY);
+    CGFloat spanY = maxY - minY;
+    CGFloat percentBetweenHeaders = (spanY < 0.001) ? 0 : MAX(0, MIN(1.0, cursorOffsetFromMin / spanY));
+
+    // Find the Y positions in the preview window that we're interpolating between.
+    CGFloat topHeaderY = 0;
+    CGFloat bottomHeaderY = previewContentHeight;
+
+    if ([webViewHeaderLocations count] > relativeHeaderIndex)
+    {
+        topHeaderY = floorf([webViewHeaderLocations[relativeHeaderIndex] doubleValue]);
+    }
+
+    if (!foundMaxY)
+    {
+        bottomHeaderY = previewContentHeight;
+    }
+    else if ([webViewHeaderLocations count] > relativeHeaderIndex + 1)
+    {
+        bottomHeaderY = ceilf([webViewHeaderLocations[relativeHeaderIndex + 1] doubleValue]);
+    }
+
+    // The absolute preview Y that corresponds to the cursor's line.
+    CGFloat matchingPreviewY = topHeaderY + (bottomHeaderY - topHeaderY) * percentBetweenHeaders;
+
+    // The cursor's position within the editor's visible viewport, as a fraction of
+    // that viewport's height.
+    CGFloat cursorFractionFromEditorTop = editorVisibleHeight < 0.001 ? 0 :
+        MAX(0, MIN(1.0, (cursorDocumentY - editorScrollOffsetY) / editorVisibleHeight));
+
+    CGFloat previewY = matchingPreviewY - cursorFractionFromEditorTop * previewVisibleHeight;
+    previewY = MAX(0, MIN(previewY, previewContentHeight - previewVisibleHeight));
+    return previewY;
+}
+
+/**
  * Synchronizes editor pane scroll position with preview pane position.
  *
  * This is the reverse of syncScrollers - when the user scrolls the preview,
  * this method scrolls the editor to the corresponding position.
  *
  * Algorithm:
- * 1. Find reference points (headers/images) before and after current preview position
+ * 1. Find reference points (headers/images/paragraphs/list items) before and after current preview position
  * 2. Calculate percentage scrolled between those reference points
  * 3. Apply same percentage between corresponding editor reference points
  * 4. Use "tapering" at document edges to center-align content mid-document but

--- a/MacDown/Resources/updateHeaderLocations.js
+++ b/MacDown/Resources/updateHeaderLocations.js
@@ -1,7 +1,7 @@
 /**
- * Detects reference points (headers and standalone images) in the preview document.
- * Returns parallel arrays of y-coordinates and kind codes (in document order) for
- * scroll synchronization.
+ * Detects reference points (headers, standalone images, paragraphs, and list items)
+ * in the preview document. Returns parallel arrays of y-coordinates and kind codes
+ * (in document order) for scroll synchronization.
  *
  * Standalone images are defined as:
  * - An image alone in a paragraph
@@ -12,8 +12,22 @@
  * in sync, because the editor (regex over markdown) and the preview (this DOM query)
  * can disagree about which reference points exist mid-document. Each reference point is
  * therefore tagged with a "kind" code so the ObjC side can align the two sequences:
- *   - image  -> 0
- *   - header -> header level (h1 -> 1, h2 -> 2, ... h6 -> 6)
+ *   - image     -> 0
+ *   - header    -> header level (h1 -> 1, h2 -> 2, ... h6 -> 6)
+ *   - paragraph -> 7
+ *   - listitem  -> 8
+ *
+ * Density fix: paragraphs and list items are tracked in addition to headers/images so
+ * long header-sparse sections of a document still have closely-spaced reference points,
+ * bounding the linear-interpolation error used to sync scroll position between them.
+ * A <p> whose only content is a standalone image is skipped here (it's already counted
+ * as that image's reference point, and double-counting would waste an alignment slot at
+ * nearly the same Y position without adding useful density). An <li> whose only content
+ * is a nested <ul>/<ol> (no other text/inline content) is skipped too, since it doesn't
+ * correspond to a distinct line of visible text. List items nested inside blockquotes,
+ * tables, or other lists are NOT filtered out — density is wanted everywhere, and any
+ * editor/DOM disagreement is reconciled by the alignment algorithm on the ObjC side, not
+ * here.
  *
  * @returns {{ys: Array<number>, kinds: Array<number>}} Parallel arrays of y-coordinates
  *          and kind codes for reference points, in document order.
@@ -24,6 +38,8 @@
 
         var headers = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
         var images = document.querySelectorAll('img');
+        var paragraphs = document.querySelectorAll('p');
+        var listItems = document.querySelectorAll('li');
         var result = [];
 
         // Collect all headers
@@ -32,6 +48,7 @@
         }
 
         // Filter images to only include standalone images
+        var standaloneImageParents = [];
         for (var i = 0; i < images.length; i++) {
             var img = images[i];
             var parent = img.parentElement;
@@ -70,6 +87,48 @@
 
             if (isStandalone) {
                 result.push({node: img, type: 'image'});
+                // Track the <p> (if any) that wraps this standalone image, so the
+                // paragraph pass below doesn't also emit a reference point for it.
+                if (parent && parent.tagName === 'P') {
+                    standaloneImageParents.push(parent);
+                } else if (parent && parent.tagName === 'A' && parent.parentElement
+                           && parent.parentElement.tagName === 'P') {
+                    standaloneImageParents.push(parent.parentElement);
+                }
+            }
+        }
+
+        // Collect paragraphs, skipping any that are themselves just a wrapper around
+        // an already-counted standalone image.
+        for (var i = 0; i < paragraphs.length; i++) {
+            var p = paragraphs[i];
+            var isStandaloneImageWrapper = false;
+            for (var j = 0; j < standaloneImageParents.length; j++) {
+                if (standaloneImageParents[j] === p) {
+                    isStandaloneImageWrapper = true;
+                    break;
+                }
+            }
+            if (!isStandaloneImageWrapper) {
+                result.push({node: p, type: 'paragraph'});
+            }
+        }
+
+        // Collect list items, skipping any whose only content is a nested list.
+        for (var i = 0; i < listItems.length; i++) {
+            var li = listItems[i];
+            var onlyChildIsNestedList = false;
+            if (li.children.length === 1) {
+                var onlyChild = li.children[0];
+                if ((onlyChild.tagName === 'UL' || onlyChild.tagName === 'OL')) {
+                    // No other text/inline content alongside the nested list.
+                    var text = (li.textContent || '').replace(/\s+/g, '');
+                    var nestedText = (onlyChild.textContent || '').replace(/\s+/g, '');
+                    onlyChildIsNestedList = (text === nestedText);
+                }
+            }
+            if (!onlyChildIsNestedList) {
+                result.push({node: li, type: 'listitem'});
             }
         }
 
@@ -92,6 +151,10 @@
             ys.push(window.scrollY + rect.top);
             if (item.type === 'image') {
                 kinds.push(0);
+            } else if (item.type === 'paragraph') {
+                kinds.push(7);
+            } else if (item.type === 'listitem') {
+                kinds.push(8);
             } else {
                 // tagName is like 'H3'; the second character is the header level.
                 var level = parseInt(String(item.node.tagName).charAt(1), 10);

--- a/MacDownTests/MPScrollSyncTests.m
+++ b/MacDownTests/MPScrollSyncTests.m
@@ -38,6 +38,15 @@ static const NSUInteger MPScrollOwnerNeither = 2;
          previewTypes:(NSArray<NSNumber *> *)previewTypes
       alignedEditorYs:(NSArray<NSNumber *> **)outEditorYs
      alignedPreviewYs:(NSArray<NSNumber *> **)outPreviewYs;
+// Pure geometry helper backing -syncScrollersToCursor (cursor-follow scroll sync)
++ (CGFloat)previewYForCursorY:(CGFloat)cursorDocumentY
+           editorContentHeight:(CGFloat)editorContentHeight
+           editorVisibleHeight:(CGFloat)editorVisibleHeight
+           editorScrollOffsetY:(CGFloat)editorScrollOffsetY
+          previewContentHeight:(CGFloat)previewContentHeight
+          previewVisibleHeight:(CGFloat)previewVisibleHeight
+        editorHeaderLocations:(NSArray<NSNumber *> *)editorHeaderLocations
+       webViewHeaderLocations:(NSArray<NSNumber *> *)webViewHeaderLocations;
 @property (strong) NSArray<NSNumber *> *webViewHeaderTypes;
 @property (strong) NSArray<NSNumber *> *editorHeaderTypes;
 - (void)syncScrollers;
@@ -1643,6 +1652,99 @@ static const NSUInteger MPScrollOwnerNeither = 2;
     XCTAssertEqual(locations.count, 0U, @"Null body should return empty array");
 }
 
+/**
+ * C6 — Paragraph and list-item detection: a <p> and an <li> inside a <ul> are
+ * detected as kind 7 and kind 8 respectively.
+ * Issue #436: density fix — paragraphs/list-items are additional reference-point kinds.
+ */
+- (void)testJSHeaderLocationsParagraphAndListItem
+{
+    NSString *script = [self loadUpdateHeaderLocationsScript];
+    if (!script) {
+        XCTFail(@"updateHeaderLocations.js not found in bundle");
+        return;
+    }
+
+    JSContext *context = [[JSContext alloc] init];
+    context.exceptionHandler = ^(JSContext *ctx, JSValue *exception) { };
+
+    [context evaluateScript:
+        @"var window = {scrollY: 0};\n"
+        @"var Node = {DOCUMENT_POSITION_FOLLOWING: 4, DOCUMENT_POSITION_PRECEDING: 2};\n"
+        @"var p0 = {getBoundingClientRect:function(){return {top:10};}, tagName:'P',\n"
+        @"          parentElement:null, children:[],\n"
+        @"          compareDocumentPosition:function(o){return o===li0?4:0;}};\n"
+        @"var li0 = {getBoundingClientRect:function(){return {top:50};}, tagName:'LI',\n"
+        @"           parentElement:null, children:[], textContent:'item',\n"
+        @"           compareDocumentPosition:function(o){return o===p0?2:0;}};\n"
+        @"var document = {\n"
+        @"    body: {},\n"
+        @"    querySelectorAll: function(sel) {\n"
+        @"        if (sel === 'h1, h2, h3, h4, h5, h6') return [];\n"
+        @"        if (sel === 'img') return [];\n"
+        @"        if (sel === 'p') return [p0];\n"
+        @"        if (sel === 'li') return [li0];\n"
+        @"        return [];\n"
+        @"    }\n"
+        @"};\n"];
+
+    JSValue *result = [context evaluateScript:script];
+    NSArray *locations = [result[@"ys"] toArray];
+    NSArray *kinds = [result[@"kinds"] toArray];
+
+    XCTAssertEqual(locations.count, 2U, @"Should return the paragraph and the list item");
+    XCTAssertEqualObjects(kinds, (@[@7, @8]),
+                          @"kinds should be [7 (paragraph), 8 (listitem)] in document order");
+    XCTAssertEqualWithAccuracy([locations[0] floatValue], 10.0, 0.5, @"paragraph y is scrollY(0)+top(10)");
+    XCTAssertEqualWithAccuracy([locations[1] floatValue], 50.0, 0.5, @"list item y is scrollY(0)+top(50)");
+}
+
+/**
+ * C7 — A <p> whose only content is a standalone <img> is NOT double-counted: it
+ * contributes one reference point (the image, kind 0), not also a paragraph (kind 7).
+ * Issue #436: double-counting the same visual line wastes an alignment slot.
+ */
+- (void)testJSHeaderLocationsStandaloneImageParagraphNotDoubleCounted
+{
+    NSString *script = [self loadUpdateHeaderLocationsScript];
+    if (!script) {
+        XCTFail(@"updateHeaderLocations.js not found in bundle");
+        return;
+    }
+
+    JSContext *context = [[JSContext alloc] init];
+    context.exceptionHandler = ^(JSContext *ctx, JSValue *exception) { };
+
+    [context evaluateScript:
+        @"var window = {scrollY: 0};\n"
+        @"var Node = {DOCUMENT_POSITION_FOLLOWING: 4, DOCUMENT_POSITION_PRECEDING: 2};\n"
+        @"var img0 = {tagName:'IMG', getBoundingClientRect:function(){return {top:20};},\n"
+        @"            compareDocumentPosition:function(o){return 0;}};\n"
+        @"var p0 = {getBoundingClientRect:function(){return {top:20};}, tagName:'P',\n"
+        @"          parentElement:null, children:[img0],\n"
+        @"          compareDocumentPosition:function(o){return 0;}};\n"
+        @"img0.parentElement = p0;\n"
+        @"var document = {\n"
+        @"    body: {},\n"
+        @"    querySelectorAll: function(sel) {\n"
+        @"        if (sel === 'h1, h2, h3, h4, h5, h6') return [];\n"
+        @"        if (sel === 'img') return [img0];\n"
+        @"        if (sel === 'p') return [p0];\n"
+        @"        if (sel === 'li') return [];\n"
+        @"        return [];\n"
+        @"    }\n"
+        @"};\n"];
+
+    JSValue *result = [context evaluateScript:script];
+    NSArray *locations = [result[@"ys"] toArray];
+    NSArray *kinds = [result[@"kinds"] toArray];
+
+    XCTAssertEqual(locations.count, 1U,
+                   @"A <p> wrapping only a standalone image must contribute exactly one reference point");
+    XCTAssertEqualObjects(kinds, (@[@0]),
+                          @"The single reference point must be the image (kind 0), not the paragraph (kind 7)");
+}
+
 #pragma mark - Issue #342: Group D — Header Array Alignment Safety
 
 /**
@@ -2217,26 +2319,30 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
 - (void)testClassifierSevenHashesNotHeader
 {
-    XCTAssertEqualObjects([self kindsFor:@"####### G"], @[],
-                          @"A2: 7 hashes is not a header in CommonMark/Hoedown (Issue #436)");
+    // Issue #436 density fix: 7+ hashes is ordinary paragraph text, so it's now a
+    // paragraph reference point (kind 7) rather than no reference point at all.
+    XCTAssertEqualObjects([self kindsFor:@"####### G"], (@[@7]),
+                          @"A2: 7 hashes is not a header in CommonMark/Hoedown, so it's treated as a paragraph (Issue #436)");
 }
 
 - (void)testClassifierEightHashesNotHeader
 {
-    XCTAssertEqualObjects([self kindsFor:@"######## H"], @[],
-                          @"A3: 8 hashes is not a header (Issue #436)");
+    XCTAssertEqualObjects([self kindsFor:@"######## H"], (@[@7]),
+                          @"A3: 8 hashes is not a header, so it's treated as a paragraph (Issue #436)");
 }
 
 - (void)testClassifierATXRequiresSpace
 {
-    XCTAssertEqualObjects([self kindsFor:@"#NoSpace"], @[],
-                          @"A4: ATX header requires a space after the hashes (Issue #436)");
+    XCTAssertEqualObjects([self kindsFor:@"#NoSpace"], (@[@7]),
+                          @"A4: ATX header requires a space after the hashes; without it, this is paragraph text (Issue #436)");
 }
 
 - (void)testClassifierBareHashNotHeader
 {
-    XCTAssertEqualObjects([self kindsFor:@"#"], @[],
-                          @"A5: a bare '#' with no following space/text is not a header (Issue #436)");
+    // A bare "#" with nothing after it fails the ATX regex (which requires \s after the
+    // hashes) and is ordinary (empty-looking but non-blank) paragraph text.
+    XCTAssertEqualObjects([self kindsFor:@"#"], (@[@7]),
+                          @"A5: a bare '#' with no following space/text is not a header, so it's a paragraph (Issue #436)");
 }
 
 - (void)testClassifierATXLeadingSpacesAllowed
@@ -2247,8 +2353,11 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
 - (void)testClassifierATXFourLeadingSpacesNotHeader
 {
-    XCTAssertEqualObjects([self kindsFor:@"    # C"], @[],
-                          @"A8: 4 leading spaces is indented code, not a header (Issue #436)");
+    // 4-space indented code is not detected as code by this classifier (it only tracks
+    // fences), so it falls through as ordinary paragraph text — a paragraph reference
+    // point, not a header.
+    XCTAssertEqualObjects([self kindsFor:@"    # C"], (@[@7]),
+                          @"A8: 4 leading spaces is indented code, not a header — treated as a paragraph (Issue #436)");
 }
 
 // --- Setext headers ---
@@ -2273,14 +2382,19 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
 - (void)testClassifierSetextAfterBlankLineIsNotHeader
 {
-    XCTAssertEqualObjects([self kindsFor:@"Text\n\n---"], @[],
-                          @"B4: a blank line breaks setext context, so '---' is an HR (Issue #436)");
+    // "Text" is a paragraph (line 0); the blank line commits it and breaks setext
+    // context, so the trailing '---' is an HR (no reference point), not a header.
+    XCTAssertEqualObjects([self kindsFor:@"Text\n\n---"], (@[@7]),
+                          @"B4: a blank line breaks setext context, so '---' is an HR, leaving just the paragraph (Issue #436)");
 }
 
 - (void)testClassifierEqualsAfterBlankIsNotHeader
 {
-    XCTAssertEqualObjects([self kindsFor:@"Text\n\n==="], @[],
-                          @"B5: '===' not directly under content is not a setext header (Issue #436)");
+    // "===" is not an HR pattern (hrRegex only matches runs of -, *, or _), and with no
+    // preceding paragraph context it isn't a setext underline either — so it falls
+    // through as its own paragraph line, giving two paragraph reference points.
+    XCTAssertEqualObjects([self kindsFor:@"Text\n\n==="], (@[@7, @7]),
+                          @"B5: '===' not directly under content is not a setext header — both lines are separate paragraphs (Issue #436)");
 }
 
 - (void)testClassifierTwoDashesSetext
@@ -2313,8 +2427,10 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
 - (void)testClassifierStandaloneDashHR
 {
-    XCTAssertEqualObjects([self kindsFor:@"---\n\ntext"], @[],
-                          @"C1: a leading '---' is an HR (Issue #436)");
+    // The leading '---' has no preceding content, so it's an HR (no reference point);
+    // "text" on the last line is still a paragraph reference point.
+    XCTAssertEqualObjects([self kindsFor:@"---\n\ntext"], (@[@7]),
+                          @"C1: a leading '---' is an HR, leaving just the trailing paragraph (Issue #436)");
 }
 
 - (void)testClassifierAsteriskHR
@@ -2400,8 +2516,11 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
 - (void)testClassifierFourLeadingSpacesIsNotAFence
 {
+    // The 4-space-indented "    ```" is not recognized as a fence marker, so it is
+    // ordinary paragraph text (a paragraph reference point) and '# Fake' right after it
+    // is a real ATX header, not swallowed code.
     XCTAssertEqualObjects([self kindsFor:@"# A\n\n    ```\n# Fake\n\n## B"],
-                          (@[@1, @1, @2]),
+                          (@[@1, @7, @1, @2]),
                           @"D9: a 4-space-indented marker is not a fence, so '# Fake' is a real header (Issue #436)");
 }
 
@@ -2428,14 +2547,16 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 
 - (void)testClassifierInlineImageInTextIgnored
 {
-    XCTAssertEqualObjects([self kindsFor:@"text ![x](y.png) more"], @[],
-                          @"E3: an image inline with text is not a reference point (Issue #436)");
+    // The image itself isn't standalone, but the line is still ordinary paragraph
+    // text, so it now yields a paragraph reference point rather than nothing.
+    XCTAssertEqualObjects([self kindsFor:@"text ![x](y.png) more"], (@[@7]),
+                          @"E3: an image inline with text is not an image reference point, but the line is a paragraph (Issue #436)");
 }
 
 - (void)testClassifierImageWithTrailingTextIgnored
 {
-    XCTAssertEqualObjects([self kindsFor:@"![x](y.png) caption"], @[],
-                          @"E5: an image with trailing text is not standalone (Issue #436)");
+    XCTAssertEqualObjects([self kindsFor:@"![x](y.png) caption"], (@[@7]),
+                          @"E5: an image with trailing text is not standalone, but the line is a paragraph (Issue #436)");
 }
 
 - (void)testClassifierHeaderThenImage
@@ -2453,8 +2574,12 @@ static const NSUInteger MPScrollOwnerNeither = 2;
     NSArray<NSNumber *> *lines = nil;
     NSArray<NSNumber *> *kinds = [MPDocument editorReferenceKindsForMarkdown:md outLineNumbers:&lines];
 
-    XCTAssertEqualObjects(kinds, (@[@1, @2, @0, @3, @0]),
-                          @"F1: mixed document yields headers and standalone images only (Issue #436)");
+    // Issue #436 density fix: "intro", "text ![inline](s.png) text", and
+    // "[f2]: f2.png" are all ordinary paragraph text lines, so they now also
+    // contribute paragraph reference points (kind 7) alongside the headers and
+    // standalone images.
+    XCTAssertEqualObjects(kinds, (@[@1, @7, @2, @0, @7, @3, @0, @7]),
+                          @"F1: mixed document yields headers, standalone images, and paragraphs (Issue #436)");
     XCTAssertEqual(lines.count, kinds.count,
                    @"F1: line numbers must run parallel to kinds (Issue #436)");
     for (NSUInteger i = 1; i < lines.count; i++) {
@@ -2485,6 +2610,150 @@ static const NSUInteger MPScrollOwnerNeither = 2;
 {
     XCTAssertEqualObjects([self kindsFor:@"# A\n"], (@[@1]),
                           @"A trailing newline must not add a spurious reference point (Issue #436)");
+}
+
+// --- Paragraphs ---
+
+- (void)testClassifierSingleLineParagraphBetweenHeaders
+{
+    NSArray<NSNumber *> *lines = nil;
+    NSArray<NSNumber *> *kinds = [MPDocument editorReferenceKindsForMarkdown:@"# H1\n\ntext\n\n## H2"
+                                                                outLineNumbers:&lines];
+    XCTAssertEqualObjects(kinds, (@[@1, @7, @2]),
+                          @"H1: a single-line paragraph between two headers is a paragraph reference point (Issue #436)");
+    XCTAssertEqualObjects(lines, (@[@0, @2, @4]),
+                          @"H1: the paragraph reference point is at its own line number (Issue #436)");
+}
+
+- (void)testClassifierMultiLineParagraphIsOneReferencePoint
+{
+    XCTAssertEqualObjects([self kindsFor:@"line one\nline two\nline three"], (@[@7]),
+                          @"H2: a multi-line paragraph (no blank line between lines) yields exactly one paragraph reference point (Issue #436)");
+}
+
+- (void)testClassifierMultiLineParagraphAtFirstLine
+{
+    NSArray<NSNumber *> *lines = nil;
+    NSArray<NSNumber *> *kinds = [MPDocument editorReferenceKindsForMarkdown:@"line one\nline two\nline three"
+                                                                outLineNumbers:&lines];
+    XCTAssertEqualObjects(kinds, (@[@7]),
+                          @"H2b: multi-line paragraph yields one paragraph reference point (Issue #436)");
+    XCTAssertEqualObjects(lines, (@[@0]),
+                          @"H2b: the paragraph reference point is at the FIRST line of the paragraph (Issue #436)");
+}
+
+- (void)testClassifierTwoParagraphsSeparatedByBlankLine
+{
+    NSArray<NSNumber *> *lines = nil;
+    NSArray<NSNumber *> *kinds = [MPDocument editorReferenceKindsForMarkdown:@"para one\n\npara two"
+                                                                outLineNumbers:&lines];
+    XCTAssertEqualObjects(kinds, (@[@7, @7]),
+                          @"H3: two paragraphs separated by a blank line yield two paragraph reference points (Issue #436)");
+    XCTAssertEqualObjects(lines, (@[@0, @2]),
+                          @"H3: each paragraph reference point is at its own first line (Issue #436)");
+}
+
+- (void)testClassifierParagraphThenSetextIsOnlyHeader
+{
+    XCTAssertEqualObjects([self kindsFor:@"Some Text\n==="], (@[@1]),
+                          @"H4: a paragraph line immediately followed by a setext underline yields ONLY the header, "
+                          @"not also a paragraph reference point (Issue #436)");
+}
+
+- (void)testClassifierParagraphThenOrdinaryLineNoExtraParagraph
+{
+    NSArray<NSNumber *> *lines = nil;
+    NSArray<NSNumber *> *kinds = [MPDocument editorReferenceKindsForMarkdown:@"first line\nsecond line"
+                                                                outLineNumbers:&lines];
+    XCTAssertEqualObjects(kinds, (@[@7]),
+                          @"H5: a paragraph line followed by an ordinary (non-setext) line yields one paragraph "
+                          @"reference point, not two (Issue #436)");
+    XCTAssertEqualObjects(lines, (@[@0]),
+                          @"H5: the paragraph reference point is at the first line (Issue #436)");
+}
+
+- (void)testClassifierStandaloneImageNotDoubleCountedAsParagraph
+{
+    XCTAssertEqualObjects([self kindsFor:@"text before\n\n![alt](img.png)\n\ntext after"],
+                          (@[@7, @0, @7]),
+                          @"H9: a standalone image adjacent to paragraph text is counted once as an image, "
+                          @"not also as a paragraph (Issue #436)");
+}
+
+// --- List items ---
+
+- (void)testClassifierUnorderedListThreeItems
+{
+    NSArray<NSNumber *> *lines = nil;
+    NSArray<NSNumber *> *kinds = [MPDocument editorReferenceKindsForMarkdown:@"- one\n- two\n- three"
+                                                                outLineNumbers:&lines];
+    XCTAssertEqualObjects(kinds, (@[@8, @8, @8]),
+                          @"H6: an unordered list with 3 items yields 3 list-item reference points (Issue #436)");
+    XCTAssertEqualObjects(lines, (@[@0, @1, @2]),
+                          @"H6: one list-item reference point per marker line (Issue #436)");
+}
+
+- (void)testClassifierOrderedListItems
+{
+    XCTAssertEqualObjects([self kindsFor:@"1. one\n2. two"], (@[@8, @8]),
+                          @"H7: an ordered list yields list-item reference points (Issue #436)");
+    XCTAssertEqualObjects([self kindsFor:@"1) one\n2) two"], (@[@8, @8]),
+                          @"H7b: ')' is also a valid ordered-list delimiter (Issue #436)");
+}
+
+- (void)testClassifierListItemThenDashesNotSetext
+{
+    NSArray<NSNumber *> *lines = nil;
+    NSArray<NSNumber *> *kinds = [MPDocument editorReferenceKindsForMarkdown:@"- item\n---"
+                                                                outLineNumbers:&lines];
+    XCTAssertEqualObjects(kinds, (@[@8]),
+                          @"H8: a list item followed by '---' is not retroactively turned into a setext header — "
+                          @"the list item is emitted, and '---' is treated as an HR, not a header (Issue #436)");
+    XCTAssertEqualObjects(lines, (@[@0]),
+                          @"H8: the list-item reference point is at the marker line (Issue #436)");
+}
+
+- (void)testClassifierListItemContinuationLineNoExtraReference
+{
+    XCTAssertEqualObjects([self kindsFor:@"- item one\n  continued text\n- item two"], (@[@8, @8]),
+                          @"H10: an indented continuation line of a list item is not a separate reference point (Issue #436)");
+}
+
+// --- Mixed / integration ---
+
+- (void)testClassifierFullMixedDocument
+{
+    NSString *md = @"# Section One\n\nintro paragraph\n\n"
+                   @"- alpha\n- beta\n- gamma\n\n"
+                   @"## Section Two\n\n"
+                   @"1. first\n2. second\n\n"
+                   @"![Figure](fig.png)\n\n"
+                   @"closing paragraph line one\nclosing paragraph line two";
+    NSArray<NSNumber *> *lines = nil;
+    NSArray<NSNumber *> *kinds = [MPDocument editorReferenceKindsForMarkdown:md outLineNumbers:&lines];
+
+    // Hand-traced line numbers (0-indexed):
+    //  0: # Section One         -> H1
+    //  1: (blank)
+    //  2: intro paragraph       -> paragraph
+    //  3: (blank)
+    //  4: - alpha                -> list item
+    //  5: - beta                 -> list item
+    //  6: - gamma                -> list item
+    //  7: (blank)
+    //  8: ## Section Two        -> H2
+    //  9: (blank)
+    // 10: 1. first                -> list item
+    // 11: 2. second               -> list item
+    // 12: (blank)
+    // 13: ![Figure](fig.png)    -> image
+    // 14: (blank)
+    // 15: closing paragraph line one   -> paragraph (first line)
+    // 16: closing paragraph line two   (continuation, not a reference point)
+    XCTAssertEqualObjects(kinds, (@[@1, @7, @8, @8, @8, @2, @8, @8, @0, @7]),
+                          @"H11: full mixed document matches hand-traced kinds (Issue #436)");
+    XCTAssertEqualObjects(lines, (@[@0, @2, @4, @5, @6, @8, @10, @11, @13, @15]),
+                          @"H11: full mixed document matches hand-traced line numbers (Issue #436)");
 }
 
 #pragma mark - Issue #436: Group Q — Reference-point aligner (LCS)
@@ -2591,6 +2860,124 @@ static const NSUInteger MPScrollOwnerNeither = 2;
                     previewYs:@[@11, @21, @31] types:@[@1, @1, @1]
                  expectEditor:@[@10, @20, @30] expectPreview:@[@11, @21, @31]
                       message:@"G11: inconsistent type counts fall back to MIN-count truncation (Issue #436)"];
+}
+
+- (void)testAlignParagraphDoesNotMatchHeader
+{
+    // Editor: [H1, Paragraph]; Preview: [H1, H2]. Even though the counts line up,
+    // a paragraph must never be treated as matching a header — only the H1 pair
+    // should align; the mismatched paragraph/H2 entries are dropped from both sides.
+    [self assertAlignEditorYs:@[@10, @20] types:@[@1, @7]
+                    previewYs:@[@11, @21] types:@[@1, @2]
+                 expectEditor:@[@10] expectPreview:@[@11]
+                      message:@"G12: a paragraph reference point never aligns with a header, even when counts match (Issue #436)"];
+}
+
+- (void)testAlignListItemDoesNotMatchParagraphOrHeader
+{
+    // Editor: [ListItem]; Preview: [Paragraph] — distinct classes, no match.
+    [self assertAlignEditorYs:@[@10] types:@[@8]
+                    previewYs:@[@11] types:@[@7]
+                 expectEditor:@[] expectPreview:@[]
+                      message:@"G13: a list-item reference point never aligns with a paragraph reference point (Issue #436)"];
+}
+
+#pragma mark - previewYForCursorY: (cursor-follow scroll sync geometry)
+
+/**
+ * No reference points on either side of the cursor: the whole document is one span.
+ * editorContentHeight=3000, editorVisibleHeight=1000, editorScrollOffsetY=0,
+ * previewContentHeight=4000, previewVisibleHeight=800, cursorDocumentY=200.
+ * percentBetweenHeaders = 200/3000 = 0.0667; matchingPreviewY = 4000*0.0667 = 266.67.
+ * cursorFraction = (200-0)/1000 = 0.2; previewY = 266.67 - 0.2*800 = 106.67.
+ */
+- (void)testPreviewYForCursorYNoReferencePoints
+{
+    CGFloat previewY = [MPDocument previewYForCursorY:200
+                                   editorContentHeight:3000
+                                   editorVisibleHeight:1000
+                                   editorScrollOffsetY:0
+                                  previewContentHeight:4000
+                                  previewVisibleHeight:800
+                                editorHeaderLocations:@[]
+                               webViewHeaderLocations:@[]];
+    XCTAssertEqualWithAccuracy(previewY, 106.67, 0.5,
+        @"With no reference points, previewY should follow the whole-document ratio, "
+        @"scaled from a viewport FRACTION (not a raw pixel offset)");
+}
+
+/**
+ * Regression test for the pane-scale bug: applying the cursor's raw pixel distance
+ * from the editor viewport's top directly as a preview pixel offset (instead of
+ * converting to a fraction of viewport height first) breaks whenever the editor and
+ * preview have different viewport heights — which they normally do, since they use
+ * different fonts/line heights. Same inputs as above, but with a much taller preview
+ * viewport (2400 instead of 800) to make a scale mismatch produce a clearly wrong
+ * (and easily distinguishable) answer if the bug regresses:
+ *   correct (fraction-based):  266.67 - 0.2*2400 = -213.33 -> clamped to 0
+ *   buggy (raw-pixel-based):   266.67 - 200       = 66.67
+ * These differ by far more than any reasonable tolerance, so this test fails loudly
+ * if the fraction conversion is ever dropped.
+ */
+- (void)testPreviewYForCursorYUsesViewportFractionNotRawPixels
+{
+    CGFloat previewY = [MPDocument previewYForCursorY:200
+                                   editorContentHeight:3000
+                                   editorVisibleHeight:1000
+                                   editorScrollOffsetY:0
+                                  previewContentHeight:4000
+                                  previewVisibleHeight:2400
+                                editorHeaderLocations:@[]
+                               webViewHeaderLocations:@[]];
+    XCTAssertEqualWithAccuracy(previewY, 0, 0.5,
+        @"previewY must be derived from the cursor's FRACTION of the editor viewport "
+        @"height, not its raw pixel distance from the viewport top — a raw-pixel "
+        @"calculation would return ~66.67 here instead of clamping to 0");
+}
+
+/**
+ * Cursor bracketed between two reference points (headers), with a nonzero editor
+ * scroll offset. editorHeaderLocations=[100, 500], webViewHeaderLocations=[150, 700].
+ * cursorDocumentY=300 falls between the two editor headers (100 and 500):
+ * percentBetweenHeaders = (300-100)/(500-100) = 0.5.
+ * matchingPreviewY = 150 + (700-150)*0.5 = 425.
+ * editorScrollOffsetY=250 (viewport scrolled so its top is at document Y=250);
+ * cursorFraction = (300-250)/1000 = 0.05.
+ * previewY = 425 - 0.05*800 = 385.
+ */
+- (void)testPreviewYForCursorYBetweenTwoHeaders
+{
+    CGFloat previewY = [MPDocument previewYForCursorY:300
+                                   editorContentHeight:3000
+                                   editorVisibleHeight:1000
+                                   editorScrollOffsetY:250
+                                  previewContentHeight:4000
+                                  previewVisibleHeight:800
+                                editorHeaderLocations:@[@100, @500]
+                               webViewHeaderLocations:@[@150, @700]];
+    XCTAssertEqualWithAccuracy(previewY, 385, 0.5,
+        @"previewY should interpolate between the two bracketing headers' preview "
+        @"positions, then offset by the cursor's viewport fraction");
+}
+
+/**
+ * Result must always be clamped within [0, previewContentHeight - previewVisibleHeight]
+ * even when the raw calculation would place the preview past the end of its content.
+ */
+- (void)testPreviewYForCursorYClampsToContentBounds
+{
+    CGFloat previewY = [MPDocument previewYForCursorY:2900
+                                   editorContentHeight:3000
+                                   editorVisibleHeight:1000
+                                   editorScrollOffsetY:2000
+                                  previewContentHeight:1000
+                                  previewVisibleHeight:800
+                                editorHeaderLocations:@[]
+                               webViewHeaderLocations:@[]];
+    XCTAssertGreaterThanOrEqual(previewY, 0,
+        @"previewY must never be negative");
+    XCTAssertLessThanOrEqual(previewY, 1000 - 800,
+        @"previewY must never scroll past the bottom of the preview's content");
 }
 
 @end


### PR DESCRIPTION
Related to #562

## Summary
- Editor-preview scroll sync only used headers and standalone images as anchor points, so long header-sparse sections (e.g. bullet-list-heavy stretches) drifted noticeably out of alignment the farther they were from the nearest header.
- Track paragraphs and list items as additional scroll-sync reference points alongside headers/images, bounding the interpolation error between any two anchors.
- Sync also only tracked the editor's viewport scroll position, not the cursor. Moving the cursor (click or arrow keys) now also refines the preview's scroll position to follow it, on top of the existing viewport-based sync, when Sync Panes is on.

## Test plan
- [x] Build succeeds (`xcodebuild ... -scheme MacDown`)
- [x] `MacDownTests/MPScrollSyncTests` passes (194 tests, including 22 new tests covering the paragraph/list-item classifier, LCS alignment across the new reference kinds, and the cursor-follow geometry)
- [ ] Manually verified in the preview: scrolling/clicking through a long document with header-sparse sections keeps the editor and preview closely aligned throughout, not just near headers