### PR TITLE
Address issue #566: fix grouped toolbar buttons not dispatching

### DIFF
--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -39,11 +39,16 @@ static NSArray<NSNumber *> *MPToolbarDocumentZoomLevels(void)
 
     /**
      * Map toolbar item identifier to the selector name (NSString) that should
-     * be dispatched to self.document when a standalone button is clicked.
-     * Needed because self.document is nil during init when toolbar items are
-     * created, so we can't set target = self.document at construction time.
+     * be dispatched to self.document when the item is activated -- covers
+     * both standalone buttons and the individual subitems of grouped/
+     * segmented toolbar items. Needed because self.document is nil during
+     * init when toolbar items are created, so we can't set target =
+     * self.document at construction time; and because NSToolbarItem.action
+     * forwards to its .view when the view responds to -action, so the real
+     * selector can't be read back off the model object either (see
+     * toolbarItemWithIdentifier:label:icon:action: below).
      */
-    NSMutableDictionary<NSString *, NSString *> *standaloneItemActions;
+    NSMutableDictionary<NSString *, NSString *> *itemActionsByIdentifier;
 
     /**
      * Weak reference to the zoom popup so we can re-sync its selected item
@@ -62,7 +67,7 @@ static NSArray<NSNumber *> *MPToolbarDocumentZoomLevels(void)
     }
 
     self->toolbarItemIdentifierObjectDictionary = [NSMutableDictionary new];
-    self->standaloneItemActions = [NSMutableDictionary new];
+    self->itemActionsByIdentifier = [NSMutableDictionary new];
     [self setupToolbarItems];
 
     // Observe NSUserDefaults so the popup's selection reflects external
@@ -194,8 +199,14 @@ static NSArray<NSNumber *> *MPToolbarDocumentZoomLevels(void)
     // garbage senders like 0x400000000000bad0 and random EXC_BAD_ACCESS
     // crashes when the invoked action (or its responder-chain validation)
     // touched sender.
+    //
+    // The real selector is looked up by item identifier rather than read off
+    // selectedItem.action: NSToolbarItem.action forwards to its .view when
+    // the view responds to -action, and every subitem's .view is a button
+    // whose own action is the shared dispatch selector, not the per-item one.
     MPDocument *document = self.document;
-    SEL action = selectedItem.action;
+    NSString *actionName = self->itemActionsByIdentifier[selectedItem.itemIdentifier];
+    SEL action = actionName ? NSSelectorFromString(actionName) : NULL;
     if (document && action && [document respondsToSelector:action])
     {
         #pragma clang diagnostic push
@@ -240,7 +251,7 @@ static NSArray<NSNumber *> *MPToolbarDocumentZoomLevels(void)
 
 - (void)standaloneToolbarItemClicked:(NSButton *)sender
 {
-    NSString *actionName = self->standaloneItemActions[sender.identifier];
+    NSString *actionName = self->itemActionsByIdentifier[sender.identifier];
     if (!actionName) return;
     SEL action = NSSelectorFromString(actionName);
     MPDocument *document = self.document;
@@ -403,14 +414,25 @@ static NSArray<NSNumber *> *MPToolbarDocumentZoomLevels(void)
 }
 
 /**
- * Factory method for creating and configuring a NSToolbarItem object.
+ * Factory method for creating and configuring a NSToolbarItem object. Used
+ * both for standalone toolbar items and for the individual subitems that
+ * toolbarItemGroupWithIdentifier:separated:label:items: assembles into a
+ * segmented control.
+ *
+ * The button's target/action are deliberately pointed at the shared
+ * dispatcher (standaloneToolbarItemClicked:), not at `action` itself: the
+ * real per-item selector is looked up from itemActionsByIdentifier at click
+ * time instead, both here and in selectedToolbarItemGroupItem:. Do not set
+ * `target`/`action` on the NSToolbarItem model object -- NSToolbarItem
+ * forwards those properties to .view when the view responds, so doing so
+ * would just overwrite the button's own target/action above.
  */
 - (NSToolbarItem *)toolbarItemWithIdentifier:(NSString *)itemIdentifier label:(NSString *)label icon:(NSString *)iconImageName action:(SEL)action {
     NSToolbarItem *toolbarItem = [[NSToolbarItem alloc] initWithItemIdentifier:itemIdentifier];
     toolbarItem.label = label;
     toolbarItem.paletteLabel = label;
     toolbarItem.toolTip = label;
-    
+
     NSImage *itemImage = [NSImage imageNamed:iconImageName];
     [itemImage setTemplate:YES];
     [itemImage setSize:CGSizeMake(19, 19)];
@@ -419,16 +441,16 @@ static NSArray<NSNumber *> *MPToolbarDocumentZoomLevels(void)
     itemButton.imageScaling = NSImageScaleProportionallyDown;
     itemButton.bezelStyle = NSBezelStyleTexturedRounded;
     itemButton.focusRingType = NSFocusRingTypeDefault;
-    [self->standaloneItemActions setObject:NSStringFromSelector(action)
-                                    forKey:itemIdentifier];
+    [self->itemActionsByIdentifier setObject:NSStringFromSelector(action)
+                                      forKey:itemIdentifier];
     itemButton.identifier = itemIdentifier;
     itemButton.target = self;
     itemButton.action = @selector(standaloneToolbarItemClicked:);
-    
+
     toolbarItem.view = itemButton;
-    
+
     [self->toolbarItemIdentifierObjectDictionary setObject:toolbarItem forKey:itemIdentifier];
-    
+
     return toolbarItem;
 }
 

--- a/MacDownTests/MPToolbarControllerTests.m
+++ b/MacDownTests/MPToolbarControllerTests.m
@@ -775,6 +775,95 @@
 }
 
 
+#pragma mark - Grouped Toolbar Item Dispatch Tests (Issue #566)
+
+- (void)testGroupedDispatchAllActionMappings
+{
+    // Verify every grouped/segmented toolbar item dispatches the correct
+    // action. Keyed by (group identifier, segment index, segment count)
+    // since that's what selectedToolbarItemGroupItem: actually receives
+    // from a segmented control's identifier and selectedSegment -- the 10
+    // individual subitem identifiers (e.g. "bold") are not independently
+    // reachable via toolbar:itemForItemIdentifier:willBeInsertedIntoToolbar:.
+    NSArray<NSArray *> *expectedMappings = @[
+        @[@"indent-group", @0, @2, @"unindent:"],
+        @[@"indent-group", @1, @2, @"indent:"],
+        @[@"text-formatting-group", @0, @3, @"toggleStrong:"],
+        @[@"text-formatting-group", @1, @3, @"toggleEmphasis:"],
+        @[@"text-formatting-group", @2, @3, @"toggleUnderline:"],
+        @[@"heading-group", @0, @3, @"convertToH1:"],
+        @[@"heading-group", @1, @3, @"convertToH2:"],
+        @[@"heading-group", @2, @3, @"convertToH3:"],
+        @[@"list-group", @0, @2, @"toggleUnorderedList:"],
+        @[@"list-group", @1, @2, @"toggleOrderedList:"],
+    ];
+
+    for (NSArray *mapping in expectedMappings) {
+        NSString *groupIdentifier = mapping[0];
+        NSInteger segmentIndex = [mapping[1] integerValue];
+        NSInteger segmentCount = [mapping[2] integerValue];
+        NSString *expectedAction = mapping[3];
+
+        MPToolbarDispatchRecorder *recorder = [[MPToolbarDispatchRecorder alloc] init];
+        self.controller.document = (MPDocument *)recorder;
+
+        NSSegmentedControl *sender = [[NSSegmentedControl alloc] init];
+        sender.identifier = groupIdentifier;
+        sender.segmentCount = segmentCount;
+        sender.selectedSegment = segmentIndex;
+
+        [self.controller selectedToolbarItemGroupItem:sender];
+
+        XCTAssertTrue([recorder.invokedSelectors containsObject:expectedAction],
+                      @"selectedToolbarItemGroupItem: with group '%@' segment %ld "
+                      @"should dispatch %@ to the document. Got: %@",
+                      groupIdentifier, (long)segmentIndex, expectedAction,
+                      recorder.invokedSelectors);
+    }
+}
+
+- (void)testGroupedDispatchWithNoDocumentDoesNotCrash
+{
+    NSSegmentedControl *sender = [[NSSegmentedControl alloc] init];
+    sender.identifier = @"indent-group";
+    sender.segmentCount = 2;
+    sender.selectedSegment = 0;
+
+    XCTAssertNoThrow([self.controller selectedToolbarItemGroupItem:sender],
+                     @"selectedToolbarItemGroupItem: must not crash when document is nil");
+}
+
+- (void)testGroupedToolbarItemGroupsTargetToolbarController
+{
+    // Pins the wiring: each group's view must be an NSSegmentedControl
+    // targeting the toolbar controller via selectedToolbarItemGroupItem:,
+    // with its identifier matching the group identifier the dispatch
+    // lookup keys on. Guards against a future refactor silently breaking
+    // this again.
+    NSArray *groupIdentifiers = @[@"indent-group", @"text-formatting-group",
+                                   @"heading-group", @"list-group"];
+
+    for (NSString *identifier in groupIdentifiers) {
+        NSToolbarItem *item = [self.controller toolbar:nil
+                                 itemForItemIdentifier:identifier
+                             willBeInsertedIntoToolbar:YES];
+        XCTAssertTrue([item.view isKindOfClass:[NSSegmentedControl class]],
+                      @"Group '%@' view should be an NSSegmentedControl", identifier);
+
+        NSSegmentedControl *segmentedControl = (NSSegmentedControl *)item.view;
+        XCTAssertEqual(segmentedControl.target, self.controller,
+                       @"Group '%@' segmented control must target the toolbar controller",
+                       identifier);
+        XCTAssertEqual(segmentedControl.action, @selector(selectedToolbarItemGroupItem:),
+                       @"Group '%@' segmented control must use selectedToolbarItemGroupItem:",
+                       identifier);
+        XCTAssertEqualObjects(segmentedControl.identifier, identifier,
+                              @"Group '%@' segmented control identifier must match the "
+                              @"group identifier the dispatch lookup keys on", identifier);
+    }
+}
+
+
 #pragma mark - Standalone Toolbar Item Dispatch Tests (Issue #278)
 
 - (void)testStandaloneButtonsTargetToolbarController

--- a/plans/test_coverage_improvement_plan.md
+++ b/plans/test_coverage_improvement_plan.md
@@ -39,7 +39,7 @@ MacDown currently has minimal test coverage (~7% test-to-code ratio) focused pri
 | MPSmartQuoteTests.m | Smart quote substitution behavior | Good | (Issue #285) |
 | MPEditorViewSubstitutionTests.m | Text substitution preference getters, NSUserDefaults integration | Good | (Issue #263) |
 | MPWordCountUpdateTests.m | Word count update debouncing, queue cancellation | Good | (Issue #294) |
-| MPToolbarControllerTests.m | Toolbar delegate methods, item identifiers, group testing, nil/bounds guards on `selectedToolbarItemGroupItem:` | Good | (Issue #313, Issue #394) |
+| MPToolbarControllerTests.m | Toolbar delegate methods, item identifiers, group testing, nil/bounds guards on `selectedToolbarItemGroupItem:`, grouped-item action dispatch | Good | (Issue #313, Issue #394, Issue #566) |
 | MPMermaidRenderingTests.m | Mermaid diagram rendering, MutationObserver re-rendering, SVG sizing | Good | (Issue #331) |
 | MPGraphvizRenderingTests.m | Graphviz diagram rendering, MutationObserver re-rendering, script inclusion | Good | (Issue #332) |
 | MPURLSecurityPolicyTests.m | URL security policy: executable/bundle detection, directory scope checking | Good | (Issue #351) |
@@ -64,7 +64,7 @@ MacDown currently has minimal test coverage (~7% test-to-code ratio) focused pri
 - Security policy (MPURLSecurityPolicy.m) - 16 tests covering executable/bundle detection and directory scope enforcement for CVE-2019-12138 and CVE-2019-12173 (Issue #351)
 - Editor text substitution settings (MPEditorView.m) - NSUserDefaults-backed getter overrides with 30 TDD tests (Issue #263)
 - Word count updates (MPDocument.m) - Tests for debounced word count updates during DOM replacement (Issue #294)
-- Toolbar controller (MPToolbarController.m) - 41 tests for NSToolbarDelegate methods, flexible space/separator support, item groups, nil-group and out-of-bounds crash guards on `selectedToolbarItemGroupItem:` (Issue #313, Issue #394)
+- Toolbar controller (MPToolbarController.m) - tests for NSToolbarDelegate methods, flexible space/separator support, item groups, nil-group and out-of-bounds crash guards on `selectedToolbarItemGroupItem:`, and grouped-item action dispatch (Issue #313, Issue #394, Issue #566)
 
 **Test Infrastructure:**
 - ✅ XCTest framework configured
@@ -453,7 +453,7 @@ MacDownTests/
 │   ├── MPAssetTests.m
 │   ├── MPEditorViewSubstitutionTests.m (✅ implemented - Issue #263 - text substitution preferences)
 │   ├── MPFileIOTests.m (new - planned)
-│   ├── MPToolbarControllerTests.m (✅ implemented - Issue #313, Issue #394 - toolbar item identifiers, groups, delegate methods, nil/bounds crash guards)
+│   ├── MPToolbarControllerTests.m (✅ implemented - Issue #313, Issue #394, Issue #566 - toolbar item identifiers, groups, delegate methods, nil/bounds crash guards, grouped-item action dispatch)
 │   └── MPURLSecurityPolicyTests.m (✅ implemented - Issue #351 - CVE-2019-12138, CVE-2019-12173: executable/bundle detection, scope checks)
 ├── Integration/ (planned)
 │   ├── MPRendererIntegrationTests.m

--- a/plans/xcuitest.md
+++ b/plans/xcuitest.md
@@ -74,7 +74,7 @@ This document analyzes the gaps and proposes technical approaches to fill them t
 
 **5. User Interactions**
 - Zero tests for: menu actions, keyboard shortcuts, preferences UI
-- ✅ Toolbar tests added (Issue #313, Issue #394) - 41 unit tests for MPToolbarController covering delegate methods, item identifiers, and nil/bounds crash guards on `selectedToolbarItemGroupItem:`
+- ✅ Toolbar tests added (Issue #313, Issue #394, Issue #566) - unit tests for MPToolbarController covering delegate methods, item identifiers, nil/bounds crash guards on `selectedToolbarItemGroupItem:`, and grouped-item action dispatch
 - Missing: interactive task lists, link clicks in preview
 
 **6. Error Handling**


### PR DESCRIPTION
## Summary

The Shift Left, Shift Right, Bold, Italic, Underline, Heading 1-3, Unordered List, and Ordered List toolbar buttons visibly depressed on click but had no effect. Their Format-menu and keyboard-shortcut equivalents worked correctly.

`MPToolbarController`'s `-selectedToolbarItemGroupItem:` resolved the selector to dispatch by reading `selectedItem.action`. `NSToolbarItem.action` forwards to `.view` when the view responds to `-action`, and every item's view is a button whose `.action` is the shared `standaloneToolbarItemClicked:` dispatcher (set in commit dd8fb71, the fix for issue #278/#496) rather than the item's real selector. `MPDocument` doesn't implement that dispatcher selector, so the dispatch guard silently failed for all 10 grouped items. This was a regression from dd8fb71, not a bug present since the toolbar was originally written.

`-selectedToolbarItemGroupItem:` now looks up the real selector by item identifier from the same identifier-keyed action map the standalone-button dispatch path already used. That map (`itemActionsByIdentifier`, renamed from `standaloneItemActions`) was already populated for grouped subitems, so this is a one-line behavioral change plus supporting comments and a rename to reflect that the map now documented/serves both dispatch paths.

## Related Issue

Related to #566

## Manual Testing Plan

Automated coverage exercises the dispatch logic directly against a mock document; it doesn't click real `NSToolbarItem`s in a running app. Manual verification on macOS is warranted given this is a click-dispatch fix and the project has a documented history of a related focus-dependent dispatch bug (#278/#496) in this same area.

**Setup:** Check out this branch, `bundle exec pod install` if needed, open `MacDown 3000.xcworkspace`, build and run, open a new document.

**Core scenarios — the 10 previously-broken buttons**, with sample text selected: Shift Right/Shift Left on multi-line selection (indentation added/removed); Bold/Italic/Underline on a word (wraps in `**`/`*`/`_`); Heading 1/2/3 with caret on a line (line prefixed `#`/`##`/`###`, replacing not stacking on repeat clicks); Unordered/Ordered List with caret on a line (prefixed `* `/`1. `). Each must visibly depress, release, and mutate the editor text — before the fix, the segment depressed but nothing happened.

**Edge cases:**
- Click each group's buttons with focus in the editor pane vs. the preview pane (the exact focus-dependent pattern behind #278/#496) — dispatch must succeed either way, with no `NSAssert`/`EXC_BAD_ACCESS`/unrecognized-selector output in the Xcode console.
- Click with no selection (caret only) — Bold/Italic/Underline should insert an empty markup span rather than crash or no-op.
- Click the same button twice — Bold/Italic/Underline and Unordered List toggle off correctly. (Ordered List does not toggle off via any entry point, including the Format menu — pre-existing behavior unrelated to this fix, not a regression.)
- One click per group in sequence (Shift Right → Bold → Heading 2 → Unordered List) to rule out any identifier collision now that all four groups' subitems share one lookup dictionary.

**Regression check — previously-working buttons:** Blockquote, Link, Image, Table, Copy HTML, Comment, Highlight, Strikethrough, Layout dropdown, and the Zoom popup should all continue to work exactly as before (add Comment/Highlight/Strikethrough to the toolbar via View > Customize Toolbar if not already present, since they aren't in the default set).

## Review Notes

The fix and test plan went through two rounds of independent design review before implementation — the first identified that the originally proposed fix (setting `.action` directly on the `NSToolbarItem` model object) doesn't work due to the same view-forwarding behavior that causes the bug, and would have broken the 9 working standalone buttons. The corrected approach and the final implementation were each independently reviewed and approved before being committed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01896dSJmkwa6Fz4R9ogaiSV)_