### PR TITLE
Fix Editor preferences pane hang in wrapping-checkbox layout test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,12 +168,15 @@ jobs:
         uses: ./.github/actions/setup-macdown
 
       - name: Run tests before release
+        timeout-minutes: 30
         run: |
           echo "🧪 Running unit tests to ensure code quality before release..."
           xcodebuild test \
             -workspace "MacDown 3000.xcworkspace" \
             -scheme MacDown \
-            -derivedDataPath DerivedData
+            -derivedDataPath DerivedData \
+            -test-timeouts-enabled YES \
+            -maximum-test-execution-time-allowance 120
           echo "✅ All tests passed"
 
       # Keep in sync with the launch-test job in smoke-test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         os: [macos-14, macos-26]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     permissions:
       contents: read
 
@@ -31,7 +32,9 @@ jobs:
         xcodebuild test \
           -workspace "MacDown 3000.xcworkspace" \
           -scheme MacDown \
-          -derivedDataPath DerivedData
+          -derivedDataPath DerivedData \
+          -test-timeouts-enabled YES \
+          -maximum-test-execution-time-allowance 120
 
     - name: Upload test results
       if: failure()

--- a/MacDown/Localization/Base.lproj/MPEditorPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPEditorPreferencesViewController.xib
@@ -326,16 +326,13 @@
                             <constraint firstItem="CXK-QF-WSK" firstAttribute="trailing" secondItem="NV7-zh-ydN" secondAttribute="trailing" id="AQ1-uk-f4c"/>
                             <constraint firstItem="tes-GA-Mpn" firstAttribute="trailing" secondItem="hSa-rl-wPT" secondAttribute="trailing" id="Jex-pw-2gL"/>
                             <constraint firstItem="CXK-QF-WSK" firstAttribute="leading" secondItem="NV7-zh-ydN" secondAttribute="leading" id="Jog-tE-o4J"/>
-                            <constraint firstItem="Hdc-ZZ-0Bg" firstAttribute="leading" secondItem="74B-GJ-2mO" secondAttribute="leading" constant="18" id="LJK-mi-lpf"/>
                             <constraint firstItem="tes-GA-Mpn" firstAttribute="top" secondItem="B3N-s7-0vd" secondAttribute="bottom" constant="6" symbolic="YES" id="U3w-XL-gGs"/>
                             <constraint firstItem="B3N-s7-0vd" firstAttribute="leading" secondItem="tes-GA-Mpn" secondAttribute="leading" id="Wfq-28-56B"/>
                             <constraint firstItem="hSa-rl-wPT" firstAttribute="top" secondItem="tes-GA-Mpn" secondAttribute="bottom" constant="6" symbolic="YES" id="Y1m-UM-0l9"/>
                             <constraint firstItem="nxG-74-mdM" firstAttribute="leading" secondItem="CXK-QF-WSK" secondAttribute="leading" id="YwU-dH-Mge"/>
                             <constraint firstItem="Hdc-ZZ-0Bg" firstAttribute="trailing" secondItem="nxG-74-mdM" secondAttribute="trailing" id="ZAd-tl-l1P"/>
                             <constraint firstItem="CXK-QF-WSK" firstAttribute="top" secondItem="nxG-74-mdM" secondAttribute="bottom" constant="6" symbolic="YES" id="aW2-NT-82W"/>
-                            <constraint firstItem="Hdc-ZZ-0Bg" firstAttribute="top" secondItem="74B-GJ-2mO" secondAttribute="top" constant="10" id="b9w-5h-zxO"/>
                             <constraint firstItem="NV7-zh-ydN" firstAttribute="trailing" secondItem="B3N-s7-0vd" secondAttribute="trailing" id="cWK-H1-qNQ"/>
-                            <constraint firstItem="Hdc-ZZ-0Bg" firstAttribute="centerX" secondItem="74B-GJ-2mO" secondAttribute="centerX" id="huD-PM-wSU"/>
                             <constraint firstItem="nxG-74-mdM" firstAttribute="top" secondItem="Hdc-ZZ-0Bg" secondAttribute="bottom" constant="6" symbolic="YES" id="iJr-Z6-ysx"/>
                             <constraint firstItem="NV7-zh-ydN" firstAttribute="leading" secondItem="B3N-s7-0vd" secondAttribute="leading" id="jTd-bf-Yb9"/>
                             <constraint firstItem="B3N-s7-0vd" firstAttribute="trailing" secondItem="tes-GA-Mpn" secondAttribute="trailing" id="jV2-c9-FVF"/>
@@ -343,9 +340,14 @@
                             <constraint firstItem="NV7-zh-ydN" firstAttribute="top" secondItem="CXK-QF-WSK" secondAttribute="bottom" constant="6" symbolic="YES" id="oAM-9C-rnP"/>
                             <constraint firstItem="Hdc-ZZ-0Bg" firstAttribute="leading" secondItem="nxG-74-mdM" secondAttribute="leading" id="pGd-1r-h4g"/>
                             <constraint firstItem="B3N-s7-0vd" firstAttribute="top" secondItem="NV7-zh-ydN" secondAttribute="bottom" constant="6" symbolic="YES" id="z6Q-dF-r1X"/>
-                            <constraint firstAttribute="bottom" secondItem="hSa-rl-wPT" secondAttribute="bottom" constant="10" id="397-bm-hSa"/>
                         </constraints>
                     </view>
+                    <constraints>
+                        <constraint firstItem="Hdc-ZZ-0Bg" firstAttribute="leading" secondItem="6JP-Pc-JFd" secondAttribute="leading" constant="19" id="LJK-mi-lpf"/>
+                        <constraint firstItem="Hdc-ZZ-0Bg" firstAttribute="top" secondItem="6JP-Pc-JFd" secondAttribute="top" constant="25" id="b9w-5h-zxO"/>
+                        <constraint firstItem="Hdc-ZZ-0Bg" firstAttribute="centerX" secondItem="6JP-Pc-JFd" secondAttribute="centerX" id="huD-PM-wSU"/>
+                        <constraint firstAttribute="bottom" secondItem="hSa-rl-wPT" secondAttribute="bottom" constant="11" id="397-bm-hSa"/>
+                    </constraints>
                 </box>
             </subviews>
             <constraints>


### PR DESCRIPTION
## Summary

- The Editor preferences pane's "Behavior" `NSBox` positioned its checkboxes relative to the box's *content view* instead of the box itself, unlike every other box in the preferences panes (General, Markdown). The content view had no constraints of its own tying it to the box, so the box's height had no required-priority path back to its checkboxes' actual size.
- `+[MPPreferencesViewController addHeightConstraintsForWrappingCheckboxesInView:]` grows checkboxes past their default height when their titles wrap, and in that state `layoutSubtreeIfNeeded` never converges for this box. `MacDownTests/MPPreferencesViewControllerResizabilityTests.m`'s `testWrappingCheckboxHeightsAccommodateMultiLineText` exercises exactly this by forcing wrapped titles, and hangs CI indefinitely as a result (observed on PR #493, unrelated to that PR's diff — this bug is pre-existing on `main`).
- The four affected constraints in `MPEditorPreferencesViewController.xib` now reference the box instead of the content view, matching the General and Markdown panes' boxes. The constants are adjusted for the box's chrome inset (1pt left/right/bottom, 15pt top), so the checkboxes' resolved position and the box's total height are unchanged — verified algebraically against the box/content-view frame deltas, not just asserted.
- Also adds a 30-minute job/step timeout and `-test-timeouts-enabled YES -maximum-test-execution-time-allowance 120` to the `xcodebuild test` invocations in `test.yml` and `release.yml`'s "Run tests before release" step, which lacked them — matching the existing convention already used in `smoke-test.yml` and `release.yml`'s UI-test step. This bounds any future test hang to minutes instead of GitHub's 6-hour default, independent of whether this particular fix is complete.

## Verification

- Root cause and fix were each independently reviewed by a separate agent (design review before implementation, full-branch implementation review after) per this repo's review process.
- XML well-formedness and constraint-graph completeness verified programmatically.
- Geometry preservation (checkbox position, box height) verified algebraically from the box/content-view frame deltas — not run, since this environment has no macOS/Xcode.
- **Not yet visually verified on macOS.** The math says nothing should move, but a human should eyeball the Editor preferences pane (English and one wrapping locale) before merge.

## Test plan

- [ ] CI passes on both `macos-14` and `macos-26` without hanging
- [ ] Manually open Preferences → Editor on macOS and confirm the "Behavior" box's checkboxes are laid out correctly (no clipping, no unexpected shift)
- [ ] Same check with a long-title locale (e.g. French) if convenient, since that's the scenario the checkbox-wrapping code exists for


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dxfe24SHv2odFfQ4C37HFP)_